### PR TITLE
refactor: move AiO detailer stage owner

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `92506109117e42ea10e4664667481f27ad08623a`
+- Integrated `dev` snapshot commit: `6a5fd7bd2c369921e5ecb18791df187d578d6637`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c22 / `9250610`; B-11c23 AiO upscale dispatcher Move in PR #317 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c23 / `6a5fd7b`; B-11c24 AiO Detailer stage Move in PR #318 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,246
-  lines after B-11c22.
-- The mechanical extraction has removed 10,417
-  lines, approximately 82.3% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,198
+  lines after B-11c23.
+- The mechanical extraction has removed 10,465
+  lines, approximately 82.6% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -82,7 +82,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   #313 / `de57090`. B-11c20 moved only the CLIP loader-type wrapper in PR #314 /
   `43c3056`. B-11c21 moved only the AiO postprocess stage in PR #315 /
   `8b3ba38`. B-11c22 moved only the AiO highres stage in PR #316 / `9250610`.
-  B-11c23 moves only the AiO upscale dispatcher in PR #317.
+  B-11c23 moved only the AiO upscale dispatcher in PR #317 / `6a5fd7b`.
+  B-11c24 moves only the AiO Detailer stage coordinator in PR #318.
 
 ### Current quality baseline
 
@@ -324,7 +325,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 AiO upscale dispatcher Move PR #317 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 AiO Detailer stage Move PR #318 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `92506109117e42ea10e4664667481f27ad08623a`
+  `6a5fd7bd2c369921e5ecb18791df187d578d6637`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c22 are integrated through PR #316. B-11c is
+- Current state: B-11a through B-11c23 are integrated through PR #317. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c23 AiO upscale dispatcher Move is tracked by PR #317.
+  the final root shim; B-11c24 AiO Detailer stage Move is tracked by PR #318.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 295 in B-11c23
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 296 in B-11c24
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 13 functions, 0 classes, and 26 assigned
-  globals in B-11c23 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 12 functions, 0 classes, and 26 assigned
+  globals in B-11c24 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 282, including
+- root names reached by those canonical runtime resolvers: 285, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -507,6 +507,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
   result identity, and leaf exception propagation are unchanged.
 - PR #317 does not move or change either leaf stage, settings/schema/defaults,
   workflow behavior, or the later #169 Contract/Behavior work.
+
+### B-11c24 AiO Detailer stage alias
+
+- Canonical owner: `easyuse_anima.aio.legacy_generation` for
+  `_run_aio_detailer_stage`.
+- The private root coordinator remains a transitional direct alias in relative
+  package and flat import modes. The canonical legacy-generation caller keeps
+  resolving the root name at call time to preserve its monkeypatch seam.
+- The existing legacy-generation binder resolves boolean coercion, target-order
+  planning, SAM3 context loading, the selected Detailer target leaf, and context
+  metadata access at use time. Disabled/no-target short-circuits, saved order,
+  output chaining, callback timing, metadata identity/order, and exception
+  propagation are unchanged.
+- PR #318 does not move or change the Detailer target leaf, SAM3 resources,
+  settings/schema/defaults, workflow behavior, or the later #169
+  Contract/Behavior work.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -104,6 +104,65 @@ def _run_aio_highres_stage(
     }
 
 
+def _run_aio_detailer_stage(
+    model,
+    clip,
+    vae,
+    positive,
+    negative,
+    image,
+    sampler_settings: dict[str, Any],
+    detailer_settings: dict[str, Any],
+    preview_callback=None,
+) -> tuple[Any, dict[str, Any]]:
+    if not _runtime_helper("_as_bool")(
+        detailer_settings.get("enabled"), False
+    ):
+        return image, {"enabled": False}
+    target_order = _runtime_helper("_aio_detailer_target_order")(detailer_settings)
+    enabled_targets = [
+        name
+        for name in target_order
+        if isinstance(detailer_settings.get(name), dict)
+        and _runtime_helper("_as_bool")(
+            detailer_settings[name].get("enabled"), False
+        )
+    ]
+    if not enabled_targets:
+        return image, {"enabled": False, "reason": "no target enabled"}
+
+    sam3_context = _runtime_helper("_load_aio_sam3_context")(detailer_settings)
+    output = image
+    target_results: dict[str, Any] = {}
+    for target_name in target_order:
+        if target_name not in enabled_targets:
+            continue
+        output, target_results[target_name] = _runtime_helper(
+            "_run_aio_detailer_target"
+        )(
+            target_name,
+            detailer_settings[target_name],
+            output,
+            model,
+            clip,
+            vae,
+            positive,
+            negative,
+            sampler_settings,
+            sam3_context,
+        )
+        if preview_callback is not None:
+            preview_callback(f"detailer_{target_name}", output)
+    return output, {
+        "enabled": True,
+        "sam3_checkpoint": _runtime_helper("_context_value")(
+            sam3_context, "ckpt_name"
+        ),
+        "order": target_order,
+        "targets": target_results,
+    }
+
+
 def _run_aio_upscale_stage(
     model,
     clip,

--- a/nodes.py
+++ b/nodes.py
@@ -21,6 +21,7 @@ try:
     )
     from .easyuse_anima.aio.legacy_generation import (
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
+        _run_aio_detailer_stage as _run_aio_detailer_stage,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
         _run_aio_upscale_stage as _run_aio_upscale_stage,
@@ -577,6 +578,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.aio.legacy_generation import (
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
+        _run_aio_detailer_stage as _run_aio_detailer_stage,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
         _run_aio_upscale_stage as _run_aio_upscale_stage,
@@ -1956,57 +1958,6 @@ def _run_aio_detailer_target(
         "enabled": True,
         "detected": _segs_has_items(segs),
         "sampler": _prompt_data_json_safe(stage_sampler),
-    }
-
-
-def _run_aio_detailer_stage(
-    model,
-    clip,
-    vae,
-    positive,
-    negative,
-    image,
-    sampler_settings: dict[str, Any],
-    detailer_settings: dict[str, Any],
-    preview_callback=None,
-) -> tuple[Any, dict[str, Any]]:
-    if not _as_bool(detailer_settings.get("enabled"), False):
-        return image, {"enabled": False}
-    target_order = _aio_detailer_target_order(detailer_settings)
-    enabled_targets = [
-        name
-        for name in target_order
-        if isinstance(detailer_settings.get(name), dict)
-        and _as_bool(detailer_settings[name].get("enabled"), False)
-    ]
-    if not enabled_targets:
-        return image, {"enabled": False, "reason": "no target enabled"}
-
-    sam3_context = _load_aio_sam3_context(detailer_settings)
-    output = image
-    target_results: dict[str, Any] = {}
-    for target_name in target_order:
-        if target_name not in enabled_targets:
-            continue
-        output, target_results[target_name] = _run_aio_detailer_target(
-            target_name,
-            detailer_settings[target_name],
-            output,
-            model,
-            clip,
-            vae,
-            positive,
-            negative,
-            sampler_settings,
-            sam3_context,
-        )
-        if preview_callback is not None:
-            preview_callback(f"detailer_{target_name}", output)
-    return output, {
-        "enabled": True,
-        "sam3_checkpoint": _context_value(sam3_context, "ckpt_name"),
-        "order": target_order,
-        "targets": target_results,
     }
 
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14640,6 +14640,37 @@
         "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
+        "alias": "_run_aio_detailer_stage",
+        "bound_name": "_run_aio_detailer_stage",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_detailer_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_run_aio_detailer_stage",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
         "alias": "_run_aio_highres_stage",
         "bound_name": "_run_aio_highres_stage",
         "branch_context": [
@@ -14754,7 +14785,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14785,7 +14816,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14816,7 +14847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14847,7 +14878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14878,7 +14909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14909,7 +14940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14940,7 +14971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14971,7 +15002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15002,7 +15033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15033,7 +15064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15064,7 +15095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15095,7 +15126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15126,7 +15157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15157,7 +15188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15188,7 +15219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15219,7 +15250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 28,
+        "line": 29,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15250,7 +15281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 46,
+        "line": 47,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15281,7 +15312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 49,
+        "line": 50,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15312,7 +15343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 49,
+        "line": 50,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15343,7 +15374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 49,
+        "line": 50,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15374,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 54,
+        "line": 55,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 54,
+        "line": 55,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 54,
+        "line": 55,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 54,
+        "line": 55,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 60,
+        "line": 61,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 60,
+        "line": 61,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 60,
+        "line": 61,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 60,
+        "line": 61,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 66,
+        "line": 67,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 81,
+        "line": 82,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 119,
+        "line": 120,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 137,
+        "line": 138,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 142,
+        "line": 143,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 149,
+        "line": 150,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 156,
+        "line": 157,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 170,
+        "line": 171,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 170,
+        "line": 171,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 170,
+        "line": 171,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 170,
+        "line": 171,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 170,
+        "line": 171,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 170,
+        "line": 171,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 170,
+        "line": 171,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 188,
+        "line": 189,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 224,
+        "line": 225,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 252,
+        "line": 253,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 268,
+        "line": 269,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 348,
+        "line": 349,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 354,
+        "line": 355,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 354,
+        "line": 355,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 354,
+        "line": 355,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 359,
+        "line": 360,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 365,
+        "line": 366,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 374,
+        "line": 375,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 374,
+        "line": 375,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 374,
+        "line": 375,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 385,
+        "line": 386,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 385,
+        "line": 386,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 385,
+        "line": 386,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 385,
+        "line": 386,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 398,
+        "line": 399,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 406,
+        "line": 407,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 417,
+        "line": 418,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 424,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 431,
+        "line": 432,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 431,
+        "line": 432,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 435,
+        "line": 436,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 444,
+        "line": 445,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 451,
+        "line": 452,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 456,
+        "line": 457,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 456,
+        "line": 457,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 456,
+        "line": 457,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 474,
+        "line": 475,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 497,
+        "line": 498,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 497,
+        "line": 498,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 506,
+        "line": 507,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 523,
+        "line": 524,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 533,
+        "line": 534,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 544,
+        "line": 545,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24302,7 +24333,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24333,7 +24364,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24352,7 +24383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24367,7 +24398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24386,7 +24417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24401,7 +24432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24420,7 +24451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24435,7 +24466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24454,7 +24485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24469,7 +24500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24488,7 +24519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24503,7 +24534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24522,7 +24553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24537,7 +24568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24556,7 +24587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24571,7 +24602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24590,7 +24621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24605,7 +24636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24624,7 +24655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24639,8 +24670,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_bind_aio_legacy_generation_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_detailer_stage",
+        "bound_name": "_run_aio_detailer_stage",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 567,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_detailer_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
+        "kind": "static_from",
+        "line": 579,
+        "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
         "role": "compatibility_fallback",
@@ -24658,7 +24723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24673,7 +24738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24692,7 +24757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24707,7 +24772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24726,7 +24791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24741,7 +24806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24760,7 +24825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24775,7 +24840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24794,7 +24859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24809,7 +24874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24828,7 +24893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24843,7 +24908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24862,7 +24927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24877,7 +24942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24896,7 +24961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24911,7 +24976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24930,7 +24995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24945,7 +25010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24964,7 +25029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -24979,7 +25044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24998,7 +25063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25013,7 +25078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25032,7 +25097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25047,7 +25112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25066,7 +25131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25081,7 +25146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25100,7 +25165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25115,7 +25180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25134,7 +25199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25149,7 +25214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25168,7 +25233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25183,7 +25248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25202,7 +25267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25217,7 +25282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25236,7 +25301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25251,7 +25316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25270,7 +25335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25285,7 +25350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25304,7 +25369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25319,7 +25384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 602,
+        "line": 604,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25338,7 +25403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25353,7 +25418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 605,
+        "line": 607,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25372,7 +25437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25387,7 +25452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 605,
+        "line": 607,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25406,7 +25471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25421,7 +25486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 607,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25440,7 +25505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25455,7 +25520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25474,7 +25539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25489,7 +25554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25508,7 +25573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25523,7 +25588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25542,7 +25607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25557,7 +25622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25576,7 +25641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25591,7 +25656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25610,7 +25675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25625,7 +25690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25644,7 +25709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25659,7 +25724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25678,7 +25743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25693,7 +25758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25712,7 +25777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25727,7 +25792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25746,7 +25811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25761,7 +25826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25780,7 +25845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25795,7 +25860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25814,7 +25879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25829,7 +25894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25848,7 +25913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25863,7 +25928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25882,7 +25947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25897,7 +25962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25916,7 +25981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25931,7 +25996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25950,7 +26015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25965,7 +26030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25984,7 +26049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -25999,7 +26064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26018,7 +26083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26033,7 +26098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26052,7 +26117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26067,7 +26132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26086,7 +26151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26101,7 +26166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26120,7 +26185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26135,7 +26200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26154,7 +26219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26169,7 +26234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26188,7 +26253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26203,7 +26268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26222,7 +26287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26237,7 +26302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26256,7 +26321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26271,7 +26336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26290,7 +26355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26305,7 +26370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26324,7 +26389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26339,7 +26404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26358,7 +26423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26373,7 +26438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26392,7 +26457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26407,7 +26472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26426,7 +26491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26441,7 +26506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26460,7 +26525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26475,7 +26540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26494,7 +26559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26509,7 +26574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26528,7 +26593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26543,7 +26608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26562,7 +26627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26577,7 +26642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26596,7 +26661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26611,7 +26676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26630,7 +26695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26645,7 +26710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26664,7 +26729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26679,7 +26744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26698,7 +26763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26713,7 +26778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26732,7 +26797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26747,7 +26812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26766,7 +26831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26781,7 +26846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26800,7 +26865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26815,7 +26880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26834,7 +26899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26849,7 +26914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26868,7 +26933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26883,7 +26948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26902,7 +26967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26917,7 +26982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26936,7 +27001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26951,7 +27016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -26970,7 +27035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -26985,7 +27050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27004,7 +27069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27019,7 +27084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27038,7 +27103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27053,7 +27118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27072,7 +27137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27087,7 +27152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27106,7 +27171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27121,7 +27186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27140,7 +27205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27155,7 +27220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27174,7 +27239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27189,7 +27254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27208,7 +27273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27223,7 +27288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27242,7 +27307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27257,7 +27322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27276,7 +27341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27291,7 +27356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27310,7 +27375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27325,7 +27390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27344,7 +27409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27359,7 +27424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27378,7 +27443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27393,7 +27458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27412,7 +27477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27427,7 +27492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27446,7 +27511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27461,7 +27526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27480,7 +27545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27495,7 +27560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27514,7 +27579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27529,7 +27594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27548,7 +27613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27563,7 +27628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27582,7 +27647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27597,7 +27662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27616,7 +27681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27631,7 +27696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27650,7 +27715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27665,7 +27730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27684,7 +27749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27699,7 +27764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27718,7 +27783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27733,7 +27798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27752,7 +27817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27767,7 +27832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27786,7 +27851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27801,7 +27866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27820,7 +27885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27835,7 +27900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27854,7 +27919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27869,7 +27934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27888,7 +27953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27903,7 +27968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27922,7 +27987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27937,7 +28002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27956,7 +28021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -27971,7 +28036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27990,7 +28055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28005,7 +28070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28024,7 +28089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28039,7 +28104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28058,7 +28123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28073,7 +28138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 705,
+        "line": 707,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28092,7 +28157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28107,7 +28172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28126,7 +28191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28141,7 +28206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28160,7 +28225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28175,7 +28240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28194,7 +28259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28209,7 +28274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28228,7 +28293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28243,7 +28308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28262,7 +28327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28277,7 +28342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28296,7 +28361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28311,7 +28376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28330,7 +28395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28345,7 +28410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28364,7 +28429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28379,7 +28444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28398,7 +28463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28413,7 +28478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28432,7 +28497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28447,7 +28512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28466,7 +28531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28481,7 +28546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28500,7 +28565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28515,7 +28580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28534,7 +28599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28549,7 +28614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28568,7 +28633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28583,7 +28648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28602,7 +28667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28617,7 +28682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28636,7 +28701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28651,7 +28716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28670,7 +28735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28685,7 +28750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28704,7 +28769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28719,7 +28784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28738,7 +28803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28753,7 +28818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28772,7 +28837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28787,7 +28852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28806,7 +28871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28821,7 +28886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28840,7 +28905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28855,7 +28920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28874,7 +28939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28889,7 +28954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28908,7 +28973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28923,7 +28988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28942,7 +29007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28957,7 +29022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28976,7 +29041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -28991,7 +29056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29010,7 +29075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29025,7 +29090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29044,7 +29109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29059,7 +29124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29078,7 +29143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29093,7 +29158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29112,7 +29177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29127,7 +29192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29146,7 +29211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29161,7 +29226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29180,7 +29245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29195,7 +29260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29214,7 +29279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29229,7 +29294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29248,7 +29313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29263,7 +29328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29282,7 +29347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29297,7 +29362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29316,7 +29381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29331,7 +29396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29350,7 +29415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29365,7 +29430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29384,7 +29449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29399,7 +29464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29418,7 +29483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29433,7 +29498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29452,7 +29517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29467,7 +29532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29486,7 +29551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29501,7 +29566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29520,7 +29585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29535,7 +29600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29554,7 +29619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29569,7 +29634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29588,7 +29653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29603,7 +29668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29622,7 +29687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29637,7 +29702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29656,7 +29721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29671,7 +29736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29690,7 +29755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29705,7 +29770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29724,7 +29789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29739,7 +29804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29758,7 +29823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29773,7 +29838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29792,7 +29857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29807,7 +29872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29826,7 +29891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29841,7 +29906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29860,7 +29925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29875,7 +29940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29894,7 +29959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29909,7 +29974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29928,7 +29993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29943,7 +30008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29962,7 +30027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -29977,7 +30042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29996,7 +30061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30011,7 +30076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30030,7 +30095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30045,7 +30110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30064,7 +30129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30079,7 +30144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30098,7 +30163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30113,7 +30178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30132,7 +30197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30147,7 +30212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30166,7 +30231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30181,7 +30246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30200,7 +30265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30215,7 +30280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30234,7 +30299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30249,7 +30314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30268,7 +30333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30283,7 +30348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30302,7 +30367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30317,7 +30382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30336,7 +30401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30351,7 +30416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30370,7 +30435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30385,7 +30450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30404,7 +30469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30419,7 +30484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30438,7 +30503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30453,7 +30518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30472,7 +30537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30487,7 +30552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30506,7 +30571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30521,7 +30586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30540,7 +30605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30555,7 +30620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30574,7 +30639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30589,7 +30654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30608,7 +30673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30623,7 +30688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30642,7 +30707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30657,7 +30722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30676,7 +30741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30691,7 +30756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30710,7 +30775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30725,7 +30790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30744,7 +30809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30759,7 +30824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30778,7 +30843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30793,7 +30858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30812,7 +30877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30827,7 +30892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30846,7 +30911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30861,7 +30926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30880,7 +30945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30895,7 +30960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30914,7 +30979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30929,7 +30994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30948,7 +31013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30963,7 +31028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30982,7 +31047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -30997,7 +31062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31016,7 +31081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31031,7 +31096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31050,7 +31115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31065,7 +31130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31084,7 +31149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31099,7 +31164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31118,7 +31183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31133,7 +31198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31152,7 +31217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31167,7 +31232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31186,7 +31251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31201,7 +31266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31220,7 +31285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31235,7 +31300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31254,7 +31319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31269,7 +31334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31288,7 +31353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31303,7 +31368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31322,7 +31387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31337,7 +31402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31356,7 +31421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31371,7 +31436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31390,7 +31455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31405,7 +31470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31424,7 +31489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31439,7 +31504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31458,7 +31523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31473,7 +31538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31492,7 +31557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31507,7 +31572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31526,7 +31591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31541,7 +31606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31560,7 +31625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31575,7 +31640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31594,7 +31659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31609,7 +31674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31628,7 +31693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31643,7 +31708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31662,7 +31727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31677,7 +31742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31696,7 +31761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31711,7 +31776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31730,7 +31795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31745,7 +31810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31764,7 +31829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31779,7 +31844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 930,
+        "line": 932,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31798,7 +31863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31813,7 +31878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 930,
+        "line": 932,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31832,7 +31897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31847,7 +31912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 930,
+        "line": 932,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31866,7 +31931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31881,7 +31946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31900,7 +31965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31915,7 +31980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31934,7 +31999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31949,7 +32014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31968,7 +32033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -31983,7 +32048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32002,7 +32067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32017,7 +32082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32036,7 +32101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32051,7 +32116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32070,7 +32135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32085,7 +32150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32104,7 +32169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32119,7 +32184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32138,7 +32203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32153,7 +32218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32172,7 +32237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32187,7 +32252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32206,7 +32271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32221,7 +32286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32240,7 +32305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32255,7 +32320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32274,7 +32339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32289,7 +32354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32308,7 +32373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32323,7 +32388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32342,7 +32407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32357,7 +32422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32376,7 +32441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32391,7 +32456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32410,7 +32475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32425,7 +32490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32444,7 +32509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32459,7 +32524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32478,7 +32543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32493,7 +32558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32512,7 +32577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32527,7 +32592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32546,7 +32611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32561,7 +32626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32580,7 +32645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32595,7 +32660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32614,7 +32679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32629,7 +32694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32648,7 +32713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32663,7 +32728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32682,7 +32747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32697,7 +32762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32716,7 +32781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32731,7 +32796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32750,7 +32815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32765,7 +32830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32784,7 +32849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32799,7 +32864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32818,7 +32883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32833,7 +32898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32852,7 +32917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32867,7 +32932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32886,7 +32951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32901,7 +32966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32920,7 +32985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32935,7 +33000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32954,7 +33019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -32969,7 +33034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32988,7 +33053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33003,7 +33068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33022,7 +33087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33037,7 +33102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1009,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33056,7 +33121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33071,7 +33136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1009,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33090,7 +33155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33105,7 +33170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1009,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33124,7 +33189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33139,7 +33204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33158,7 +33223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33173,7 +33238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33192,7 +33257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33207,7 +33272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33226,7 +33291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33241,7 +33306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33260,7 +33325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33275,7 +33340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33294,7 +33359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33309,7 +33374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33328,7 +33393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33343,7 +33408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33362,7 +33427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33377,7 +33442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33396,7 +33461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33411,7 +33476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33430,7 +33495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33445,7 +33510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33464,7 +33529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33479,7 +33544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33498,7 +33563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33513,7 +33578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33532,7 +33597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33547,7 +33612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33566,7 +33631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33581,7 +33646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33600,7 +33665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33615,7 +33680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33634,7 +33699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33649,7 +33714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33668,7 +33733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33683,7 +33748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33702,7 +33767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33717,7 +33782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33736,7 +33801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33751,7 +33816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33770,7 +33835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33785,7 +33850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33804,7 +33869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33819,7 +33884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33838,7 +33903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33853,7 +33918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33872,7 +33937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33887,7 +33952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33906,7 +33971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33921,7 +33986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33940,7 +34005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33955,7 +34020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33974,7 +34039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -33989,7 +34054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34008,7 +34073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34023,7 +34088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34042,7 +34107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34057,7 +34122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34076,7 +34141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34091,7 +34156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34110,7 +34175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34125,7 +34190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34144,7 +34209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34159,7 +34224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34178,7 +34243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34193,7 +34258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34212,7 +34277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34227,7 +34292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34246,7 +34311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34261,7 +34326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34280,7 +34345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34295,7 +34360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34314,7 +34379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34329,7 +34394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34348,7 +34413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34363,7 +34428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34382,7 +34447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34397,7 +34462,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34416,7 +34481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34431,7 +34496,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34450,7 +34515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34465,7 +34530,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1096,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34484,7 +34549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34499,7 +34564,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34518,7 +34583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34533,7 +34598,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34552,7 +34617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34567,7 +34632,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34586,7 +34651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34601,7 +34666,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1102,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34620,7 +34685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34635,7 +34700,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1102,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34654,7 +34719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34669,7 +34734,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34688,7 +34753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34703,7 +34768,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34722,7 +34787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34737,7 +34802,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34756,7 +34821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34771,7 +34836,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34790,7 +34855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34805,7 +34870,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34824,7 +34889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34839,7 +34904,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34858,7 +34923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34873,7 +34938,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34892,7 +34957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34907,7 +34972,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34926,7 +34991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34941,7 +35006,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34960,7 +35025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -34975,7 +35040,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34994,7 +35059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35009,7 +35074,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35028,7 +35093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35043,7 +35108,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35062,7 +35127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35077,7 +35142,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35096,7 +35161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35111,7 +35176,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35130,7 +35195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35145,7 +35210,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35164,7 +35229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35179,7 +35244,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35198,7 +35263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35213,7 +35278,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35232,7 +35297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35247,7 +35312,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35266,7 +35331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -35281,7 +35346,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35299,7 +35364,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1618
+            "line": 1620
           }
         ],
         "classification": "external",
@@ -35307,7 +35372,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1619,
+        "line": 1621,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35324,7 +35389,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1628
           }
         ],
         "classification": "external",
@@ -35332,7 +35397,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1629,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35349,7 +35414,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1636
           }
         ],
         "classification": "external",
@@ -35357,7 +35422,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1637,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38341,13 +38406,13 @@
       },
       {
         "is_package": false,
-        "loc": 560,
+        "loc": 619,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "82d0a1a3c8f2a1e83cc99041a997f5a706ca0935",
+        "normalized_git_blob_sha1": "2c35456fcd13ecb9c851912b19c53ce537e023c5",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 5,
+          "function_count": 6,
           "global_count": 3
         }
       },
@@ -38989,13 +39054,13 @@
       },
       {
         "is_package": false,
-        "loc": 2198,
+        "loc": 2149,
         "module": "nodes",
-        "normalized_git_blob_sha1": "bb8d65eedc9c124c5fd3e2ea967386bbf1b1ce8b",
+        "normalized_git_blob_sha1": "6546a965e0c3f57704b074904d88ae8ed988af50",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 13,
+          "function_count": 12,
           "global_count": 26
         }
       },
@@ -40355,7 +40420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40364,7 +40429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40378,7 +40443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40387,7 +40452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40401,7 +40466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40410,7 +40475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40424,7 +40489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40433,7 +40498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40447,7 +40512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40456,7 +40521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40470,7 +40535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40479,7 +40544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40493,7 +40558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40502,7 +40567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40516,7 +40581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40525,7 +40590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 567,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40539,7 +40604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40548,7 +40613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40562,7 +40627,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
+        "kind": "static_from",
+        "line": 579,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40571,7 +40659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40585,7 +40673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40594,7 +40682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40608,7 +40696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40617,7 +40705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 578,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40631,7 +40719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40640,7 +40728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40654,7 +40742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40663,7 +40751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40677,7 +40765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40686,7 +40774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40700,7 +40788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40709,7 +40797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40723,7 +40811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40732,7 +40820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40746,7 +40834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40755,7 +40843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40769,7 +40857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40778,7 +40866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40792,7 +40880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40801,7 +40889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40815,7 +40903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40824,7 +40912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40838,7 +40926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40847,7 +40935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40861,7 +40949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40870,7 +40958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40884,7 +40972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40893,7 +40981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40907,7 +40995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40916,7 +41004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40930,7 +41018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40939,7 +41027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40953,7 +41041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40962,7 +41050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40976,7 +41064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -40985,7 +41073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 584,
+        "line": 586,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40999,7 +41087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41008,7 +41096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 602,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41022,7 +41110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41031,7 +41119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 605,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41045,7 +41133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41054,7 +41142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 605,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41068,7 +41156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41077,7 +41165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 605,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41091,7 +41179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41100,7 +41188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41114,7 +41202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41123,7 +41211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41137,7 +41225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41146,7 +41234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41160,7 +41248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41169,7 +41257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 610,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41183,7 +41271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41192,7 +41280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41206,7 +41294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41215,7 +41303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41229,7 +41317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41238,7 +41326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41252,7 +41340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41261,7 +41349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41275,7 +41363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41284,7 +41372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41298,7 +41386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41307,7 +41395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41321,7 +41409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41330,7 +41418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41344,7 +41432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41353,7 +41441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41367,7 +41455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41376,7 +41464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41390,7 +41478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41399,7 +41487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41413,7 +41501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41422,7 +41510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41436,7 +41524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41445,7 +41533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41459,7 +41547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41468,7 +41556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41482,7 +41570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41491,7 +41579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41505,7 +41593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41514,7 +41602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41528,7 +41616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41537,7 +41625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41551,7 +41639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41560,7 +41648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41574,7 +41662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41583,7 +41671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41597,7 +41685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41606,7 +41694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41620,7 +41708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41629,7 +41717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41643,7 +41731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41652,7 +41740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41666,7 +41754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41675,7 +41763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41689,7 +41777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41698,7 +41786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41712,7 +41800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41721,7 +41809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41735,7 +41823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41744,7 +41832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41758,7 +41846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41767,7 +41855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41781,7 +41869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41790,7 +41878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41804,7 +41892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41813,7 +41901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41827,7 +41915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41836,7 +41924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 637,
+        "line": 639,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41850,7 +41938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41859,7 +41947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41873,7 +41961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41882,7 +41970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41896,7 +41984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41905,7 +41993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41919,7 +42007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41928,7 +42016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41942,7 +42030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41951,7 +42039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41965,7 +42053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41974,7 +42062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41988,7 +42076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -41997,7 +42085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42011,7 +42099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42020,7 +42108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42034,7 +42122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42043,7 +42131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42057,7 +42145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42066,7 +42154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 651,
+        "line": 653,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42080,7 +42168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42089,7 +42177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42103,7 +42191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42112,7 +42200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42126,7 +42214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42135,7 +42223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42149,7 +42237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42158,7 +42246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42172,7 +42260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42181,7 +42269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42195,7 +42283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42204,7 +42292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42218,7 +42306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42227,7 +42315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42241,7 +42329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42250,7 +42338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42264,7 +42352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42273,7 +42361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42287,7 +42375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42296,7 +42384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 663,
+        "line": 665,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42310,7 +42398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42319,7 +42407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42333,7 +42421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42342,7 +42430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42356,7 +42444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42365,7 +42453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42379,7 +42467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42388,7 +42476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42402,7 +42490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42411,7 +42499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42425,7 +42513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42434,7 +42522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42448,7 +42536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42457,7 +42545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42471,7 +42559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42480,7 +42568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42494,7 +42582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42503,7 +42591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42517,7 +42605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42526,7 +42614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42540,7 +42628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42549,7 +42637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42563,7 +42651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42572,7 +42660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42586,7 +42674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42595,7 +42683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42609,7 +42697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42618,7 +42706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42632,7 +42720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42641,7 +42729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42655,7 +42743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42664,7 +42752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 677,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42678,7 +42766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42687,7 +42775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42701,7 +42789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42710,7 +42798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42724,7 +42812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42733,7 +42821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 693,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42747,7 +42835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42756,7 +42844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42770,7 +42858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42779,7 +42867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42793,7 +42881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42802,7 +42890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42816,7 +42904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42825,7 +42913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42839,7 +42927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42848,7 +42936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 698,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42862,7 +42950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42871,7 +42959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 705,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42885,7 +42973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42894,7 +42982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42908,7 +42996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42917,7 +43005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42931,7 +43019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42940,7 +43028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42954,7 +43042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42963,7 +43051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42977,7 +43065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -42986,7 +43074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43000,7 +43088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43009,7 +43097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43023,7 +43111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43032,7 +43120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43046,7 +43134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43055,7 +43143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43069,7 +43157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43078,7 +43166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43092,7 +43180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43101,7 +43189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43115,7 +43203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43124,7 +43212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43138,7 +43226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43147,7 +43235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43161,7 +43249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43170,7 +43258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43184,7 +43272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43193,7 +43281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43207,7 +43295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43216,7 +43304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43230,7 +43318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43239,7 +43327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43253,7 +43341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43262,7 +43350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43276,7 +43364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43285,7 +43373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43299,7 +43387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43308,7 +43396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43322,7 +43410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43331,7 +43419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43345,7 +43433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43354,7 +43442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 726,
+        "line": 728,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43368,7 +43456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43377,7 +43465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43391,7 +43479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43400,7 +43488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43414,7 +43502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43423,7 +43511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43437,7 +43525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43446,7 +43534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43460,7 +43548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43469,7 +43557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43483,7 +43571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43492,7 +43580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43506,7 +43594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43515,7 +43603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43529,7 +43617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43538,7 +43626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43552,7 +43640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43561,7 +43649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43575,7 +43663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43584,7 +43672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43598,7 +43686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43607,7 +43695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43621,7 +43709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43630,7 +43718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43644,7 +43732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43653,7 +43741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43667,7 +43755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43676,7 +43764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43690,7 +43778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43699,7 +43787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43713,7 +43801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43722,7 +43810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43736,7 +43824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43745,7 +43833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43759,7 +43847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43768,7 +43856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43782,7 +43870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43791,7 +43879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43805,7 +43893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43814,7 +43902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43828,7 +43916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43837,7 +43925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43851,7 +43939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43860,7 +43948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 746,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43874,7 +43962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43883,7 +43971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43897,7 +43985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43906,7 +43994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43920,7 +44008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43929,7 +44017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43943,7 +44031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43952,7 +44040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43966,7 +44054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43975,7 +44063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43989,7 +44077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -43998,7 +44086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44012,7 +44100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44021,7 +44109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44035,7 +44123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44044,7 +44132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44058,7 +44146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44067,7 +44155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44081,7 +44169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44090,7 +44178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44104,7 +44192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44113,7 +44201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44127,7 +44215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44136,7 +44224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44150,7 +44238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44159,7 +44247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44173,7 +44261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44182,7 +44270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 782,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44196,7 +44284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44205,7 +44293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44219,7 +44307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44228,7 +44316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44242,7 +44330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44251,7 +44339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44265,7 +44353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44274,7 +44362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44288,7 +44376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44297,7 +44385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44311,7 +44399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44320,7 +44408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44334,7 +44422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44343,7 +44431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44357,7 +44445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44366,7 +44454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44380,7 +44468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44389,7 +44477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 808,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44403,7 +44491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44412,7 +44500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44426,7 +44514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44435,7 +44523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44449,7 +44537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44458,7 +44546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44472,7 +44560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44481,7 +44569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44495,7 +44583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44504,7 +44592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44518,7 +44606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44527,7 +44615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44541,7 +44629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44550,7 +44638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44564,7 +44652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44573,7 +44661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44587,7 +44675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44596,7 +44684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44610,7 +44698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44619,7 +44707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44633,7 +44721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44642,7 +44730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44656,7 +44744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44665,7 +44753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44679,7 +44767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44688,7 +44776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44702,7 +44790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44711,7 +44799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44725,7 +44813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44734,7 +44822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44748,7 +44836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44757,7 +44845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44771,7 +44859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44780,7 +44868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44794,7 +44882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44803,7 +44891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44817,7 +44905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44826,7 +44914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44840,7 +44928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44849,7 +44937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44863,7 +44951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44872,7 +44960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44886,7 +44974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44895,7 +44983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44909,7 +44997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44918,7 +45006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44932,7 +45020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44941,7 +45029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44955,7 +45043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44964,7 +45052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 824,
+        "line": 826,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44978,7 +45066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -44987,7 +45075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45001,7 +45089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45010,7 +45098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45024,7 +45112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45033,7 +45121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45047,7 +45135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45056,7 +45144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 904,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45070,7 +45158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45079,7 +45167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45093,7 +45181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45102,7 +45190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45116,7 +45204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45125,7 +45213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45139,7 +45227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45148,7 +45236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45162,7 +45250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45171,7 +45259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45185,7 +45273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45194,7 +45282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45208,7 +45296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45217,7 +45305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45231,7 +45319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45240,7 +45328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45254,7 +45342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45263,7 +45351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45277,7 +45365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45286,7 +45374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45300,7 +45388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45309,7 +45397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45323,7 +45411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45332,7 +45420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45346,7 +45434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45355,7 +45443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45369,7 +45457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45378,7 +45466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 930,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45392,7 +45480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45401,7 +45489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 930,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45415,7 +45503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45424,7 +45512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 930,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45438,7 +45526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45447,7 +45535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45461,7 +45549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45470,7 +45558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45484,7 +45572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45493,7 +45581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45507,7 +45595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45516,7 +45604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 941,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45530,7 +45618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45539,7 +45627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45553,7 +45641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45562,7 +45650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 954,
+        "line": 956,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45576,7 +45664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45585,7 +45673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45599,7 +45687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45608,7 +45696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45622,7 +45710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45631,7 +45719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45645,7 +45733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45654,7 +45742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45668,7 +45756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45677,7 +45765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45691,7 +45779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45700,7 +45788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45714,7 +45802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45723,7 +45811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45737,7 +45825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45746,7 +45834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45760,7 +45848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45769,7 +45857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45783,7 +45871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45792,7 +45880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45806,7 +45894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45815,7 +45903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45829,7 +45917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45838,7 +45926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 973,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45852,7 +45940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45861,7 +45949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45875,7 +45963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45884,7 +45972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45898,7 +45986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45907,7 +45995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45921,7 +46009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45930,7 +46018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45944,7 +46032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45953,7 +46041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45967,7 +46055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45976,7 +46064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45990,7 +46078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -45999,7 +46087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46013,7 +46101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46022,7 +46110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46036,7 +46124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46045,7 +46133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46059,7 +46147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46068,7 +46156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46082,7 +46170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46091,7 +46179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46105,7 +46193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46114,7 +46202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46128,7 +46216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46137,7 +46225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46151,7 +46239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46160,7 +46248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46174,7 +46262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46183,7 +46271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46197,7 +46285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46206,7 +46294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46220,7 +46308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46229,7 +46317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46243,7 +46331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46252,7 +46340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46266,7 +46354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46275,7 +46363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46289,7 +46377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46298,7 +46386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46312,7 +46400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46321,7 +46409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46335,7 +46423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46344,7 +46432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46358,7 +46446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46367,7 +46455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46381,7 +46469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46390,7 +46478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46404,7 +46492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46413,7 +46501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46427,7 +46515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46436,7 +46524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46450,7 +46538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46459,7 +46547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1030,
+        "line": 1032,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46473,7 +46561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46482,7 +46570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46496,7 +46584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46505,7 +46593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1055,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46519,7 +46607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46528,7 +46616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46542,7 +46630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46551,7 +46639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46565,7 +46653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46574,7 +46662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46588,7 +46676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46597,7 +46685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46611,7 +46699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46620,7 +46708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46634,7 +46722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46643,7 +46731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46657,7 +46745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46666,7 +46754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46680,7 +46768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46689,7 +46777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46703,7 +46791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46712,7 +46800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46726,7 +46814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46735,7 +46823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46749,7 +46837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46758,7 +46846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46772,7 +46860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46781,7 +46869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46795,7 +46883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46804,7 +46892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46818,7 +46906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46827,7 +46915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46841,7 +46929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46850,7 +46938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46864,7 +46952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46873,7 +46961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46887,7 +46975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46896,7 +46984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46910,7 +46998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46919,7 +47007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46933,7 +47021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46942,7 +47030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46956,7 +47044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46965,7 +47053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46979,7 +47067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -46988,7 +47076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47002,7 +47090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47011,7 +47099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47025,7 +47113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47034,7 +47122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47048,7 +47136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47057,7 +47145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47071,7 +47159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47080,7 +47168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1081,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47094,7 +47182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47103,7 +47191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47117,7 +47205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47126,7 +47214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47140,7 +47228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47149,7 +47237,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47163,7 +47251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47172,7 +47260,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47186,7 +47274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47195,7 +47283,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47209,7 +47297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47218,7 +47306,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47232,7 +47320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47241,7 +47329,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47255,7 +47343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47264,7 +47352,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47278,7 +47366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47287,7 +47375,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47301,7 +47389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47310,7 +47398,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47324,7 +47412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47333,7 +47421,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47347,7 +47435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47356,7 +47444,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47370,7 +47458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47379,7 +47467,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47393,7 +47481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47402,7 +47490,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47416,7 +47504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47425,7 +47513,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47439,7 +47527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47448,7 +47536,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47462,7 +47550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47471,7 +47559,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47485,7 +47573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47494,7 +47582,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47508,7 +47596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47517,7 +47605,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47531,7 +47619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47540,7 +47628,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47554,7 +47642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47563,7 +47651,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47577,7 +47665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47586,7 +47674,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47600,7 +47688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47609,7 +47697,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47623,7 +47711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47632,7 +47720,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47646,7 +47734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47655,7 +47743,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47669,7 +47757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47678,7 +47766,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47692,7 +47780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47701,7 +47789,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47715,7 +47803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47724,7 +47812,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47738,7 +47826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 566,
+            "handler_line": 567,
             "kind": "try",
             "line": 10
           }
@@ -47747,7 +47835,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51574,14 +51662,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1618
+            "line": 1620
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1619,
+        "line": 1621,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51593,14 +51681,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1628
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1629,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51612,14 +51700,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1636
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1637,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52994,14 +53082,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1618
+            "line": 1620
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1619,
+        "line": 1621,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53013,14 +53101,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1628
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1629,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53032,14 +53120,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1636
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1637,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54500,7 +54588,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1123,
+        "line": 1125,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54509,7 +54597,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2094,
+        "line": 2045,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54518,7 +54606,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2097,
+        "line": 2048,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54527,7 +54615,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2100,
+        "line": 2051,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54536,7 +54624,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2103,
+        "line": 2054,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54545,7 +54633,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2106,
+        "line": 2057,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54554,7 +54642,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2109,
+        "line": 2060,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54563,7 +54651,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2112,
+        "line": 2063,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54572,7 +54660,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2115,
+        "line": 2066,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54581,7 +54669,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2118,
+        "line": 2069,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54590,7 +54678,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2121,
+        "line": 2072,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54599,7 +54687,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2124,
+        "line": 2075,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54608,7 +54696,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2127,
+        "line": 2078,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54617,7 +54705,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2130,
+        "line": 2081,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54626,7 +54714,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2133,
+        "line": 2084,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54635,7 +54723,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2136,
+        "line": 2087,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54644,7 +54732,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2139,
+        "line": 2090,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54653,7 +54741,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2143,
+        "line": 2094,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54662,7 +54750,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2146,
+        "line": 2097,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54671,7 +54759,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2150,
+        "line": 2101,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54680,7 +54768,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2153,
+        "line": 2104,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54689,7 +54777,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2157,
+        "line": 2108,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54698,7 +54786,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2160,
+        "line": 2111,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54707,7 +54795,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2163,
+        "line": 2114,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54716,7 +54804,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2166,
+        "line": 2117,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54725,7 +54813,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2169,
+        "line": 2120,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54734,7 +54822,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2172,
+        "line": 2123,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54743,7 +54831,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2179,
+        "line": 2130,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54752,7 +54840,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2185,
+        "line": 2136,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54761,7 +54849,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2190,
+        "line": 2141,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54770,7 +54858,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2194,
+        "line": 2145,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55284,13 +55372,13 @@
       },
       {
         "kind": "dict",
-        "line": 1185,
+        "line": 1187,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1174,
+        "line": 1176,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "92506109117e42ea10e4664667481f27ad08623a",
+    "base_commit": "6a5fd7bd2c369921e5ecb18791df187d578d6637",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -53,7 +53,8 @@
       "B-11c20",
       "B-11c21",
       "B-11c22",
-      "B-11c23"
+      "B-11c23",
+      "B-11c24"
     ]
   },
   "enums": {
@@ -88,11 +89,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 295,
+    "nodes_canonical_bindings": 296,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 13,
+    "root_residual_functions": 12,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -417,7 +418,8 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "_aio_detailer_target_order": [
-      "easyuse_anima.aio.generation_normalization"
+      "easyuse_anima.aio.generation_normalization",
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_aio_final_fit_size": [
       "easyuse_anima.aio.postprocess"
@@ -650,6 +652,9 @@
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.regional_nodes"
     ],
+    "_context_value": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
     "_copy_prompt_data_for_update": [
       "easyuse_anima.nodes.aio_nodes"
     ],
@@ -784,6 +789,9 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "_load_aio_resources_from_input_context": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
+    "_load_aio_sam3_context": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_load_checkpoint_with_comfy": [
@@ -1015,6 +1023,9 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "_run_aio_detailer_stage": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
+    "_run_aio_detailer_target": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_run_aio_highres_stage": [
@@ -2104,6 +2115,7 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_bind_aio_legacy_generation_runtime": "_bind_aio_legacy_generation_runtime",
+        "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_highres_stage": "_run_aio_highres_stage",
         "_run_aio_legacy_generation": "_run_aio_legacy_generation",
         "_run_aio_upscale_stage": "_run_aio_upscale_stage"
@@ -2605,10 +2617,12 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.resources"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup"
       ],
       "removal_gates": [
@@ -4184,7 +4198,6 @@
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class",
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
-        "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_detailer_target": "_run_aio_detailer_target",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
         "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -33,6 +33,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             legacy_generation._run_aio_legacy_generation,
         )
         self.assertIs(
+            nodes._run_aio_detailer_stage,
+            legacy_generation._run_aio_detailer_stage,
+        )
+        self.assertIs(
             nodes._run_aio_highres_stage,
             legacy_generation._run_aio_highres_stage,
         )
@@ -52,6 +56,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             self.assertIs(
                 package_nodes._run_aio_legacy_generation,
                 canonical_module._run_aio_legacy_generation,
+            )
+            self.assertIs(
+                package_nodes._run_aio_detailer_stage,
+                canonical_module._run_aio_detailer_stage,
             )
             self.assertIs(
                 package_nodes._run_aio_highres_stage,
@@ -353,6 +361,336 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 "cleanup",
             ],
         )
+
+    def test_detailer_stage_preserves_lazy_filter_and_no_target_short_circuits(self):
+        image = _Token("image")
+
+        def execute(detailer_settings, target_order):
+            trace = []
+
+            def as_bool(value, default):
+                trace.append(("call", "_as_bool", value, default))
+                return bool(value)
+
+            helpers = {
+                "_as_bool": as_bool,
+                "_aio_detailer_target_order": lambda settings: (
+                    trace.append(("call", "_aio_detailer_target_order"))
+                    or target_order
+                ),
+            }
+
+            def resolve(name):
+                trace.append(("resolve", name))
+                if name not in helpers:
+                    self.fail(f"short-circuit resolved unexpected helper: {name}")
+                return helpers[name]
+
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=resolve
+            )
+            try:
+                result = nodes._run_aio_detailer_stage(
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    image,
+                    {},
+                    detailer_settings,
+                )
+            finally:
+                legacy_generation._bind_aio_legacy_generation_runtime(
+                    resolve_helper=lambda name: getattr(nodes, name)
+                )
+            return result, trace
+
+        disabled_result, disabled_trace = execute({"enabled": False}, [])
+        self.assertIs(disabled_result[0], image)
+        self.assertEqual(disabled_result[1], {"enabled": False})
+        self.assertEqual(
+            disabled_trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", False, False),
+            ],
+        )
+
+        no_target_result, no_target_trace = execute(
+            {
+                "enabled": True,
+                "face": {"enabled": False},
+                "missing": "not-a-dict",
+            },
+            ["face", "missing"],
+        )
+        self.assertIs(no_target_result[0], image)
+        self.assertEqual(
+            no_target_result[1],
+            {"enabled": False, "reason": "no target enabled"},
+        )
+        self.assertEqual(
+            no_target_trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+                ("resolve", "_aio_detailer_target_order"),
+                ("call", "_aio_detailer_target_order"),
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", False, False),
+            ],
+        )
+
+    def test_detailer_stage_preserves_order_chaining_callback_and_metadata(self):
+        trace = []
+        model = _Token("model")
+        clip = _Token("clip")
+        vae = _Token("vae")
+        positive = _Token("positive")
+        negative = _Token("negative")
+        image = _Token("image")
+        eye_image = _Token("eye_image")
+        face_image = _Token("face_image")
+        sampler_settings = {"seed": 17}
+        detailer_settings = {
+            "enabled": True,
+            "eye": {"enabled": True},
+            "disabled": {"enabled": False},
+            "missing": "not-a-dict",
+            "face": {"enabled": True},
+        }
+        target_order = ["eye", "disabled", "missing", "face"]
+        sam3_context = {"ckpt_name": "sam3.safetensors"}
+        eye_metadata = {"enabled": True, "target": "eye"}
+        face_metadata = {"enabled": True, "target": "face"}
+
+        def as_bool(value, default):
+            trace.append(("call", "_as_bool", value, default))
+            return bool(value)
+
+        def target_order_helper(settings):
+            trace.append(("call", "_aio_detailer_target_order"))
+            self.assertIs(settings, detailer_settings)
+            return target_order
+
+        def load_context(settings):
+            trace.append(("call", "_load_aio_sam3_context"))
+            self.assertIs(settings, detailer_settings)
+            return sam3_context
+
+        def run_target(*args):
+            target_name = args[0]
+            trace.append(("call", "_run_aio_detailer_target", target_name))
+            expected_image = image if target_name == "eye" else eye_image
+            self.assertEqual(
+                args,
+                (
+                    target_name,
+                    detailer_settings[target_name],
+                    expected_image,
+                    model,
+                    clip,
+                    vae,
+                    positive,
+                    negative,
+                    sampler_settings,
+                    sam3_context,
+                ),
+            )
+            if target_name == "eye":
+                return eye_image, eye_metadata
+            return face_image, face_metadata
+
+        def context_value(context, key):
+            trace.append(("call", "_context_value", key))
+            self.assertIs(context, sam3_context)
+            return context[key]
+
+        helpers = {
+            "_as_bool": as_bool,
+            "_aio_detailer_target_order": target_order_helper,
+            "_load_aio_sam3_context": load_context,
+            "_run_aio_detailer_target": run_target,
+            "_context_value": context_value,
+        }
+
+        def resolve(name):
+            trace.append(("resolve", name))
+            return helpers[name]
+
+        def preview(stage, output):
+            trace.append(("callback", stage, output.name))
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            result = nodes._run_aio_detailer_stage(
+                model,
+                clip,
+                vae,
+                positive,
+                negative,
+                image,
+                sampler_settings,
+                detailer_settings,
+                preview,
+            )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertIs(result[0], face_image)
+        self.assertIs(result[1]["order"], target_order)
+        self.assertIs(result[1]["targets"]["eye"], eye_metadata)
+        self.assertIs(result[1]["targets"]["face"], face_metadata)
+        self.assertEqual(
+            result[1],
+            {
+                "enabled": True,
+                "sam3_checkpoint": "sam3.safetensors",
+                "order": target_order,
+                "targets": {"eye": eye_metadata, "face": face_metadata},
+            },
+        )
+        self.assertEqual(
+            trace,
+            [
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+                ("resolve", "_aio_detailer_target_order"),
+                ("call", "_aio_detailer_target_order"),
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", False, False),
+                ("resolve", "_as_bool"),
+                ("call", "_as_bool", True, False),
+                ("resolve", "_load_aio_sam3_context"),
+                ("call", "_load_aio_sam3_context"),
+                ("resolve", "_run_aio_detailer_target"),
+                ("call", "_run_aio_detailer_target", "eye"),
+                ("callback", "detailer_eye", "eye_image"),
+                ("resolve", "_run_aio_detailer_target"),
+                ("call", "_run_aio_detailer_target", "face"),
+                ("callback", "detailer_face", "face_image"),
+                ("resolve", "_context_value"),
+                ("call", "_context_value", "ckpt_name"),
+            ],
+        )
+
+    def test_detailer_stage_propagates_target_and_callback_failures_in_place(self):
+        detailer_settings = {
+            "enabled": True,
+            "eye": {"enabled": True},
+            "face": {"enabled": True},
+        }
+
+        def execute(run_target, preview_callback, trace):
+            helpers = {
+                "_as_bool": lambda value, default: bool(value),
+                "_aio_detailer_target_order": lambda settings: ["eye", "face"],
+                "_load_aio_sam3_context": lambda settings: {},
+                "_run_aio_detailer_target": run_target(trace),
+                "_context_value": lambda context, key: trace.append("context_value"),
+            }
+
+            def resolve(name):
+                trace.append(f"resolve:{name}")
+                return helpers[name]
+
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=resolve
+            )
+            try:
+                nodes._run_aio_detailer_stage(
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    _Token("image"),
+                    {},
+                    detailer_settings,
+                    preview_callback(trace),
+                )
+            finally:
+                legacy_generation._bind_aio_legacy_generation_runtime(
+                    resolve_helper=lambda name: getattr(nodes, name)
+                )
+            return trace
+
+        def failing_target(trace):
+            def run(target_name, *args):
+                trace.append(f"target:{target_name}")
+                raise ValueError("target failed")
+
+            return run
+
+        target_trace = []
+        with self.assertRaisesRegex(ValueError, "target failed"):
+            execute(
+                failing_target,
+                lambda trace: lambda *args: trace.append("preview"),
+                target_trace,
+            )
+        self.assertEqual(
+            target_trace[-2:],
+            ["resolve:_run_aio_detailer_target", "target:eye"],
+        )
+        self.assertNotIn("preview", target_trace)
+        self.assertNotIn("target:face", target_trace)
+        self.assertNotIn("context_value", target_trace)
+
+        def short_target(trace):
+            def run(target_name, *args):
+                trace.append(f"target:{target_name}")
+                return (_Token("only_value"),)
+
+            return run
+
+        unpack_trace = []
+        with self.assertRaisesRegex(ValueError, "not enough values to unpack"):
+            execute(
+                short_target,
+                lambda trace: lambda *args: trace.append("preview"),
+                unpack_trace,
+            )
+        self.assertEqual(
+            unpack_trace[-2:],
+            ["resolve:_run_aio_detailer_target", "target:eye"],
+        )
+        self.assertNotIn("preview", unpack_trace)
+        self.assertNotIn("target:face", unpack_trace)
+        self.assertNotIn("context_value", unpack_trace)
+
+        def successful_target(trace):
+            def run(target_name, *args):
+                trace.append(f"target:{target_name}")
+                return _Token(f"{target_name}_image"), {"target": target_name}
+
+            return run
+
+        def failing_preview(trace):
+            def preview(*args):
+                trace.append("preview:eye")
+                raise LookupError("preview failed")
+
+            return preview
+
+        callback_trace = []
+        with self.assertRaisesRegex(LookupError, "preview failed"):
+            execute(successful_target, failing_preview, callback_trace)
+        self.assertEqual(
+            callback_trace[-3:],
+            [
+                "resolve:_run_aio_detailer_target",
+                "target:eye",
+                "preview:eye",
+            ],
+        )
+        self.assertNotIn("target:face", callback_trace)
+        self.assertNotIn("context_value", callback_trace)
 
     def test_upscale_dispatcher_preserves_lazy_branch_and_exception_contract(self):
         model = _Token("model")

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "bb8d65eedc9c124c5fd3e2ea967386bbf1b1ce8b")
-        # Issue #184 B-11c23 moves only the AiO upscale dispatcher to its
+        self.assertEqual(report["git_blob_sha1"], "6546a965e0c3f57704b074904d88ae8ed988af50")
+        # Issue #184 B-11c24 moves only the AiO Detailer stage to its
         # canonical legacy-generation owner.
-        self.assertEqual(report["top_level"]["function_count"], 13)
+        self.assertEqual(report["top_level"]["function_count"], 12)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_198)
+        self.assertEqual(report["line_count"], 2_149)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "92506109117e42ea10e4664667481f27ad08623a"
+BASE_COMMIT = "6a5fd7bd2c369921e5ecb18791df187d578d6637"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1326,6 +1326,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c21",
                 "B-11c22",
                 "B-11c23",
+                "B-11c24",
             ],
         },
         "enums": {
@@ -1338,11 +1339,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 295,
+            "nodes_canonical_bindings": 296,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 13,
+            "root_residual_functions": 12,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c24 단일 Move로 root `_run_aio_detailer_stage` coordinator body만 roadmap의 temporary current-order orchestration owner `easyuse_anima.aio.legacy_generation`으로 이동합니다.
- Detailer target leaf와 SAM3 resource helper는 root에 남기고, root `nodes.py`에는 relative/flat direct identity alias를 유지합니다.

## 작업 전 inventory

### Symbol / caller

- `_run_aio_detailer_stage`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: `easyuse_anima.aio.legacy_generation._run_aio_legacy_generation`이 `_runtime_helper("_run_aio_detailer_stage")`로 매 호출 root seam 조회
  - 기존 direct behavior tests는 저장된/custom target 순서와 output chaining을 소비하고 generator tests는 root monkeypatch seam을 소비
  - public mapping/export 없음
- canonical owner는 B-09b가 지정한 `easyuse_anima.aio.legacy_generation`입니다. 새 stage module은 #169 Contract를 선점하므로 추가하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical coordinator identity를 유지합니다.
- 기존 `_bind_aio_legacy_generation_runtime`과 `_RUNTIME_RESOLVER`만 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- production caller는 같은 모듈 안에서도 기존 root string lookup을 유지해 monkeypatch seam을 보존합니다.
- coordinator 자체 mutable global/cache/lock/cleanup은 없고, `target_results`와 `output`은 호출별 local 상태입니다. 입력 settings는 읽기만 합니다.

### Call-time dependency inventory

- `_as_bool`
- `_aio_detailer_target_order`
- `_load_aio_sam3_context`
- `_run_aio_detailer_target`
- `_context_value`

### 보존할 평가·예외 순서

1. `_as_bool`을 resolve해 전체 stage 활성화를 확인하고, disabled면 다른 helper 없이 동일 image와 `{"enabled": False}`를 반환합니다.
2. `_aio_detailer_target_order`를 resolve하고, 각 target에서 설정이 dict인지 먼저 확인한 뒤에만 `_as_bool`을 매번 resolve해 enabled 여부를 검사합니다.
3. enabled target이 없으면 SAM3를 로드하지 않고 동일 image와 기존 reason metadata를 반환합니다.
4. `_load_aio_sam3_context`를 한 번 resolve/call한 뒤 원래 target order를 순회합니다.
5. enabled target마다 `_run_aio_detailer_target`을 매번 call-time resolve하며, 이전 output을 다음 target image로 전달하고 결과를 삽입한 뒤 preview callback을 호출합니다.
6. 모든 target/callback 성공 뒤에만 `_context_value`를 resolve하고 `enabled`, `sam3_checkpoint`, `order`, `targets` 순서로 metadata를 생성합니다.
7. order/boolean/context/target/callback/context-value 예외와 target 2-value unpack 오류는 catch 없이 그대로 전파합니다. target 또는 callback 실패 뒤의 target/metadata는 실행하지 않습니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/legacy_generation.py`, `nodes.py`
- contract/analyzer: `tests/test_aio_legacy_generation.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- base: `dev` / `6a5fd7bd2c369921e5ecb18791df187d578d6637`
- canonical bindings: `295 → 296`
- root/top-level residual functions: `13 → 12`
- runtime binders: `30` 유지
- runtime resolver names: `282 → 285` (`_load_aio_sam3_context`, `_run_aio_detailer_target`, `_context_value` 신규; `_aio_detailer_target_order` 기존)
- legacy-generation resolver consumers: `45 → 49`
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6, direct root-import tests 21: 변화 없음
- `nodes.py` line count: `2,198 → 2,149` 예상, 구현 후 analyzer actual로 고정

## 금지 경계

- `_run_aio_detailer_target`, SAM3 context/resource helper 동시 이동 금지
- legacy caller의 root string lookup을 sibling direct call로 바꾸지 않음
- enabled filtering, target 순서/chaining, callback 이름·시점, metadata 키·삽입 순서 변경 금지
- cleanup/예외 wrapping/validation 추가 금지
- settings/schema/default/workflow, Detailer normalizer, #169 stage protocol/Contract/Behavior 변경 금지
- 새 binder/global/module 또는 public `__all__` 결합 금지

## 검증

- exact head: `7f72932a1d1b25a620445051f266dcf9e5ff8122`
- focused alias/disabled/no-target/order/chaining/callback/exception order와 기존 direct Detailer behavior/analyzer/import-boundary: 36 tests passed
- 독립 검토 P1 base provenance 수정 후 targeted 2 tests passed
- canonical owner Ruff: clean
- 독립 diff review 및 재검토: 차단점 없음
- `tools/check_project.ps1 -Profile full`: passed
  - Python unittest: 925 passed
  - Frontend: 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline ratchet: passed (66 files, 60 baseline errors)
  - Python import boundary gate: passed (6 groups, 0 violations)
  - Git diff check: passed
  - Ruff: 기존 G-01 report-only 113건, blocking failure 없음
- Live ComfyUI/browser smoke: private coordinator Move 범위에서는 수행하지 않음

## 상태

- Ready
- Move-only 경계, 독립 diff review, exact-head focused/full 검증을 충족했습니다.
