### PR TITLE
refactor: move AiO upscale dispatcher owner

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `8b3ba38988407225aa53b9cd23e151db3a7d6ac8`
+- Integrated `dev` snapshot commit: `92506109117e42ea10e4664667481f27ad08623a`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c21 / `8b3ba38`; B-11c22 AiO highres stage Move in PR #316 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c22 / `9250610`; B-11c23 AiO upscale dispatcher Move in PR #317 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,319
-  lines after B-11c21.
-- The mechanical extraction has removed 10,344
-  lines, approximately 81.7% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,246
+  lines after B-11c22.
+- The mechanical extraction has removed 10,417
+  lines, approximately 82.3% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -81,7 +81,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   wrapper in PR #312 / `3d7e5d2`. B-11c19 moved only the VAE name wrapper in PR
   #313 / `de57090`. B-11c20 moved only the CLIP loader-type wrapper in PR #314 /
   `43c3056`. B-11c21 moved only the AiO postprocess stage in PR #315 /
-  `8b3ba38`. B-11c22 moves only the AiO highres stage in PR #316.
+  `8b3ba38`. B-11c22 moved only the AiO highres stage in PR #316 / `9250610`.
+  B-11c23 moves only the AiO upscale dispatcher in PR #317.
 
 ### Current quality baseline
 
@@ -323,7 +324,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 AiO highres stage Move PR #316 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 AiO upscale dispatcher Move PR #317 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -930,9 +931,14 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     deferred until a host-provider contract can preserve its zero-argument root
     wrapper without importing root `nodes` from canonical code.
   - B-11c22 moves only `_run_aio_highres_stage` to the existing AiO legacy-
-    generation owner in PR #316. Sampler planning, scaler construction, VAE,
-    model-patch, sampling, cleanup, resize, and metadata helpers remain call-time
-    root seams; execution order and the legacy caller lookup remain unchanged.
+    generation owner in PR #316 / `9250610`. Sampler planning, scaler
+    construction, VAE, model-patch, sampling, cleanup, resize, and metadata
+    helpers remain call-time root seams; execution order and the legacy caller
+    lookup remain unchanged.
+  - B-11c23 moves only `_run_aio_upscale_stage` to the existing AiO legacy-
+    generation owner in PR #317. Boolean coercion and both leaf stages remain
+    call-time root seams; disabled, USDU, ResShift, unsupported-backend, and
+    exception behavior remain unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `8b3ba38988407225aa53b9cd23e151db3a7d6ac8`
+  `92506109117e42ea10e4664667481f27ad08623a`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c21 are integrated through PR #315. B-11c is
+- Current state: B-11a through B-11c22 are integrated through PR #316. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c22 AiO highres stage Move is tracked by PR #316.
+  the final root shim; B-11c23 AiO upscale dispatcher Move is tracked by PR #317.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 294 in B-11c22
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 295 in B-11c23
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 14 functions, 0 classes, and 26 assigned
-  globals in B-11c22 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 13 functions, 0 classes, and 26 assigned
+  globals in B-11c23 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 280, including
+- root names reached by those canonical runtime resolvers: 282, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -493,6 +493,20 @@ convenience-node compatibility; it remains unmapped and is not public support.
   argument order, and metadata order are unchanged.
 - PR #316 does not move or change sampling helpers, the stage protocol, schema,
   defaults, workflow behavior, or the later #169 Contract/Behavior work.
+
+### B-11c23 AiO upscale dispatcher alias
+
+- Canonical owner: `easyuse_anima.aio.legacy_generation` for
+  `_run_aio_upscale_stage`.
+- The private root dispatcher remains a transitional direct alias in relative
+  package and flat import modes. The canonical legacy-generation caller keeps
+  resolving the root name at call time to preserve its monkeypatch seam.
+- The existing legacy-generation binder resolves boolean coercion and only the
+  selected USDU or ResShift leaf at use time. Disabled short-circuit, falsy-
+  backend USDU default, exact leaf argument order, unsupported-backend error,
+  result identity, and leaf exception propagation are unchanged.
+- PR #317 does not move or change either leaf stage, settings/schema/defaults,
+  workflow behavior, or the later #169 Contract/Behavior work.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -104,6 +104,60 @@ def _run_aio_highres_stage(
     }
 
 
+def _run_aio_upscale_stage(
+    model,
+    clip,
+    vae,
+    positive,
+    negative,
+    image,
+    sampler_settings: dict[str, Any],
+    upscale_settings: dict[str, Any],
+    quality_tags: str = "",
+    quality_neg: str = "",
+    prompt_data: str | dict | None = None,
+    exclude_positive_quality: bool = False,
+    exclude_negative_quality: bool = False,
+) -> tuple[Any, dict[str, Any]]:
+    if not _runtime_helper("_as_bool")(
+        upscale_settings.get("enabled"), False
+    ):
+        return image, {"enabled": False}
+    backend = str(upscale_settings.get("backend") or "usdu")
+    if backend == "usdu":
+        output, metadata = _runtime_helper("_run_aio_usdu_upscale_stage")(
+            model,
+            clip,
+            vae,
+            positive,
+            negative,
+            image,
+            sampler_settings,
+            upscale_settings,
+            quality_tags,
+            quality_neg,
+            prompt_data,
+            exclude_positive_quality,
+            exclude_negative_quality,
+        )
+    elif backend == "resshift":
+        output, metadata = _runtime_helper("_run_aio_resshift_upscale_stage")(
+            image,
+            sampler_settings,
+            upscale_settings,
+            quality_tags,
+            quality_neg,
+            prompt_data,
+            exclude_positive_quality,
+            exclude_negative_quality,
+        )
+    else:
+        raise RuntimeError(
+            f"[EasyUseAnima] Unsupported final upscale backend: {backend}"
+        )
+    return output, metadata
+
+
 def _run_aio_legacy_generation(
     generator,
     easy_use_anima_input,

--- a/nodes.py
+++ b/nodes.py
@@ -23,6 +23,7 @@ try:
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
+        _run_aio_upscale_stage as _run_aio_upscale_stage,
     )
     from .easyuse_anima.aio.generation_normalization import (
         AIO_SPECIAL_SEEDS as AIO_SPECIAL_SEEDS,
@@ -578,6 +579,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
+        _run_aio_upscale_stage as _run_aio_upscale_stage,
     )
     from easyuse_anima.aio.generation_normalization import (
         AIO_SPECIAL_SEEDS as AIO_SPECIAL_SEEDS,
@@ -1873,56 +1875,6 @@ def _run_aio_resshift_upscale_stage(
         "height": int(height),
         "scale": str(resshift_settings.get("scale") or "x2"),
     }
-
-
-def _run_aio_upscale_stage(
-    model,
-    clip,
-    vae,
-    positive,
-    negative,
-    image,
-    sampler_settings: dict[str, Any],
-    upscale_settings: dict[str, Any],
-    quality_tags: str = "",
-    quality_neg: str = "",
-    prompt_data: str | dict | None = None,
-    exclude_positive_quality: bool = False,
-    exclude_negative_quality: bool = False,
-) -> tuple[Any, dict[str, Any]]:
-    if not _as_bool(upscale_settings.get("enabled"), False):
-        return image, {"enabled": False}
-    backend = str(upscale_settings.get("backend") or "usdu")
-    if backend == "usdu":
-        output, metadata = _run_aio_usdu_upscale_stage(
-            model,
-            clip,
-            vae,
-            positive,
-            negative,
-            image,
-            sampler_settings,
-            upscale_settings,
-            quality_tags,
-            quality_neg,
-            prompt_data,
-            exclude_positive_quality,
-            exclude_negative_quality,
-        )
-    elif backend == "resshift":
-        output, metadata = _run_aio_resshift_upscale_stage(
-            image,
-            sampler_settings,
-            upscale_settings,
-            quality_tags,
-            quality_neg,
-            prompt_data,
-            exclude_positive_quality,
-            exclude_negative_quality,
-        )
-    else:
-        raise RuntimeError(f"[EasyUseAnima] Unsupported final upscale backend: {backend}")
-    return output, metadata
 
 
 def _run_aio_detailer_target(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14702,6 +14702,37 @@
         "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
+        "alias": "_run_aio_upscale_stage",
+        "bound_name": "_run_aio_upscale_stage",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_upscale_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_run_aio_upscale_stage",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
         "alias": "AIO_SPECIAL_SEEDS",
         "bound_name": "AIO_SPECIAL_SEEDS",
         "branch_context": [
@@ -14723,7 +14754,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14754,7 +14785,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14785,7 +14816,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14816,7 +14847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14847,7 +14878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14878,7 +14909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14909,7 +14940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14940,7 +14971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14971,7 +15002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15002,7 +15033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15033,7 +15064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15064,7 +15095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15095,7 +15126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15126,7 +15157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15157,7 +15188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15188,7 +15219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 27,
+        "line": 28,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15219,7 +15250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 45,
+        "line": 46,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15250,7 +15281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 48,
+        "line": 49,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15281,7 +15312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 48,
+        "line": 49,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15312,7 +15343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 48,
+        "line": 49,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15343,7 +15374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 53,
+        "line": 54,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15374,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 53,
+        "line": 54,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 53,
+        "line": 54,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 53,
+        "line": 54,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 59,
+        "line": 60,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 59,
+        "line": 60,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 59,
+        "line": 60,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 59,
+        "line": 60,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 65,
+        "line": 66,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 80,
+        "line": 81,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 94,
+        "line": 95,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 106,
+        "line": 107,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 118,
+        "line": 119,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 136,
+        "line": 137,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 148,
+        "line": 149,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 155,
+        "line": 156,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 169,
+        "line": 170,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 169,
+        "line": 170,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 169,
+        "line": 170,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 169,
+        "line": 170,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 169,
+        "line": 170,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 169,
+        "line": 170,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 169,
+        "line": 170,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 187,
+        "line": 188,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 223,
+        "line": 224,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 251,
+        "line": 252,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 267,
+        "line": 268,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 347,
+        "line": 348,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 347,
+        "line": 348,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 347,
+        "line": 348,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 347,
+        "line": 348,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 353,
+        "line": 354,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 353,
+        "line": 354,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 353,
+        "line": 354,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 364,
+        "line": 365,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 373,
+        "line": 374,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 384,
+        "line": 385,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 397,
+        "line": 398,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 397,
+        "line": 398,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 405,
+        "line": 406,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 416,
+        "line": 417,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 422,
+        "line": 423,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 430,
+        "line": 431,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 430,
+        "line": 431,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 450,
+        "line": 451,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 450,
+        "line": 451,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 450,
+        "line": 451,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 455,
+        "line": 456,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 455,
+        "line": 456,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 455,
+        "line": 456,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 473,
+        "line": 474,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 496,
+        "line": 497,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 496,
+        "line": 497,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 522,
+        "line": 523,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 532,
+        "line": 533,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24302,7 +24333,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24321,7 +24352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24336,7 +24367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24355,7 +24386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24370,7 +24401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24389,7 +24420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24404,7 +24435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24423,7 +24454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24438,7 +24469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24457,7 +24488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24472,7 +24503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24491,7 +24522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24506,7 +24537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24525,7 +24556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24540,7 +24571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24559,7 +24590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24574,7 +24605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24593,7 +24624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24608,7 +24639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24627,7 +24658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24642,7 +24673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24661,7 +24692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24676,8 +24707,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "name": "_run_aio_legacy_generation",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_upscale_stage",
+        "bound_name": "_run_aio_upscale_stage",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 566,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_upscale_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
+        "kind": "static_from",
+        "line": 578,
+        "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
         "role": "compatibility_fallback",
@@ -24695,7 +24760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24710,7 +24775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24729,7 +24794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24744,7 +24809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24763,7 +24828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24778,7 +24843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24797,7 +24862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24812,7 +24877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24831,7 +24896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24846,7 +24911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24865,7 +24930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24880,7 +24945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24899,7 +24964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24914,7 +24979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24933,7 +24998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24948,7 +25013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24967,7 +25032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -24982,7 +25047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25001,7 +25066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25016,7 +25081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25035,7 +25100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25050,7 +25115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25069,7 +25134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25084,7 +25149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25103,7 +25168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25118,7 +25183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25137,7 +25202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25152,7 +25217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25171,7 +25236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25186,7 +25251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25205,7 +25270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25220,7 +25285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25239,7 +25304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25254,7 +25319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 600,
+        "line": 602,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25273,7 +25338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25288,7 +25353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25307,7 +25372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25322,7 +25387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25341,7 +25406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25356,7 +25421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25375,7 +25440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25390,7 +25455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25409,7 +25474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25424,7 +25489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25443,7 +25508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25458,7 +25523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25477,7 +25542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25492,7 +25557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25511,7 +25576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25526,7 +25591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25545,7 +25610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25560,7 +25625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25579,7 +25644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25594,7 +25659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25613,7 +25678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25628,7 +25693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25647,7 +25712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25662,7 +25727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25681,7 +25746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25696,7 +25761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25715,7 +25780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25730,7 +25795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25749,7 +25814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25764,7 +25829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25783,7 +25848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25798,7 +25863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25817,7 +25882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25832,7 +25897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25851,7 +25916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25866,7 +25931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25885,7 +25950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25900,7 +25965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25919,7 +25984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25934,7 +25999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25953,7 +26018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -25968,7 +26033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25987,7 +26052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26002,7 +26067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26021,7 +26086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26036,7 +26101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26055,7 +26120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26070,7 +26135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26089,7 +26154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26104,7 +26169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26123,7 +26188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26138,7 +26203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26157,7 +26222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26172,7 +26237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26191,7 +26256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26206,7 +26271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26225,7 +26290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26240,7 +26305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26259,7 +26324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26274,7 +26339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26293,7 +26358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26308,7 +26373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26327,7 +26392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26342,7 +26407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26361,7 +26426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26376,7 +26441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26395,7 +26460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26410,7 +26475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26429,7 +26494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26444,7 +26509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26463,7 +26528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26478,7 +26543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26497,7 +26562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26512,7 +26577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26531,7 +26596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26546,7 +26611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26565,7 +26630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26580,7 +26645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26599,7 +26664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26614,7 +26679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26633,7 +26698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26648,7 +26713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26667,7 +26732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26682,7 +26747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26701,7 +26766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26716,7 +26781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26735,7 +26800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26750,7 +26815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26769,7 +26834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26784,7 +26849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26803,7 +26868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26818,7 +26883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26837,7 +26902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26852,7 +26917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26871,7 +26936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26886,7 +26951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26905,7 +26970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26920,7 +26985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26939,7 +27004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26954,7 +27019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26973,7 +27038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -26988,7 +27053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27007,7 +27072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27022,7 +27087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27041,7 +27106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27056,7 +27121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27075,7 +27140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27090,7 +27155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27109,7 +27174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27124,7 +27189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27143,7 +27208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27158,7 +27223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27177,7 +27242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27192,7 +27257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27211,7 +27276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27226,7 +27291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27245,7 +27310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27260,7 +27325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27279,7 +27344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27294,7 +27359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27313,7 +27378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27328,7 +27393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27347,7 +27412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27362,7 +27427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27381,7 +27446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27396,7 +27461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27415,7 +27480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27430,7 +27495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27449,7 +27514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27464,7 +27529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27483,7 +27548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27498,7 +27563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27517,7 +27582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27532,7 +27597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27551,7 +27616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27566,7 +27631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27585,7 +27650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27600,7 +27665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27619,7 +27684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27634,7 +27699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27653,7 +27718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27668,7 +27733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27687,7 +27752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27702,7 +27767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27721,7 +27786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27736,7 +27801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27755,7 +27820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27770,7 +27835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27789,7 +27854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27804,7 +27869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27823,7 +27888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27838,7 +27903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27857,7 +27922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27872,7 +27937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27891,7 +27956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27906,7 +27971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27925,7 +27990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27940,7 +28005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27959,7 +28024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -27974,7 +28039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27993,7 +28058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28008,7 +28073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 703,
+        "line": 705,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28027,7 +28092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28042,7 +28107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28061,7 +28126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28076,7 +28141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28095,7 +28160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28110,7 +28175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28129,7 +28194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28144,7 +28209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28163,7 +28228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28178,7 +28243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28197,7 +28262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28212,7 +28277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28231,7 +28296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28246,7 +28311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28265,7 +28330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28280,7 +28345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28299,7 +28364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28314,7 +28379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28333,7 +28398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28348,7 +28413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28367,7 +28432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28382,7 +28447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28401,7 +28466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28416,7 +28481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28435,7 +28500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28450,7 +28515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28469,7 +28534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28484,7 +28549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28503,7 +28568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28518,7 +28583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28537,7 +28602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28552,7 +28617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28571,7 +28636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28586,7 +28651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28605,7 +28670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28620,7 +28685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28639,7 +28704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28654,7 +28719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28673,7 +28738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28688,7 +28753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28707,7 +28772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28722,7 +28787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28741,7 +28806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28756,7 +28821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28775,7 +28840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28790,7 +28855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28809,7 +28874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28824,7 +28889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28843,7 +28908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28858,7 +28923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28877,7 +28942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28892,7 +28957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28911,7 +28976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28926,7 +28991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28945,7 +29010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28960,7 +29025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28979,7 +29044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -28994,7 +29059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29013,7 +29078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29028,7 +29093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29047,7 +29112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29062,7 +29127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29081,7 +29146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29096,7 +29161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29115,7 +29180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29130,7 +29195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29149,7 +29214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29164,7 +29229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29183,7 +29248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29198,7 +29263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29217,7 +29282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29232,7 +29297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29251,7 +29316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29266,7 +29331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29285,7 +29350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29300,7 +29365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29319,7 +29384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29334,7 +29399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29353,7 +29418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29368,7 +29433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29387,7 +29452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29402,7 +29467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29421,7 +29486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29436,7 +29501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29455,7 +29520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29470,7 +29535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29489,7 +29554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29504,7 +29569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29523,7 +29588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29538,7 +29603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29557,7 +29622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29572,7 +29637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29591,7 +29656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29606,7 +29671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29625,7 +29690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29640,7 +29705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29659,7 +29724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29674,7 +29739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29693,7 +29758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29708,7 +29773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29727,7 +29792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29742,7 +29807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29761,7 +29826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29776,7 +29841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29795,7 +29860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29810,7 +29875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29829,7 +29894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29844,7 +29909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29863,7 +29928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29878,7 +29943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29897,7 +29962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29912,7 +29977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29931,7 +29996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29946,7 +30011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29965,7 +30030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -29980,7 +30045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -29999,7 +30064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30014,7 +30079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30033,7 +30098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30048,7 +30113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30067,7 +30132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30082,7 +30147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30101,7 +30166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30116,7 +30181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30135,7 +30200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30150,7 +30215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30169,7 +30234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30184,7 +30249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30203,7 +30268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30218,7 +30283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30237,7 +30302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30252,7 +30317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30271,7 +30336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30286,7 +30351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30305,7 +30370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30320,7 +30385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30339,7 +30404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30354,7 +30419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30373,7 +30438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30388,7 +30453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30407,7 +30472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30422,7 +30487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30441,7 +30506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30456,7 +30521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30475,7 +30540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30490,7 +30555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30509,7 +30574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30524,7 +30589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30543,7 +30608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30558,7 +30623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30577,7 +30642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30592,7 +30657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30611,7 +30676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30626,7 +30691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30645,7 +30710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30660,7 +30725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30679,7 +30744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30694,7 +30759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30713,7 +30778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30728,7 +30793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30747,7 +30812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30762,7 +30827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30781,7 +30846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30796,7 +30861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30815,7 +30880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30830,7 +30895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30849,7 +30914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30864,7 +30929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30883,7 +30948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30898,7 +30963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30917,7 +30982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30932,7 +30997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30951,7 +31016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -30966,7 +31031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30985,7 +31050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31000,7 +31065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31019,7 +31084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31034,7 +31099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31053,7 +31118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31068,7 +31133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31087,7 +31152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31102,7 +31167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31121,7 +31186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31136,7 +31201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31155,7 +31220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31170,7 +31235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31189,7 +31254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31204,7 +31269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31223,7 +31288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31238,7 +31303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31257,7 +31322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31272,7 +31337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31291,7 +31356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31306,7 +31371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31325,7 +31390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31340,7 +31405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31359,7 +31424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31374,7 +31439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31393,7 +31458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31408,7 +31473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31427,7 +31492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31442,7 +31507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31461,7 +31526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31476,7 +31541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31495,7 +31560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31510,7 +31575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31529,7 +31594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31544,7 +31609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31563,7 +31628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31578,7 +31643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31597,7 +31662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31612,7 +31677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31631,7 +31696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31646,7 +31711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31665,7 +31730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31680,7 +31745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31699,7 +31764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31714,7 +31779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31733,7 +31798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31748,7 +31813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31767,7 +31832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31782,7 +31847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31801,7 +31866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31816,7 +31881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31835,7 +31900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31850,7 +31915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31869,7 +31934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31884,7 +31949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31903,7 +31968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31918,7 +31983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31937,7 +32002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31952,7 +32017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -31971,7 +32036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -31986,7 +32051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32005,7 +32070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32020,7 +32085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32039,7 +32104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32054,7 +32119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32073,7 +32138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32088,7 +32153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32107,7 +32172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32122,7 +32187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32141,7 +32206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32156,7 +32221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32175,7 +32240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32190,7 +32255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32209,7 +32274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32224,7 +32289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32243,7 +32308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32258,7 +32323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32277,7 +32342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32292,7 +32357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32311,7 +32376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32326,7 +32391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32345,7 +32410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32360,7 +32425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32379,7 +32444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32394,7 +32459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32413,7 +32478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32428,7 +32493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32447,7 +32512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32462,7 +32527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32481,7 +32546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32496,7 +32561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32515,7 +32580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32530,7 +32595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32549,7 +32614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32564,7 +32629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32583,7 +32648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32598,7 +32663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32617,7 +32682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32632,7 +32697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32651,7 +32716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32666,7 +32731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32685,7 +32750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32700,7 +32765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32719,7 +32784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32734,7 +32799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32753,7 +32818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32768,7 +32833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32787,7 +32852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32802,7 +32867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32821,7 +32886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32836,7 +32901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32855,7 +32920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32870,7 +32935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32889,7 +32954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32904,7 +32969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32923,7 +32988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32938,7 +33003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32957,7 +33022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -32972,7 +33037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1007,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -32991,7 +33056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33006,7 +33071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1007,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33025,7 +33090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33040,7 +33105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1007,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33059,7 +33124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33074,7 +33139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33093,7 +33158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33108,7 +33173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33127,7 +33192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33142,7 +33207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33161,7 +33226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33176,7 +33241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33195,7 +33260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33210,7 +33275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33229,7 +33294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33244,7 +33309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33263,7 +33328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33278,7 +33343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33297,7 +33362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33312,7 +33377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33331,7 +33396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33346,7 +33411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33365,7 +33430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33380,7 +33445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33399,7 +33464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33414,7 +33479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33433,7 +33498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33448,7 +33513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33467,7 +33532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33482,7 +33547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33501,7 +33566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33516,7 +33581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33535,7 +33600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33550,7 +33615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33569,7 +33634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33584,7 +33649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33603,7 +33668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33618,7 +33683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33637,7 +33702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33652,7 +33717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33671,7 +33736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33686,7 +33751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33705,7 +33770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33720,7 +33785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33739,7 +33804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33754,7 +33819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33773,7 +33838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33788,7 +33853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33807,7 +33872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33822,7 +33887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33841,7 +33906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33856,7 +33921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33875,7 +33940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33890,7 +33955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33909,7 +33974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33924,7 +33989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33943,7 +34008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33958,7 +34023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33977,7 +34042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -33992,7 +34057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34011,7 +34076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34026,7 +34091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34045,7 +34110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34060,7 +34125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34079,7 +34144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34094,7 +34159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34113,7 +34178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34128,7 +34193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34147,7 +34212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34162,7 +34227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34181,7 +34246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34196,7 +34261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34215,7 +34280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34230,7 +34295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34249,7 +34314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34264,7 +34329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34283,7 +34348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34298,7 +34363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34317,7 +34382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34332,7 +34397,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34351,7 +34416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34366,7 +34431,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34385,7 +34450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34400,7 +34465,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1094,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34419,7 +34484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34434,7 +34499,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34453,7 +34518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34468,7 +34533,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34487,7 +34552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34502,7 +34567,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34521,7 +34586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34536,7 +34601,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1100,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34555,7 +34620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34570,7 +34635,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1100,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34589,7 +34654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34604,7 +34669,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34623,7 +34688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34638,7 +34703,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34657,7 +34722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34672,7 +34737,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34691,7 +34756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34706,7 +34771,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34725,7 +34790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34740,7 +34805,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34759,7 +34824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34774,7 +34839,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34793,7 +34858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34808,7 +34873,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34827,7 +34892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34842,7 +34907,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34861,7 +34926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34876,7 +34941,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34895,7 +34960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34910,7 +34975,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34929,7 +34994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34944,7 +35009,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34963,7 +35028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -34978,7 +35043,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34997,7 +35062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -35012,7 +35077,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35031,7 +35096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -35046,7 +35111,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35065,7 +35130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -35080,7 +35145,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35099,7 +35164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -35114,7 +35179,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35133,7 +35198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -35148,7 +35213,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35167,7 +35232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -35182,7 +35247,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35201,7 +35266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -35216,7 +35281,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35234,7 +35299,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1616
+            "line": 1618
           }
         ],
         "classification": "external",
@@ -35242,7 +35307,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1617,
+        "line": 1619,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35259,7 +35324,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1624
+            "line": 1626
           }
         ],
         "classification": "external",
@@ -35267,7 +35332,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1625,
+        "line": 1627,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35284,7 +35349,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1632
+            "line": 1634
           }
         ],
         "classification": "external",
@@ -35292,7 +35357,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1633,
+        "line": 1635,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38276,13 +38341,13 @@
       },
       {
         "is_package": false,
-        "loc": 506,
+        "loc": 560,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "1fb24486e282b1cc2752365c643338871818dc6e",
+        "normalized_git_blob_sha1": "82d0a1a3c8f2a1e83cc99041a997f5a706ca0935",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 4,
+          "function_count": 5,
           "global_count": 3
         }
       },
@@ -38924,13 +38989,13 @@
       },
       {
         "is_package": false,
-        "loc": 2246,
+        "loc": 2198,
         "module": "nodes",
-        "normalized_git_blob_sha1": "f15e16b263a29953f593b289bf793871fb2c0c08",
+        "normalized_git_blob_sha1": "bb8d65eedc9c124c5fd3e2ea967386bbf1b1ce8b",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 14,
+          "function_count": 13,
           "global_count": 26
         }
       },
@@ -40290,7 +40355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40299,7 +40364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40313,7 +40378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40322,7 +40387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40336,7 +40401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40345,7 +40410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40359,7 +40424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40368,7 +40433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40382,7 +40447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40391,7 +40456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40405,7 +40470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40414,7 +40479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40428,7 +40493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40437,7 +40502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40451,7 +40516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40460,7 +40525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 566,
+        "line": 567,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40474,7 +40539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40483,7 +40548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40497,7 +40562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40506,7 +40571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40520,7 +40585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40529,7 +40594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 577,
+        "line": 578,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40543,7 +40608,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
+        "kind": "static_from",
+        "line": 578,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40552,7 +40640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40566,7 +40654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40575,7 +40663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40589,7 +40677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40598,7 +40686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40612,7 +40700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40621,7 +40709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40635,7 +40723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40644,7 +40732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40658,7 +40746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40667,7 +40755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40681,7 +40769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40690,7 +40778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40704,7 +40792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40713,7 +40801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40727,7 +40815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40736,7 +40824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40750,7 +40838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40759,7 +40847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40773,7 +40861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40782,7 +40870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40796,7 +40884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40805,7 +40893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40819,7 +40907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40828,7 +40916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40842,7 +40930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40851,7 +40939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40865,7 +40953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40874,7 +40962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40888,7 +40976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40897,7 +40985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 582,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40911,7 +40999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40920,7 +41008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 600,
+        "line": 602,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40934,7 +41022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40943,7 +41031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40957,7 +41045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40966,7 +41054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40980,7 +41068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -40989,7 +41077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 603,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41003,7 +41091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41012,7 +41100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41026,7 +41114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41035,7 +41123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41049,7 +41137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41058,7 +41146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41072,7 +41160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41081,7 +41169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41095,7 +41183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41104,7 +41192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41118,7 +41206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41127,7 +41215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41141,7 +41229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41150,7 +41238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41164,7 +41252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41173,7 +41261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41187,7 +41275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41196,7 +41284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41210,7 +41298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41219,7 +41307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41233,7 +41321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41242,7 +41330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41256,7 +41344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41265,7 +41353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41279,7 +41367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41288,7 +41376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41302,7 +41390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41311,7 +41399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41325,7 +41413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41334,7 +41422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41348,7 +41436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41357,7 +41445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41371,7 +41459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41380,7 +41468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41394,7 +41482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41403,7 +41491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41417,7 +41505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41426,7 +41514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41440,7 +41528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41449,7 +41537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41463,7 +41551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41472,7 +41560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41486,7 +41574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41495,7 +41583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41509,7 +41597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41518,7 +41606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41532,7 +41620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41541,7 +41629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41555,7 +41643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41564,7 +41652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41578,7 +41666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41587,7 +41675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41601,7 +41689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41610,7 +41698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41624,7 +41712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41633,7 +41721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41647,7 +41735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41656,7 +41744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41670,7 +41758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41679,7 +41767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41693,7 +41781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41702,7 +41790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41716,7 +41804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41725,7 +41813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41739,7 +41827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41748,7 +41836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 635,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41762,7 +41850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41771,7 +41859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41785,7 +41873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41794,7 +41882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41808,7 +41896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41817,7 +41905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41831,7 +41919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41840,7 +41928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41854,7 +41942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41863,7 +41951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41877,7 +41965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41886,7 +41974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41900,7 +41988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41909,7 +41997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41923,7 +42011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41932,7 +42020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41946,7 +42034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41955,7 +42043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41969,7 +42057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -41978,7 +42066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 649,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41992,7 +42080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42001,7 +42089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42015,7 +42103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42024,7 +42112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42038,7 +42126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42047,7 +42135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42061,7 +42149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42070,7 +42158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42084,7 +42172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42093,7 +42181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42107,7 +42195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42116,7 +42204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42130,7 +42218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42139,7 +42227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42153,7 +42241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42162,7 +42250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42176,7 +42264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42185,7 +42273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42199,7 +42287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42208,7 +42296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 661,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42222,7 +42310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42231,7 +42319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42245,7 +42333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42254,7 +42342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42268,7 +42356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42277,7 +42365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42291,7 +42379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42300,7 +42388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42314,7 +42402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42323,7 +42411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42337,7 +42425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42346,7 +42434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42360,7 +42448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42369,7 +42457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42383,7 +42471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42392,7 +42480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42406,7 +42494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42415,7 +42503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42429,7 +42517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42438,7 +42526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42452,7 +42540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42461,7 +42549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42475,7 +42563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42484,7 +42572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42498,7 +42586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42507,7 +42595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42521,7 +42609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42530,7 +42618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42544,7 +42632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42553,7 +42641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42567,7 +42655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42576,7 +42664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 673,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42590,7 +42678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42599,7 +42687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42613,7 +42701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42622,7 +42710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42636,7 +42724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42645,7 +42733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 691,
+        "line": 693,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42659,7 +42747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42668,7 +42756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42682,7 +42770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42691,7 +42779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42705,7 +42793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42714,7 +42802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42728,7 +42816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42737,7 +42825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42751,7 +42839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42760,7 +42848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 696,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42774,7 +42862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42783,7 +42871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 703,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42797,7 +42885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42806,7 +42894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42820,7 +42908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42829,7 +42917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42843,7 +42931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42852,7 +42940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42866,7 +42954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42875,7 +42963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42889,7 +42977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42898,7 +42986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42912,7 +43000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42921,7 +43009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42935,7 +43023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42944,7 +43032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42958,7 +43046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42967,7 +43055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42981,7 +43069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -42990,7 +43078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43004,7 +43092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43013,7 +43101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43027,7 +43115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43036,7 +43124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43050,7 +43138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43059,7 +43147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43073,7 +43161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43082,7 +43170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43096,7 +43184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43105,7 +43193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43119,7 +43207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43128,7 +43216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43142,7 +43230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43151,7 +43239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43165,7 +43253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43174,7 +43262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43188,7 +43276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43197,7 +43285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43211,7 +43299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43220,7 +43308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43234,7 +43322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43243,7 +43331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43257,7 +43345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43266,7 +43354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 724,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43280,7 +43368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43289,7 +43377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43303,7 +43391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43312,7 +43400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43326,7 +43414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43335,7 +43423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43349,7 +43437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43358,7 +43446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43372,7 +43460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43381,7 +43469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43395,7 +43483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43404,7 +43492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43418,7 +43506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43427,7 +43515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43441,7 +43529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43450,7 +43538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43464,7 +43552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43473,7 +43561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43487,7 +43575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43496,7 +43584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43510,7 +43598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43519,7 +43607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43533,7 +43621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43542,7 +43630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43556,7 +43644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43565,7 +43653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43579,7 +43667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43588,7 +43676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43602,7 +43690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43611,7 +43699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43625,7 +43713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43634,7 +43722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43648,7 +43736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43657,7 +43745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43671,7 +43759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43680,7 +43768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43694,7 +43782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43703,7 +43791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43717,7 +43805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43726,7 +43814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43740,7 +43828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43749,7 +43837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43763,7 +43851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43772,7 +43860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 742,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43786,7 +43874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43795,7 +43883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43809,7 +43897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43818,7 +43906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43832,7 +43920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43841,7 +43929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43855,7 +43943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43864,7 +43952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43878,7 +43966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43887,7 +43975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43901,7 +43989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43910,7 +43998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43924,7 +44012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43933,7 +44021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43947,7 +44035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43956,7 +44044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43970,7 +44058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -43979,7 +44067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43993,7 +44081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44002,7 +44090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44016,7 +44104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44025,7 +44113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44039,7 +44127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44048,7 +44136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44062,7 +44150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44071,7 +44159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44085,7 +44173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44094,7 +44182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 778,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44108,7 +44196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44117,7 +44205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44131,7 +44219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44140,7 +44228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44154,7 +44242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44163,7 +44251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44177,7 +44265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44186,7 +44274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44200,7 +44288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44209,7 +44297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44223,7 +44311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44232,7 +44320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44246,7 +44334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44255,7 +44343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44269,7 +44357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44278,7 +44366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44292,7 +44380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44301,7 +44389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 806,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44315,7 +44403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44324,7 +44412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44338,7 +44426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44347,7 +44435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44361,7 +44449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44370,7 +44458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44384,7 +44472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44393,7 +44481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44407,7 +44495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44416,7 +44504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44430,7 +44518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44439,7 +44527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44453,7 +44541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44462,7 +44550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44476,7 +44564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44485,7 +44573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44499,7 +44587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44508,7 +44596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44522,7 +44610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44531,7 +44619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44545,7 +44633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44554,7 +44642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44568,7 +44656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44577,7 +44665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44591,7 +44679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44600,7 +44688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44614,7 +44702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44623,7 +44711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44637,7 +44725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44646,7 +44734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44660,7 +44748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44669,7 +44757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44683,7 +44771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44692,7 +44780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44706,7 +44794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44715,7 +44803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44729,7 +44817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44738,7 +44826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44752,7 +44840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44761,7 +44849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44775,7 +44863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44784,7 +44872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44798,7 +44886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44807,7 +44895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44821,7 +44909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44830,7 +44918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44844,7 +44932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44853,7 +44941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44867,7 +44955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44876,7 +44964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 822,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44890,7 +44978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44899,7 +44987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44913,7 +45001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44922,7 +45010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44936,7 +45024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44945,7 +45033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44959,7 +45047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44968,7 +45056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 902,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44982,7 +45070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -44991,7 +45079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45005,7 +45093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45014,7 +45102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45028,7 +45116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45037,7 +45125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45051,7 +45139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45060,7 +45148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45074,7 +45162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45083,7 +45171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45097,7 +45185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45106,7 +45194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45120,7 +45208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45129,7 +45217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45143,7 +45231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45152,7 +45240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45166,7 +45254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45175,7 +45263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45189,7 +45277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45198,7 +45286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45212,7 +45300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45221,7 +45309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45235,7 +45323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45244,7 +45332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45258,7 +45346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45267,7 +45355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45281,7 +45369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45290,7 +45378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45304,7 +45392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45313,7 +45401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45327,7 +45415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45336,7 +45424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 928,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45350,7 +45438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45359,7 +45447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45373,7 +45461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45382,7 +45470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45396,7 +45484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45405,7 +45493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45419,7 +45507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45428,7 +45516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 939,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45442,7 +45530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45451,7 +45539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45465,7 +45553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45474,7 +45562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 952,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45488,7 +45576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45497,7 +45585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45511,7 +45599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45520,7 +45608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45534,7 +45622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45543,7 +45631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45557,7 +45645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45566,7 +45654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45580,7 +45668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45589,7 +45677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45603,7 +45691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45612,7 +45700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45626,7 +45714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45635,7 +45723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45649,7 +45737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45658,7 +45746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45672,7 +45760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45681,7 +45769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45695,7 +45783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45704,7 +45792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45718,7 +45806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45727,7 +45815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45741,7 +45829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45750,7 +45838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 971,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45764,7 +45852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45773,7 +45861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45787,7 +45875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45796,7 +45884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45810,7 +45898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45819,7 +45907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45833,7 +45921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45842,7 +45930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45856,7 +45944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45865,7 +45953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45879,7 +45967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45888,7 +45976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45902,7 +45990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45911,7 +45999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45925,7 +46013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45934,7 +46022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45948,7 +46036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45957,7 +46045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45971,7 +46059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -45980,7 +46068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45994,7 +46082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46003,7 +46091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46017,7 +46105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46026,7 +46114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46040,7 +46128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46049,7 +46137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46063,7 +46151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46072,7 +46160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46086,7 +46174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46095,7 +46183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46109,7 +46197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46118,7 +46206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46132,7 +46220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46141,7 +46229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46155,7 +46243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46164,7 +46252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46178,7 +46266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46187,7 +46275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46201,7 +46289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46210,7 +46298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46224,7 +46312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46233,7 +46321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46247,7 +46335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46256,7 +46344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46270,7 +46358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46279,7 +46367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46293,7 +46381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46302,7 +46390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46316,7 +46404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46325,7 +46413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46339,7 +46427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46348,7 +46436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46362,7 +46450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46371,7 +46459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1028,
+        "line": 1030,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46385,7 +46473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46394,7 +46482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46408,7 +46496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46417,7 +46505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1051,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46431,7 +46519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46440,7 +46528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46454,7 +46542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46463,7 +46551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46477,7 +46565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46486,7 +46574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46500,7 +46588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46509,7 +46597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46523,7 +46611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46532,7 +46620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46546,7 +46634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46555,7 +46643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46569,7 +46657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46578,7 +46666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46592,7 +46680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46601,7 +46689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46615,7 +46703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46624,7 +46712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46638,7 +46726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46647,7 +46735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46661,7 +46749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46670,7 +46758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46684,7 +46772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46693,7 +46781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46707,7 +46795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46716,7 +46804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46730,7 +46818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46739,7 +46827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46753,7 +46841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46762,7 +46850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46776,7 +46864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46785,7 +46873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46799,7 +46887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46808,7 +46896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46822,7 +46910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46831,7 +46919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46845,7 +46933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46854,7 +46942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46868,7 +46956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46877,7 +46965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46891,7 +46979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46900,7 +46988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46914,7 +47002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46923,7 +47011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46937,7 +47025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46946,7 +47034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46960,7 +47048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46969,7 +47057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46983,7 +47071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -46992,7 +47080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47006,7 +47094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47015,7 +47103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47029,7 +47117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47038,7 +47126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47052,7 +47140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47061,7 +47149,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47075,7 +47163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47084,7 +47172,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47098,7 +47186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47107,7 +47195,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47121,7 +47209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47130,7 +47218,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47144,7 +47232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47153,7 +47241,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47167,7 +47255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47176,7 +47264,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47190,7 +47278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47199,7 +47287,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47213,7 +47301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47222,7 +47310,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47236,7 +47324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47245,7 +47333,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47259,7 +47347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47268,7 +47356,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47282,7 +47370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47291,7 +47379,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47305,7 +47393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47314,7 +47402,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47328,7 +47416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47337,7 +47425,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47351,7 +47439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47360,7 +47448,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47374,7 +47462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47383,7 +47471,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47397,7 +47485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47406,7 +47494,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47420,7 +47508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47429,7 +47517,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47443,7 +47531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47452,7 +47540,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47466,7 +47554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47475,7 +47563,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47489,7 +47577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47498,7 +47586,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47512,7 +47600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47521,7 +47609,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47535,7 +47623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47544,7 +47632,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47558,7 +47646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47567,7 +47655,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47581,7 +47669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47590,7 +47678,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47604,7 +47692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47613,7 +47701,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47627,7 +47715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47636,7 +47724,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47650,7 +47738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 565,
+            "handler_line": 566,
             "kind": "try",
             "line": 10
           }
@@ -47659,7 +47747,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51486,14 +51574,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1616
+            "line": 1618
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1617,
+        "line": 1619,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51505,14 +51593,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1624
+            "line": 1626
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1625,
+        "line": 1627,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51524,14 +51612,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1632
+            "line": 1634
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1633,
+        "line": 1635,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52906,14 +52994,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1616
+            "line": 1618
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1617,
+        "line": 1619,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52925,14 +53013,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1624
+            "line": 1626
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1625,
+        "line": 1627,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52944,14 +53032,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1632
+            "line": 1634
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1633,
+        "line": 1635,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54412,7 +54500,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1121,
+        "line": 1123,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54421,7 +54509,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2142,
+        "line": 2094,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54430,7 +54518,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2145,
+        "line": 2097,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54439,7 +54527,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2148,
+        "line": 2100,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54448,7 +54536,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2151,
+        "line": 2103,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54457,7 +54545,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2154,
+        "line": 2106,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54466,7 +54554,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2157,
+        "line": 2109,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54475,7 +54563,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2160,
+        "line": 2112,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54484,7 +54572,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2163,
+        "line": 2115,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54493,7 +54581,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2166,
+        "line": 2118,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54502,7 +54590,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2169,
+        "line": 2121,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54511,7 +54599,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2172,
+        "line": 2124,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54520,7 +54608,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2175,
+        "line": 2127,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54529,7 +54617,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2178,
+        "line": 2130,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54538,7 +54626,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2181,
+        "line": 2133,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54547,7 +54635,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2184,
+        "line": 2136,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54556,7 +54644,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2187,
+        "line": 2139,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54565,7 +54653,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2191,
+        "line": 2143,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54574,7 +54662,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2194,
+        "line": 2146,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54583,7 +54671,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2198,
+        "line": 2150,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54592,7 +54680,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2201,
+        "line": 2153,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54601,7 +54689,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2205,
+        "line": 2157,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54610,7 +54698,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2208,
+        "line": 2160,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54619,7 +54707,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2211,
+        "line": 2163,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54628,7 +54716,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2214,
+        "line": 2166,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54637,7 +54725,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2217,
+        "line": 2169,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54646,7 +54734,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2220,
+        "line": 2172,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54655,7 +54743,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2227,
+        "line": 2179,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54664,7 +54752,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2233,
+        "line": 2185,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54673,7 +54761,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2238,
+        "line": 2190,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54682,7 +54770,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2242,
+        "line": 2194,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55196,13 +55284,13 @@
       },
       {
         "kind": "dict",
-        "line": 1183,
+        "line": 1185,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1172,
+        "line": 1174,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "8b3ba38988407225aa53b9cd23e151db3a7d6ac8",
+    "base_commit": "92506109117e42ea10e4664667481f27ad08623a",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -52,7 +52,8 @@
       "B-11c19",
       "B-11c20",
       "B-11c21",
-      "B-11c22"
+      "B-11c22",
+      "B-11c23"
     ]
   },
   "enums": {
@@ -87,11 +88,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 294,
+    "nodes_canonical_bindings": 295,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 14,
+    "root_residual_functions": 13,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -1025,7 +1026,13 @@
     "_run_aio_postprocess_stage": [
       "easyuse_anima.aio.legacy_generation"
     ],
+    "_run_aio_resshift_upscale_stage": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
     "_run_aio_upscale_stage": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
+    "_run_aio_usdu_upscale_stage": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_sam3_context": [
@@ -2098,7 +2105,8 @@
       "symbols": {
         "_bind_aio_legacy_generation_runtime": "_bind_aio_legacy_generation_runtime",
         "_run_aio_highres_stage": "_run_aio_highres_stage",
-        "_run_aio_legacy_generation": "_run_aio_legacy_generation"
+        "_run_aio_legacy_generation": "_run_aio_legacy_generation",
+        "_run_aio_upscale_stage": "_run_aio_upscale_stage"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -4179,7 +4187,6 @@
         "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_detailer_target": "_run_aio_detailer_target",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
-        "_run_aio_upscale_stage": "_run_aio_upscale_stage",
         "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
       },
       "classification": "transitional_private_seam",

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -36,6 +36,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             nodes._run_aio_highres_stage,
             legacy_generation._run_aio_highres_stage,
         )
+        self.assertIs(
+            nodes._run_aio_upscale_stage,
+            legacy_generation._run_aio_upscale_stage,
+        )
 
         with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
             canonical_module = sys.modules[
@@ -52,6 +56,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             self.assertIs(
                 package_nodes._run_aio_highres_stage,
                 canonical_module._run_aio_highres_stage,
+            )
+            self.assertIs(
+                package_nodes._run_aio_upscale_stage,
+                canonical_module._run_aio_upscale_stage,
             )
 
     def test_highres_stage_disabled_short_circuits_after_as_bool(self):
@@ -343,6 +351,193 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 "sample",
                 "resolve:_cleanup_aio_ephemeral_model",
                 "cleanup",
+            ],
+        )
+
+    def test_upscale_dispatcher_preserves_lazy_branch_and_exception_contract(self):
+        model = _Token("model")
+        clip = _Token("clip")
+        vae = _Token("vae")
+        positive = _Token("positive")
+        negative = _Token("negative")
+        image = _Token("image")
+        sampler_settings = {"seed": 17}
+        prompt_data = {"fields": []}
+        quality_tags = "quality"
+        quality_neg = "quality-neg"
+
+        def execute(upscale_settings, leaf_helpers, trace):
+            def as_bool(value, default):
+                trace.append(("call", "_as_bool", value, default))
+                return bool(value)
+
+            helpers = {"_as_bool": as_bool, **leaf_helpers}
+
+            def resolve(name):
+                trace.append(("resolve", name))
+                return helpers[name]
+
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=resolve
+            )
+            try:
+                return nodes._run_aio_upscale_stage(
+                    model,
+                    clip,
+                    vae,
+                    positive,
+                    negative,
+                    image,
+                    sampler_settings,
+                    upscale_settings,
+                    quality_tags,
+                    quality_neg,
+                    prompt_data,
+                    True,
+                    False,
+                )
+            finally:
+                legacy_generation._bind_aio_legacy_generation_runtime(
+                    resolve_helper=lambda name: getattr(nodes, name)
+                )
+
+        disabled_trace = []
+        disabled_result = execute({"enabled": False}, {}, disabled_trace)
+        self.assertIs(disabled_result[0], image)
+        self.assertEqual(disabled_result[1], {"enabled": False})
+        self.assertEqual(
+            disabled_trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", False, False),
+            ],
+        )
+
+        usdu_settings = {"enabled": True, "backend": ""}
+        usdu_output = _Token("usdu_output")
+        usdu_metadata = {"backend": "usdu"}
+        usdu_trace = []
+
+        def run_usdu(*args):
+            usdu_trace.append(("call", "usdu"))
+            self.assertEqual(
+                args,
+                (
+                    model,
+                    clip,
+                    vae,
+                    positive,
+                    negative,
+                    image,
+                    sampler_settings,
+                    usdu_settings,
+                    quality_tags,
+                    quality_neg,
+                    prompt_data,
+                    True,
+                    False,
+                ),
+            )
+            return usdu_output, usdu_metadata
+
+        usdu_result = execute(
+            usdu_settings,
+            {"_run_aio_usdu_upscale_stage": run_usdu},
+            usdu_trace,
+        )
+        self.assertEqual(usdu_result, (usdu_output, usdu_metadata))
+        self.assertIs(usdu_result[0], usdu_output)
+        self.assertIs(usdu_result[1], usdu_metadata)
+        self.assertEqual(
+            usdu_trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+                ("resolve", "_run_aio_usdu_upscale_stage"),
+                ("call", "usdu"),
+            ],
+        )
+
+        resshift_settings = {"enabled": True, "backend": "resshift"}
+        resshift_output = _Token("resshift_output")
+        resshift_metadata = {"backend": "resshift"}
+        resshift_trace = []
+
+        def run_resshift(*args):
+            resshift_trace.append(("call", "resshift"))
+            self.assertEqual(
+                args,
+                (
+                    image,
+                    sampler_settings,
+                    resshift_settings,
+                    quality_tags,
+                    quality_neg,
+                    prompt_data,
+                    True,
+                    False,
+                ),
+            )
+            return resshift_output, resshift_metadata
+
+        resshift_result = execute(
+            resshift_settings,
+            {"_run_aio_resshift_upscale_stage": run_resshift},
+            resshift_trace,
+        )
+        self.assertEqual(
+            resshift_result,
+            (resshift_output, resshift_metadata),
+        )
+        self.assertIs(resshift_result[0], resshift_output)
+        self.assertIs(resshift_result[1], resshift_metadata)
+        self.assertEqual(
+            resshift_trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+                ("resolve", "_run_aio_resshift_upscale_stage"),
+                ("call", "resshift"),
+            ],
+        )
+
+        unsupported_trace = []
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] Unsupported final upscale backend: unknown$",
+        ):
+            execute(
+                {"enabled": True, "backend": "unknown"},
+                {},
+                unsupported_trace,
+            )
+        self.assertEqual(
+            unsupported_trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+            ],
+        )
+
+        failure_trace = []
+
+        def fail_usdu(*args):
+            failure_trace.append(("call", "usdu"))
+            raise ValueError("leaf failed")
+
+        with self.assertRaisesRegex(ValueError, "leaf failed"):
+            execute(
+                {"enabled": True, "backend": "usdu"},
+                {"_run_aio_usdu_upscale_stage": fail_usdu},
+                failure_trace,
+            )
+        self.assertEqual(
+            failure_trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+                ("resolve", "_run_aio_usdu_upscale_stage"),
+                ("call", "usdu"),
             ],
         )
 

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "f15e16b263a29953f593b289bf793871fb2c0c08")
-        # Issue #184 B-11c22 moves only the AiO highres stage to its canonical
-        # legacy-generation owner.
-        self.assertEqual(report["top_level"]["function_count"], 14)
+        self.assertEqual(report["git_blob_sha1"], "bb8d65eedc9c124c5fd3e2ea967386bbf1b1ce8b")
+        # Issue #184 B-11c23 moves only the AiO upscale dispatcher to its
+        # canonical legacy-generation owner.
+        self.assertEqual(report["top_level"]["function_count"], 13)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_246)
+        self.assertEqual(report["line_count"], 2_198)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "8b3ba38988407225aa53b9cd23e151db3a7d6ac8"
+BASE_COMMIT = "92506109117e42ea10e4664667481f27ad08623a"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1325,6 +1325,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c20",
                 "B-11c21",
                 "B-11c22",
+                "B-11c23",
             ],
         },
         "enums": {
@@ -1337,11 +1338,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 294,
+            "nodes_canonical_bindings": 295,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 14,
+            "root_residual_functions": 13,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c23 단일 Move로 root `_run_aio_upscale_stage` dispatcher body만 roadmap의 temporary current-order orchestration owner `easyuse_anima.aio.legacy_generation`으로 이동합니다.
- USDU/ResShift leaf 구현은 root에 남기고, root `nodes.py`에는 relative/flat direct identity alias를 유지합니다.

## 작업 전 inventory

### Symbol / caller

- `_run_aio_upscale_stage`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.aio.legacy_generation._run_aio_legacy_generation`이 `_runtime_helper("_run_aio_upscale_stage")`로 매 호출 root seam 조회
  - 기존 direct behavior tests는 USDU/ResShift 선택 경로를 소비하고 generator tests는 root monkeypatch seam을 소비
  - public mapping/export 없음
- canonical owner는 B-09b가 지정한 `easyuse_anima.aio.legacy_generation`입니다. 새 stage module은 #169 Contract를 선점하므로 추가하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical dispatcher identity를 유지합니다.
- 기존 `_bind_aio_legacy_generation_runtime`과 `_RUNTIME_RESOLVER`만 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- production caller는 같은 모듈 안에서도 기존 root string lookup을 유지해 monkeypatch seam을 보존합니다.
- dispatcher 자체 mutable state, cache, cleanup, 입력 mutation은 없습니다.

### Call-time dependency inventory

- `_as_bool`
- `_run_aio_usdu_upscale_stage`
- `_run_aio_resshift_upscale_stage`

### 보존할 평가·예외 순서

- 먼저 `_as_bool`을 resolve해 `upscale_settings.get("enabled")`를 평가하며, disabled면 backend/leaf를 resolve하지 않고 동일 image와 `{"enabled": False}`를 반환합니다.
- enabled면 `str(upscale_settings.get("backend") or "usdu")`를 평가합니다. falsy backend는 USDU로 처리합니다.
- `usdu`는 USDU leaf만 resolve해 기존 13개 positional argument를 그대로 전달합니다.
- `resshift`는 ResShift leaf만 resolve해 기존 8개 positional argument를 그대로 전달합니다.
- 지원하지 않는 truthy backend는 leaf를 resolve하지 않고 기존 exact `RuntimeError`를 발생시킵니다.
- 선택 leaf의 예외와 2-value unpack 오류는 catch 없이 그대로 전파하며 성공 결과 두 객체 identity를 보존합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/legacy_generation.py`, `nodes.py`
- contract/analyzer: `tests/test_aio_legacy_generation.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- base: `dev` / `92506109117e42ea10e4664667481f27ad08623a`
- canonical bindings: `294 → 295`
- root/top-level residual functions: `14 → 13`
- runtime binders: `30` 유지
- runtime resolver names: `280 → 282` (`_run_aio_usdu_upscale_stage`, `_run_aio_resshift_upscale_stage` 신규)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6: 변화 없음
- `nodes.py` line count: `2,246 → 2,198` 예상, 구현 후 analyzer actual로 고정

## 금지 경계

- USDU/ResShift leaf body, Detailer, resize/provider helper 동시 이동 금지
- legacy caller의 root string lookup을 sibling direct call로 바꾸지 않음
- settings/schema/default/workflow, stage protocol, #169 Contract/Behavior 변경 금지
- dependency 정적 import, 예외/cleanup/validation 추가, 인자·분기·반환 순서 변경 금지
- 새 binder/global/module 또는 public `__all__` 결합 금지

## 검증

- exact head: `4a33be658f55b2019db3ad4e57663798cbc9110f`
- focused alias/disabled/USDU/ResShift/unsupported/leaf-exception order와 기존 leaf behavior/analyzer/import-boundary: 33 tests passed
- canonical owner Ruff: clean
- 독립 diff review: 차단점 없음
- `tools/check_project.ps1 -Profile full`: passed
  - Python unittest: 922 passed
  - Frontend: 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline ratchet: passed (66 files, 60 baseline errors)
  - Python import boundary gate: passed (6 groups, 0 violations)
  - Git diff check: passed
  - Ruff: 기존 G-01 report-only 113건, blocking failure 없음
- Live ComfyUI/browser smoke: private dispatcher Move 범위에서는 수행하지 않음

## 상태

- Ready
- Move-only 경계, 독립 diff review, exact-head focused/full 검증을 충족했습니다.
