### PR TITLE
refactor: move AiO ResShift stage owner

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `6a5fd7bd2c369921e5ecb18791df187d578d6637`
+- Integrated `dev` snapshot commit: `2abc54d12f96b784f2e63e07400522227f7affe3`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c23 / `6a5fd7b`; B-11c24 AiO Detailer stage Move in PR #318 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c24 / `2abc54d`; B-11c25 AiO ResShift leaf Move in PR #319 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,198
-  lines after B-11c23.
-- The mechanical extraction has removed 10,465
-  lines, approximately 82.6% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,149
+  lines after B-11c24.
+- The mechanical extraction has removed 10,514
+  lines, approximately 83.0% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -83,7 +83,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   `43c3056`. B-11c21 moved only the AiO postprocess stage in PR #315 /
   `8b3ba38`. B-11c22 moved only the AiO highres stage in PR #316 / `9250610`.
   B-11c23 moved only the AiO upscale dispatcher in PR #317 / `6a5fd7b`.
-  B-11c24 moves only the AiO Detailer stage coordinator in PR #318.
+  B-11c24 moved only the AiO Detailer stage coordinator in PR #318 / `2abc54d`.
+  B-11c25 moves only the AiO ResShift leaf in PR #319.
 
 ### Current quality baseline
 
@@ -325,7 +326,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 AiO Detailer stage Move PR #318 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 AiO ResShift leaf Move PR #319 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `6a5fd7bd2c369921e5ecb18791df187d578d6637`
+  `2abc54d12f96b784f2e63e07400522227f7affe3`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c23 are integrated through PR #317. B-11c is
+- Current state: B-11a through B-11c24 are integrated through PR #318. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c24 AiO Detailer stage Move is tracked by PR #318.
+  the final root shim; B-11c25 AiO ResShift leaf Move is tracked by PR #319.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 296 in B-11c24
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 297 in B-11c25
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,8 +84,8 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 12 functions, 0 classes, and 26 assigned
-  globals in B-11c24 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 11 functions, 0 classes, and 26 assigned
+  globals in B-11c25 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
 - root names reached by those canonical runtime resolvers: 285, including
   literal lookups and binder-owned helper-name/default collections;
@@ -521,6 +521,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
   output chaining, callback timing, metadata identity/order, and exception
   propagation are unchanged.
 - PR #318 does not move or change the Detailer target leaf, SAM3 resources,
+  settings/schema/defaults, workflow behavior, or the later #169
+  Contract/Behavior work.
+
+### B-11c25 AiO ResShift leaf alias
+
+- Canonical owner: `easyuse_anima.aio.legacy_generation` for
+  `_run_aio_resshift_upscale_stage`.
+- The private root leaf remains a transitional direct alias in relative package
+  and flat import modes. The canonical upscale dispatcher keeps resolving the
+  root name at call time to preserve its monkeypatch seam.
+- The existing legacy-generation binder resolves provider lookup, output tuple
+  normalization, runtime seed, integer coercion, and image-size access at use
+  time. Provider order, loader/upscaler method validation, tuple-helper lookup
+  timing, argument order, exact errors, result identity, and exception
+  propagation are unchanged.
+- PR #319 does not move or change the USDU leaf, dispatcher,
   settings/schema/defaults, workflow behavior, or the later #169
   Contract/Behavior work.
 

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -163,6 +163,69 @@ def _run_aio_detailer_stage(
     }
 
 
+def _run_aio_resshift_upscale_stage(
+    image,
+    sampler_settings: dict[str, Any],
+    upscale_settings: dict[str, Any],
+    quality_tags: str = "",
+    quality_neg: str = "",
+    prompt_data: str | dict | None = None,
+    exclude_positive_quality: bool = False,
+    exclude_negative_quality: bool = False,
+) -> tuple[Any, dict[str, Any]]:
+    resshift_settings = upscale_settings.get("resshift", {})
+    if not isinstance(resshift_settings, dict):
+        resshift_settings = {}
+    loader_cls = _runtime_helper("_require_custom_node_class")(
+        "ResShiftLoader",
+        "ComfyUI-Distilled-ResShift",
+        "Required for AiO Generator final Upscale > ResShift.",
+    )
+    upscale_cls = _runtime_helper("_require_custom_node_class")(
+        "ResShiftUpscale",
+        "ComfyUI-Distilled-ResShift",
+        "Required for AiO Generator final Upscale > ResShift.",
+    )
+    loader = loader_cls()
+    load = getattr(loader, "load", None)
+    if load is None:
+        raise RuntimeError("[EasyUseAnima] ResShiftLoader does not expose load().")
+    model_values = _runtime_helper("_node_output_tuple")(
+        load(
+            str(resshift_settings.get("scale") or "x2"),
+            str(resshift_settings.get("student_name") or "(auto-download)"),
+            str(resshift_settings.get("dtype") or "bf16"),
+        )
+    )
+    if not model_values:
+        raise RuntimeError("[EasyUseAnima] ResShiftLoader returned no RESSHIFT_MODEL.")
+    upscaler = upscale_cls()
+    upscale = getattr(upscaler, "upscale", None)
+    if upscale is None:
+        raise RuntimeError("[EasyUseAnima] ResShiftUpscale does not expose upscale().")
+    values = _runtime_helper("_node_output_tuple")(
+        upscale(
+            model_values[0],
+            image,
+            _runtime_helper("_resolve_aio_runtime_seed")(sampler_settings.get("seed")),
+            _runtime_helper("_as_int")(resshift_settings.get("chop"), 512),
+            _runtime_helper("_as_int")(resshift_settings.get("overlap"), 64),
+            _runtime_helper("_as_int")(resshift_settings.get("tile_batch"), 4),
+        )
+    )
+    if not values:
+        raise RuntimeError("[EasyUseAnima] ResShiftUpscale returned no IMAGE.")
+    output = values[0]
+    width, height = _runtime_helper("_image_tensor_size")(output, 0, 0)
+    return output, {
+        "enabled": True,
+        "backend": "resshift",
+        "width": int(width),
+        "height": int(height),
+        "scale": str(resshift_settings.get("scale") or "x2"),
+    }
+
+
 def _run_aio_upscale_stage(
     model,
     clip,

--- a/nodes.py
+++ b/nodes.py
@@ -24,6 +24,7 @@ try:
         _run_aio_detailer_stage as _run_aio_detailer_stage,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
+        _run_aio_resshift_upscale_stage as _run_aio_resshift_upscale_stage,
         _run_aio_upscale_stage as _run_aio_upscale_stage,
     )
     from .easyuse_anima.aio.generation_normalization import (
@@ -581,6 +582,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _run_aio_detailer_stage as _run_aio_detailer_stage,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
+        _run_aio_resshift_upscale_stage as _run_aio_resshift_upscale_stage,
         _run_aio_upscale_stage as _run_aio_upscale_stage,
     )
     from easyuse_anima.aio.generation_normalization import (
@@ -1817,65 +1819,6 @@ def _run_aio_usdu_upscale_stage(
         "tile_target_height": int(tile_plan.get("target_height") or 0),
         "prompt_mode": str(usdu_settings.get("prompt_mode") or AIO_USDU_PROMPT_FULL),
         "sampler": _prompt_data_json_safe(stage_sampler),
-    }
-
-
-def _run_aio_resshift_upscale_stage(
-    image,
-    sampler_settings: dict[str, Any],
-    upscale_settings: dict[str, Any],
-    quality_tags: str = "",
-    quality_neg: str = "",
-    prompt_data: str | dict | None = None,
-    exclude_positive_quality: bool = False,
-    exclude_negative_quality: bool = False,
-) -> tuple[Any, dict[str, Any]]:
-    resshift_settings = upscale_settings.get("resshift", {})
-    if not isinstance(resshift_settings, dict):
-        resshift_settings = {}
-    loader_cls = _require_custom_node_class(
-        "ResShiftLoader",
-        "ComfyUI-Distilled-ResShift",
-        "Required for AiO Generator final Upscale > ResShift.",
-    )
-    upscale_cls = _require_custom_node_class(
-        "ResShiftUpscale",
-        "ComfyUI-Distilled-ResShift",
-        "Required for AiO Generator final Upscale > ResShift.",
-    )
-    loader = loader_cls()
-    load = getattr(loader, "load", None)
-    if load is None:
-        raise RuntimeError("[EasyUseAnima] ResShiftLoader does not expose load().")
-    model_values = _node_output_tuple(load(
-        str(resshift_settings.get("scale") or "x2"),
-        str(resshift_settings.get("student_name") or "(auto-download)"),
-        str(resshift_settings.get("dtype") or "bf16"),
-    ))
-    if not model_values:
-        raise RuntimeError("[EasyUseAnima] ResShiftLoader returned no RESSHIFT_MODEL.")
-    upscaler = upscale_cls()
-    upscale = getattr(upscaler, "upscale", None)
-    if upscale is None:
-        raise RuntimeError("[EasyUseAnima] ResShiftUpscale does not expose upscale().")
-    values = _node_output_tuple(upscale(
-        model_values[0],
-        image,
-        _resolve_aio_runtime_seed(sampler_settings.get("seed")),
-        _as_int(resshift_settings.get("chop"), 512),
-        _as_int(resshift_settings.get("overlap"), 64),
-        _as_int(resshift_settings.get("tile_batch"), 4),
-    ))
-    if not values:
-        raise RuntimeError("[EasyUseAnima] ResShiftUpscale returned no IMAGE.")
-    output = values[0]
-    width, height = _image_tensor_size(output, 0, 0)
-    return output, {
-        "enabled": True,
-        "backend": "resshift",
-        "width": int(width),
-        "height": int(height),
-        "scale": str(resshift_settings.get("scale") or "x2"),
     }
 
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14733,6 +14733,37 @@
         "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
+        "alias": "_run_aio_resshift_upscale_stage",
+        "bound_name": "_run_aio_resshift_upscale_stage",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_resshift_upscale_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_run_aio_resshift_upscale_stage",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
         "alias": "_run_aio_upscale_stage",
         "bound_name": "_run_aio_upscale_stage",
         "branch_context": [
@@ -14785,7 +14816,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14816,7 +14847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14847,7 +14878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14878,7 +14909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14909,7 +14940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14940,7 +14971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14971,7 +15002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15002,7 +15033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15033,7 +15064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15064,7 +15095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15095,7 +15126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15126,7 +15157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15157,7 +15188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15188,7 +15219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15219,7 +15250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15250,7 +15281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 29,
+        "line": 30,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15281,7 +15312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 47,
+        "line": 48,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15312,7 +15343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15343,7 +15374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15374,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 50,
+        "line": 51,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 55,
+        "line": 56,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 61,
+        "line": 62,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 61,
+        "line": 62,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 61,
+        "line": 62,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 61,
+        "line": 62,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 67,
+        "line": 68,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 82,
+        "line": 83,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 96,
+        "line": 97,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 108,
+        "line": 109,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 120,
+        "line": 121,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 138,
+        "line": 139,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 143,
+        "line": 144,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 150,
+        "line": 151,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 157,
+        "line": 158,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 171,
+        "line": 172,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 189,
+        "line": 190,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 225,
+        "line": 226,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 253,
+        "line": 254,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 269,
+        "line": 270,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 349,
+        "line": 350,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 355,
+        "line": 356,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 355,
+        "line": 356,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 355,
+        "line": 356,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 360,
+        "line": 361,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 366,
+        "line": 367,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 375,
+        "line": 376,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 375,
+        "line": 376,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 375,
+        "line": 376,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 386,
+        "line": 387,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 399,
+        "line": 400,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 407,
+        "line": 408,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 418,
+        "line": 419,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 424,
+        "line": 425,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 425,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 425,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 425,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 425,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 432,
+        "line": 433,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 432,
+        "line": 433,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 436,
+        "line": 437,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 440,
+        "line": 441,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 445,
+        "line": 446,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 452,
+        "line": 453,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 452,
+        "line": 453,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 452,
+        "line": 453,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 457,
+        "line": 458,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 457,
+        "line": 458,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 457,
+        "line": 458,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 475,
+        "line": 476,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 475,
+        "line": 476,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 475,
+        "line": 476,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 475,
+        "line": 476,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 475,
+        "line": 476,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 498,
+        "line": 499,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 502,
+        "line": 503,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 507,
+        "line": 508,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 524,
+        "line": 525,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 534,
+        "line": 535,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 538,
+        "line": 539,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 545,
+        "line": 546,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24302,7 +24333,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24333,7 +24364,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24364,7 +24395,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24383,7 +24414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24398,7 +24429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24417,7 +24448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24432,7 +24463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24451,7 +24482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24466,7 +24497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24485,7 +24516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24500,7 +24531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24519,7 +24550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24534,7 +24565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24553,7 +24584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24568,7 +24599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24587,7 +24618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24602,7 +24633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24621,7 +24652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24636,7 +24667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24655,7 +24686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24670,7 +24701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24689,7 +24720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24704,7 +24735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24723,7 +24754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24738,7 +24769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24757,7 +24788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24772,8 +24803,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_run_aio_legacy_generation",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_resshift_upscale_stage",
+        "bound_name": "_run_aio_resshift_upscale_stage",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 568,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_resshift_upscale_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
+        "kind": "static_from",
+        "line": 580,
+        "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
         "role": "compatibility_fallback",
@@ -24791,7 +24856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24806,7 +24871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24825,7 +24890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24840,7 +24905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24859,7 +24924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24874,7 +24939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24893,7 +24958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24908,7 +24973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24927,7 +24992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24942,7 +25007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24961,7 +25026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -24976,7 +25041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24995,7 +25060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25010,7 +25075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25029,7 +25094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25044,7 +25109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25063,7 +25128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25078,7 +25143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25097,7 +25162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25112,7 +25177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25131,7 +25196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25146,7 +25211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25165,7 +25230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25180,7 +25245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25199,7 +25264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25214,7 +25279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25233,7 +25298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25248,7 +25313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25267,7 +25332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25282,7 +25347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25301,7 +25366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25316,7 +25381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25335,7 +25400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25350,7 +25415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25369,7 +25434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25384,7 +25449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25403,7 +25468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25418,7 +25483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25437,7 +25502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25452,7 +25517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25471,7 +25536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25486,7 +25551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25505,7 +25570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25520,7 +25585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25539,7 +25604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25554,7 +25619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25573,7 +25638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25588,7 +25653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25607,7 +25672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25622,7 +25687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25641,7 +25706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25656,7 +25721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25675,7 +25740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25690,7 +25755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25709,7 +25774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25724,7 +25789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25743,7 +25808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25758,7 +25823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25777,7 +25842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25792,7 +25857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25811,7 +25876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25826,7 +25891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25845,7 +25910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25860,7 +25925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25879,7 +25944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25894,7 +25959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25913,7 +25978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25928,7 +25993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25947,7 +26012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25962,7 +26027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25981,7 +26046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -25996,7 +26061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26015,7 +26080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26030,7 +26095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26049,7 +26114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26064,7 +26129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26083,7 +26148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26098,7 +26163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26117,7 +26182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26132,7 +26197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26151,7 +26216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26166,7 +26231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26185,7 +26250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26200,7 +26265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26219,7 +26284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26234,7 +26299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26253,7 +26318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26268,7 +26333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26287,7 +26352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26302,7 +26367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26321,7 +26386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26336,7 +26401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26355,7 +26420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26370,7 +26435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26389,7 +26454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26404,7 +26469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26423,7 +26488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26438,7 +26503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26457,7 +26522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26472,7 +26537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26491,7 +26556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26506,7 +26571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26525,7 +26590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26540,7 +26605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26559,7 +26624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26574,7 +26639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26593,7 +26658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26608,7 +26673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26627,7 +26692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26642,7 +26707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26661,7 +26726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26676,7 +26741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26695,7 +26760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26710,7 +26775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26729,7 +26794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26744,7 +26809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26763,7 +26828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26778,7 +26843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26797,7 +26862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26812,7 +26877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26831,7 +26896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26846,7 +26911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26865,7 +26930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26880,7 +26945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26899,7 +26964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26914,7 +26979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26933,7 +26998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26948,7 +27013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26967,7 +27032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -26982,7 +27047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27001,7 +27066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27016,7 +27081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27035,7 +27100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27050,7 +27115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27069,7 +27134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27084,7 +27149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27103,7 +27168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27118,7 +27183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27137,7 +27202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27152,7 +27217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27171,7 +27236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27186,7 +27251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27205,7 +27270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27220,7 +27285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27239,7 +27304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27254,7 +27319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27273,7 +27338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27288,7 +27353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27307,7 +27372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27322,7 +27387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27341,7 +27406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27356,7 +27421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27375,7 +27440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27390,7 +27455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27409,7 +27474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27424,7 +27489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27443,7 +27508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27458,7 +27523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27477,7 +27542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27492,7 +27557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27511,7 +27576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27526,7 +27591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27545,7 +27610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27560,7 +27625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27579,7 +27644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27594,7 +27659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27613,7 +27678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27628,7 +27693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27647,7 +27712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27662,7 +27727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27681,7 +27746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27696,7 +27761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27715,7 +27780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27730,7 +27795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27749,7 +27814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27764,7 +27829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27783,7 +27848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27798,7 +27863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27817,7 +27882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27832,7 +27897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27851,7 +27916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27866,7 +27931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27885,7 +27950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27900,7 +27965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27919,7 +27984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27934,7 +27999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27953,7 +28018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -27968,7 +28033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -27987,7 +28052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28002,7 +28067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28021,7 +28086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28036,7 +28101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28055,7 +28120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28070,7 +28135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28089,7 +28154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28104,7 +28169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28123,7 +28188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28138,7 +28203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 707,
+        "line": 709,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28157,7 +28222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28172,7 +28237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28191,7 +28256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28206,7 +28271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28225,7 +28290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28240,7 +28305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28259,7 +28324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28274,7 +28339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28293,7 +28358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28308,7 +28373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28327,7 +28392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28342,7 +28407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28361,7 +28426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28376,7 +28441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28395,7 +28460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28410,7 +28475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28429,7 +28494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28444,7 +28509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28463,7 +28528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28478,7 +28543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28497,7 +28562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28512,7 +28577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28531,7 +28596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28546,7 +28611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28565,7 +28630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28580,7 +28645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28599,7 +28664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28614,7 +28679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28633,7 +28698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28648,7 +28713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28667,7 +28732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28682,7 +28747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28701,7 +28766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28716,7 +28781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28735,7 +28800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28750,7 +28815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28769,7 +28834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28784,7 +28849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28803,7 +28868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28818,7 +28883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28837,7 +28902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28852,7 +28917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28871,7 +28936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28886,7 +28951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28905,7 +28970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28920,7 +28985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28939,7 +29004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28954,7 +29019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28973,7 +29038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -28988,7 +29053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29007,7 +29072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29022,7 +29087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29041,7 +29106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29056,7 +29121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29075,7 +29140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29090,7 +29155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29109,7 +29174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29124,7 +29189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29143,7 +29208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29158,7 +29223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29177,7 +29242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29192,7 +29257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29211,7 +29276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29226,7 +29291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29245,7 +29310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29260,7 +29325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29279,7 +29344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29294,7 +29359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29313,7 +29378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29328,7 +29393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29347,7 +29412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29362,7 +29427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29381,7 +29446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29396,7 +29461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29415,7 +29480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29430,7 +29495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29449,7 +29514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29464,7 +29529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29483,7 +29548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29498,7 +29563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29517,7 +29582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29532,7 +29597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29551,7 +29616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29566,7 +29631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29585,7 +29650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29600,7 +29665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29619,7 +29684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29634,7 +29699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29653,7 +29718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29668,7 +29733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29687,7 +29752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29702,7 +29767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29721,7 +29786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29736,7 +29801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29755,7 +29820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29770,7 +29835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29789,7 +29854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29804,7 +29869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29823,7 +29888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29838,7 +29903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29857,7 +29922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29872,7 +29937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29891,7 +29956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29906,7 +29971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29925,7 +29990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29940,7 +30005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29959,7 +30024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -29974,7 +30039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29993,7 +30058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30008,7 +30073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30027,7 +30092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30042,7 +30107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30061,7 +30126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30076,7 +30141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30095,7 +30160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30110,7 +30175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30129,7 +30194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30144,7 +30209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30163,7 +30228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30178,7 +30243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30197,7 +30262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30212,7 +30277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30231,7 +30296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30246,7 +30311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30265,7 +30330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30280,7 +30345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30299,7 +30364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30314,7 +30379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30333,7 +30398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30348,7 +30413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30367,7 +30432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30382,7 +30447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30401,7 +30466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30416,7 +30481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30435,7 +30500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30450,7 +30515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30469,7 +30534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30484,7 +30549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30503,7 +30568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30518,7 +30583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30537,7 +30602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30552,7 +30617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30571,7 +30636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30586,7 +30651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30605,7 +30670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30620,7 +30685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30639,7 +30704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30654,7 +30719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30673,7 +30738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30688,7 +30753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30707,7 +30772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30722,7 +30787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30741,7 +30806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30756,7 +30821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30775,7 +30840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30790,7 +30855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30809,7 +30874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30824,7 +30889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30843,7 +30908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30858,7 +30923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30877,7 +30942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30892,7 +30957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30911,7 +30976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30926,7 +30991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30945,7 +31010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30960,7 +31025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30979,7 +31044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -30994,7 +31059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31013,7 +31078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31028,7 +31093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31047,7 +31112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31062,7 +31127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31081,7 +31146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31096,7 +31161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31115,7 +31180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31130,7 +31195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31149,7 +31214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31164,7 +31229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31183,7 +31248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31198,7 +31263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31217,7 +31282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31232,7 +31297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31251,7 +31316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31266,7 +31331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31285,7 +31350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31300,7 +31365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31319,7 +31384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31334,7 +31399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31353,7 +31418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31368,7 +31433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31387,7 +31452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31402,7 +31467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31421,7 +31486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31436,7 +31501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31455,7 +31520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31470,7 +31535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31489,7 +31554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31504,7 +31569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31523,7 +31588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31538,7 +31603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31557,7 +31622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31572,7 +31637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31591,7 +31656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31606,7 +31671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31625,7 +31690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31640,7 +31705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31659,7 +31724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31674,7 +31739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31693,7 +31758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31708,7 +31773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31727,7 +31792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31742,7 +31807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31761,7 +31826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31776,7 +31841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31795,7 +31860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31810,7 +31875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31829,7 +31894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31844,7 +31909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31863,7 +31928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31878,7 +31943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31897,7 +31962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31912,7 +31977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31931,7 +31996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31946,7 +32011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31965,7 +32030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -31980,7 +32045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -31999,7 +32064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32014,7 +32079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32033,7 +32098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32048,7 +32113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32067,7 +32132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32082,7 +32147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32101,7 +32166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32116,7 +32181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32135,7 +32200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32150,7 +32215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32169,7 +32234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32184,7 +32249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32203,7 +32268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32218,7 +32283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32237,7 +32302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32252,7 +32317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32271,7 +32336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32286,7 +32351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32305,7 +32370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32320,7 +32385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32339,7 +32404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32354,7 +32419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32373,7 +32438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32388,7 +32453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32407,7 +32472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32422,7 +32487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32441,7 +32506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32456,7 +32521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32475,7 +32540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32490,7 +32555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32509,7 +32574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32524,7 +32589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32543,7 +32608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32558,7 +32623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32577,7 +32642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32592,7 +32657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32611,7 +32676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32626,7 +32691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32645,7 +32710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32660,7 +32725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32679,7 +32744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32694,7 +32759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32713,7 +32778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32728,7 +32793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32747,7 +32812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32762,7 +32827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32781,7 +32846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32796,7 +32861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32815,7 +32880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32830,7 +32895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32849,7 +32914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32864,7 +32929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32883,7 +32948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32898,7 +32963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32917,7 +32982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32932,7 +32997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32951,7 +33016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -32966,7 +33031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -32985,7 +33050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33000,7 +33065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33019,7 +33084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33034,7 +33099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33053,7 +33118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33068,7 +33133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33087,7 +33152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33102,7 +33167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1011,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33121,7 +33186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33136,7 +33201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1011,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33155,7 +33220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33170,7 +33235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1011,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33189,7 +33254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33204,7 +33269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33223,7 +33288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33238,7 +33303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33257,7 +33322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33272,7 +33337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33291,7 +33356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33306,7 +33371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33325,7 +33390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33340,7 +33405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33359,7 +33424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33374,7 +33439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33393,7 +33458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33408,7 +33473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33427,7 +33492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33442,7 +33507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33461,7 +33526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33476,7 +33541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33495,7 +33560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33510,7 +33575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33529,7 +33594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33544,7 +33609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33563,7 +33628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33578,7 +33643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33597,7 +33662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33612,7 +33677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33631,7 +33696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33646,7 +33711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33665,7 +33730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33680,7 +33745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33699,7 +33764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33714,7 +33779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33733,7 +33798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33748,7 +33813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33767,7 +33832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33782,7 +33847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33801,7 +33866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33816,7 +33881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33835,7 +33900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33850,7 +33915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33869,7 +33934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33884,7 +33949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33903,7 +33968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33918,7 +33983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33937,7 +34002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33952,7 +34017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33971,7 +34036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -33986,7 +34051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34005,7 +34070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34020,7 +34085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34039,7 +34104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34054,7 +34119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34073,7 +34138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34088,7 +34153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34107,7 +34172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34122,7 +34187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34141,7 +34206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34156,7 +34221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34175,7 +34240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34190,7 +34255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34209,7 +34274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34224,7 +34289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34243,7 +34308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34258,7 +34323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34277,7 +34342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34292,7 +34357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34311,7 +34376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34326,7 +34391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34345,7 +34410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34360,7 +34425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34379,7 +34444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34394,7 +34459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34413,7 +34478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34428,7 +34493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34447,7 +34512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34462,7 +34527,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34481,7 +34546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34496,7 +34561,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34515,7 +34580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34530,7 +34595,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1098,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34549,7 +34614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34564,7 +34629,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34583,7 +34648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34598,7 +34663,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34617,7 +34682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34632,7 +34697,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34651,7 +34716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34666,7 +34731,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1104,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34685,7 +34750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34700,7 +34765,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1104,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34719,7 +34784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34734,7 +34799,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34753,7 +34818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34768,7 +34833,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34787,7 +34852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34802,7 +34867,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34821,7 +34886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34836,7 +34901,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34855,7 +34920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34870,7 +34935,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34889,7 +34954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34904,7 +34969,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34923,7 +34988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34938,7 +35003,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34957,7 +35022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -34972,7 +35037,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34991,7 +35056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35006,7 +35071,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35025,7 +35090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35040,7 +35105,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35059,7 +35124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35074,7 +35139,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35093,7 +35158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35108,7 +35173,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35127,7 +35192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35142,7 +35207,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35161,7 +35226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35176,7 +35241,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35195,7 +35260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35210,7 +35275,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35229,7 +35294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35244,7 +35309,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35263,7 +35328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35278,7 +35343,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35297,7 +35362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35312,7 +35377,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35331,7 +35396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -35346,7 +35411,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35364,7 +35429,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1620
+            "line": 1622
           }
         ],
         "classification": "external",
@@ -35372,7 +35437,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1621,
+        "line": 1623,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35389,7 +35454,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1630
           }
         ],
         "classification": "external",
@@ -35397,7 +35462,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1631,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35414,7 +35479,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1638
           }
         ],
         "classification": "external",
@@ -35422,7 +35487,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1639,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38406,13 +38471,13 @@
       },
       {
         "is_package": false,
-        "loc": 619,
+        "loc": 682,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "2c35456fcd13ecb9c851912b19c53ce537e023c5",
+        "normalized_git_blob_sha1": "9ae2e782c541ad32e8d684f37909cedcffca4a84",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
+          "function_count": 7,
           "global_count": 3
         }
       },
@@ -39054,13 +39119,13 @@
       },
       {
         "is_package": false,
-        "loc": 2149,
+        "loc": 2092,
         "module": "nodes",
-        "normalized_git_blob_sha1": "6546a965e0c3f57704b074904d88ae8ed988af50",
+        "normalized_git_blob_sha1": "3586d54ce9dc559eaa11a0f1233311e42c6e26ec",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 12,
+          "function_count": 11,
           "global_count": 26
         }
       },
@@ -40420,7 +40485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40429,7 +40494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40443,7 +40508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40452,7 +40517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40466,7 +40531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40475,7 +40540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40489,7 +40554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40498,7 +40563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40512,7 +40577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40521,7 +40586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40535,7 +40600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40544,7 +40609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40558,7 +40623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40567,7 +40632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40581,7 +40646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40590,7 +40655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40604,7 +40669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40613,7 +40678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40627,7 +40692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40636,7 +40701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40650,7 +40715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40659,7 +40724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40673,7 +40738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40682,7 +40747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40696,7 +40761,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
+        "kind": "static_from",
+        "line": 580,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40705,7 +40793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40719,7 +40807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40728,7 +40816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40742,7 +40830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40751,7 +40839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40765,7 +40853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40774,7 +40862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40788,7 +40876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40797,7 +40885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40811,7 +40899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40820,7 +40908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40834,7 +40922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40843,7 +40931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40857,7 +40945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40866,7 +40954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40880,7 +40968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40889,7 +40977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40903,7 +40991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40912,7 +41000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40926,7 +41014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40935,7 +41023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40949,7 +41037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40958,7 +41046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40972,7 +41060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -40981,7 +41069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40995,7 +41083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41004,7 +41092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41018,7 +41106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41027,7 +41115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41041,7 +41129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41050,7 +41138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41064,7 +41152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41073,7 +41161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 586,
+        "line": 588,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41087,7 +41175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41096,7 +41184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 604,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41110,7 +41198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41119,7 +41207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41133,7 +41221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41142,7 +41230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41156,7 +41244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41165,7 +41253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41179,7 +41267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41188,7 +41276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41202,7 +41290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41211,7 +41299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41225,7 +41313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41234,7 +41322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41248,7 +41336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41257,7 +41345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 612,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41271,7 +41359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41280,7 +41368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41294,7 +41382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41303,7 +41391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41317,7 +41405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41326,7 +41414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41340,7 +41428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41349,7 +41437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41363,7 +41451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41372,7 +41460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41386,7 +41474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41395,7 +41483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41409,7 +41497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41418,7 +41506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41432,7 +41520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41441,7 +41529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41455,7 +41543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41464,7 +41552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41478,7 +41566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41487,7 +41575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41501,7 +41589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41510,7 +41598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41524,7 +41612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41533,7 +41621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41547,7 +41635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41556,7 +41644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41570,7 +41658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41579,7 +41667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41593,7 +41681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41602,7 +41690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41616,7 +41704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41625,7 +41713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41639,7 +41727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41648,7 +41736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41662,7 +41750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41671,7 +41759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41685,7 +41773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41694,7 +41782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41708,7 +41796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41717,7 +41805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41731,7 +41819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41740,7 +41828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41754,7 +41842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41763,7 +41851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41777,7 +41865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41786,7 +41874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41800,7 +41888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41809,7 +41897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41823,7 +41911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41832,7 +41920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41846,7 +41934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41855,7 +41943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41869,7 +41957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41878,7 +41966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41892,7 +41980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41901,7 +41989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41915,7 +42003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41924,7 +42012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 639,
+        "line": 641,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41938,7 +42026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41947,7 +42035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41961,7 +42049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41970,7 +42058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41984,7 +42072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -41993,7 +42081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42007,7 +42095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42016,7 +42104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42030,7 +42118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42039,7 +42127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42053,7 +42141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42062,7 +42150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42076,7 +42164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42085,7 +42173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42099,7 +42187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42108,7 +42196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42122,7 +42210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42131,7 +42219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42145,7 +42233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42154,7 +42242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 653,
+        "line": 655,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42168,7 +42256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42177,7 +42265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42191,7 +42279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42200,7 +42288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42214,7 +42302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42223,7 +42311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42237,7 +42325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42246,7 +42334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42260,7 +42348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42269,7 +42357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42283,7 +42371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42292,7 +42380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42306,7 +42394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42315,7 +42403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42329,7 +42417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42338,7 +42426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42352,7 +42440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42361,7 +42449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42375,7 +42463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42384,7 +42472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 665,
+        "line": 667,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42398,7 +42486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42407,7 +42495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42421,7 +42509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42430,7 +42518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42444,7 +42532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42453,7 +42541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42467,7 +42555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42476,7 +42564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42490,7 +42578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42499,7 +42587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42513,7 +42601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42522,7 +42610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42536,7 +42624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42545,7 +42633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42559,7 +42647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42568,7 +42656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42582,7 +42670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42591,7 +42679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42605,7 +42693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42614,7 +42702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42628,7 +42716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42637,7 +42725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42651,7 +42739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42660,7 +42748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42674,7 +42762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42683,7 +42771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42697,7 +42785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42706,7 +42794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42720,7 +42808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42729,7 +42817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42743,7 +42831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42752,7 +42840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 677,
+        "line": 679,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42766,7 +42854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42775,7 +42863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42789,7 +42877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42798,7 +42886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42812,7 +42900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42821,7 +42909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 695,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42835,7 +42923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42844,7 +42932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42858,7 +42946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42867,7 +42955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42881,7 +42969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42890,7 +42978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42904,7 +42992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42913,7 +43001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42927,7 +43015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42936,7 +43024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 700,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42950,7 +43038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42959,7 +43047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 707,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42973,7 +43061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -42982,7 +43070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42996,7 +43084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43005,7 +43093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43019,7 +43107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43028,7 +43116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43042,7 +43130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43051,7 +43139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 708,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43065,7 +43153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43074,7 +43162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43088,7 +43176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43097,7 +43185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43111,7 +43199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43120,7 +43208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43134,7 +43222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43143,7 +43231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43157,7 +43245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43166,7 +43254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43180,7 +43268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43189,7 +43277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43203,7 +43291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43212,7 +43300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43226,7 +43314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43235,7 +43323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43249,7 +43337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43258,7 +43346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43272,7 +43360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43281,7 +43369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43295,7 +43383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43304,7 +43392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43318,7 +43406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43327,7 +43415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43341,7 +43429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43350,7 +43438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43364,7 +43452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43373,7 +43461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43387,7 +43475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43396,7 +43484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43410,7 +43498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43419,7 +43507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43433,7 +43521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43442,7 +43530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 728,
+        "line": 730,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43456,7 +43544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43465,7 +43553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43479,7 +43567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43488,7 +43576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43502,7 +43590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43511,7 +43599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43525,7 +43613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43534,7 +43622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43548,7 +43636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43557,7 +43645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43571,7 +43659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43580,7 +43668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43594,7 +43682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43603,7 +43691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43617,7 +43705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43626,7 +43714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43640,7 +43728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43649,7 +43737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43663,7 +43751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43672,7 +43760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43686,7 +43774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43695,7 +43783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43709,7 +43797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43718,7 +43806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43732,7 +43820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43741,7 +43829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43755,7 +43843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43764,7 +43852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43778,7 +43866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43787,7 +43875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43801,7 +43889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43810,7 +43898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43824,7 +43912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43833,7 +43921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43847,7 +43935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43856,7 +43944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43870,7 +43958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43879,7 +43967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43893,7 +43981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43902,7 +43990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43916,7 +44004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43925,7 +44013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43939,7 +44027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43948,7 +44036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 746,
+        "line": 748,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43962,7 +44050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43971,7 +44059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43985,7 +44073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -43994,7 +44082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44008,7 +44096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44017,7 +44105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44031,7 +44119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44040,7 +44128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44054,7 +44142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44063,7 +44151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44077,7 +44165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44086,7 +44174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44100,7 +44188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44109,7 +44197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44123,7 +44211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44132,7 +44220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44146,7 +44234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44155,7 +44243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44169,7 +44257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44178,7 +44266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44192,7 +44280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44201,7 +44289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44215,7 +44303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44224,7 +44312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44238,7 +44326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44247,7 +44335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44261,7 +44349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44270,7 +44358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 782,
+        "line": 784,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44284,7 +44372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44293,7 +44381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44307,7 +44395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44316,7 +44404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44330,7 +44418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44339,7 +44427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44353,7 +44441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44362,7 +44450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44376,7 +44464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44385,7 +44473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44399,7 +44487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44408,7 +44496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44422,7 +44510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44431,7 +44519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44445,7 +44533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44454,7 +44542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44468,7 +44556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44477,7 +44565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 810,
+        "line": 812,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44491,7 +44579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44500,7 +44588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44514,7 +44602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44523,7 +44611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44537,7 +44625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44546,7 +44634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44560,7 +44648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44569,7 +44657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44583,7 +44671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44592,7 +44680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44606,7 +44694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44615,7 +44703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44629,7 +44717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44638,7 +44726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44652,7 +44740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44661,7 +44749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44675,7 +44763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44684,7 +44772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44698,7 +44786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44707,7 +44795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44721,7 +44809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44730,7 +44818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44744,7 +44832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44753,7 +44841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44767,7 +44855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44776,7 +44864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44790,7 +44878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44799,7 +44887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44813,7 +44901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44822,7 +44910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44836,7 +44924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44845,7 +44933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44859,7 +44947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44868,7 +44956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44882,7 +44970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44891,7 +44979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44905,7 +44993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44914,7 +45002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44928,7 +45016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44937,7 +45025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44951,7 +45039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44960,7 +45048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44974,7 +45062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -44983,7 +45071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44997,7 +45085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45006,7 +45094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45020,7 +45108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45029,7 +45117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45043,7 +45131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45052,7 +45140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 826,
+        "line": 828,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45066,7 +45154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45075,7 +45163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45089,7 +45177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45098,7 +45186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45112,7 +45200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45121,7 +45209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45135,7 +45223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45144,7 +45232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 906,
+        "line": 908,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45158,7 +45246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45167,7 +45255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45181,7 +45269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45190,7 +45278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45204,7 +45292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45213,7 +45301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45227,7 +45315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45236,7 +45324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45250,7 +45338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45259,7 +45347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45273,7 +45361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45282,7 +45370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 917,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45296,7 +45384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45305,7 +45393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45319,7 +45407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45328,7 +45416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45342,7 +45430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45351,7 +45439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45365,7 +45453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45374,7 +45462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45388,7 +45476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45397,7 +45485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45411,7 +45499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45420,7 +45508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45434,7 +45522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45443,7 +45531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45457,7 +45545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45466,7 +45554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45480,7 +45568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45489,7 +45577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45503,7 +45591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45512,7 +45600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 932,
+        "line": 934,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45526,7 +45614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45535,7 +45623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45549,7 +45637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45558,7 +45646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45572,7 +45660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45581,7 +45669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45595,7 +45683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45604,7 +45692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 943,
+        "line": 945,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45618,7 +45706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45627,7 +45715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45641,7 +45729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45650,7 +45738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 956,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45664,7 +45752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45673,7 +45761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45687,7 +45775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45696,7 +45784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45710,7 +45798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45719,7 +45807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45733,7 +45821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45742,7 +45830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45756,7 +45844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45765,7 +45853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45779,7 +45867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45788,7 +45876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45802,7 +45890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45811,7 +45899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45825,7 +45913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45834,7 +45922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 964,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45848,7 +45936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45857,7 +45945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45871,7 +45959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45880,7 +45968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45894,7 +45982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45903,7 +45991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45917,7 +46005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45926,7 +46014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 975,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45940,7 +46028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45949,7 +46037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45963,7 +46051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45972,7 +46060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45986,7 +46074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -45995,7 +46083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46009,7 +46097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46018,7 +46106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46032,7 +46120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46041,7 +46129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46055,7 +46143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46064,7 +46152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46078,7 +46166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46087,7 +46175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 989,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46101,7 +46189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46110,7 +46198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46124,7 +46212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46133,7 +46221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46147,7 +46235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46156,7 +46244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46170,7 +46258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46179,7 +46267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46193,7 +46281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46202,7 +46290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46216,7 +46304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46225,7 +46313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46239,7 +46327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46248,7 +46336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46262,7 +46350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46271,7 +46359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46285,7 +46373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46294,7 +46382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46308,7 +46396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46317,7 +46405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46331,7 +46419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46340,7 +46428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46354,7 +46442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46363,7 +46451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46377,7 +46465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46386,7 +46474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46400,7 +46488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46409,7 +46497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46423,7 +46511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46432,7 +46520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46446,7 +46534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46455,7 +46543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46469,7 +46557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46478,7 +46566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46492,7 +46580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46501,7 +46589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46515,7 +46603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46524,7 +46612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46538,7 +46626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46547,7 +46635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1032,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46561,7 +46649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46570,7 +46658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46584,7 +46672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46593,7 +46681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1055,
+        "line": 1057,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46607,7 +46695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46616,7 +46704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46630,7 +46718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46639,7 +46727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46653,7 +46741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46662,7 +46750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46676,7 +46764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46685,7 +46773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46699,7 +46787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46708,7 +46796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46722,7 +46810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46731,7 +46819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46745,7 +46833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46754,7 +46842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46768,7 +46856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46777,7 +46865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46791,7 +46879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46800,7 +46888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46814,7 +46902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46823,7 +46911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46837,7 +46925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46846,7 +46934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46860,7 +46948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46869,7 +46957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46883,7 +46971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46892,7 +46980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46906,7 +46994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46915,7 +47003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46929,7 +47017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46938,7 +47026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46952,7 +47040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46961,7 +47049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46975,7 +47063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -46984,7 +47072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46998,7 +47086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47007,7 +47095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47021,7 +47109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47030,7 +47118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47044,7 +47132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47053,7 +47141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47067,7 +47155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47076,7 +47164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47090,7 +47178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47099,7 +47187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47113,7 +47201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47122,7 +47210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47136,7 +47224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47145,7 +47233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47159,7 +47247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47168,7 +47256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1081,
+        "line": 1083,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47182,7 +47270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47191,7 +47279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47205,7 +47293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47214,7 +47302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1093,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47228,7 +47316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47237,7 +47325,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47251,7 +47339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47260,7 +47348,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47274,7 +47362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47283,7 +47371,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47297,7 +47385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47306,7 +47394,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47320,7 +47408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47329,7 +47417,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47343,7 +47431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47352,7 +47440,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47366,7 +47454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47375,7 +47463,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47389,7 +47477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47398,7 +47486,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47412,7 +47500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47421,7 +47509,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47435,7 +47523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47444,7 +47532,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47458,7 +47546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47467,7 +47555,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47481,7 +47569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47490,7 +47578,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47504,7 +47592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47513,7 +47601,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47527,7 +47615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47536,7 +47624,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47550,7 +47638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47559,7 +47647,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47573,7 +47661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47582,7 +47670,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47596,7 +47684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47605,7 +47693,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47619,7 +47707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47628,7 +47716,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47642,7 +47730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47651,7 +47739,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47665,7 +47753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47674,7 +47762,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47688,7 +47776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47697,7 +47785,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47711,7 +47799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47720,7 +47808,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47734,7 +47822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47743,7 +47831,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47757,7 +47845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47766,7 +47854,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47780,7 +47868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47789,7 +47877,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47803,7 +47891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47812,7 +47900,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47826,7 +47914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 568,
             "kind": "try",
             "line": 10
           }
@@ -47835,7 +47923,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51662,14 +51750,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1620
+            "line": 1622
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1621,
+        "line": 1623,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51681,14 +51769,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1630
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1631,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51700,14 +51788,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1638
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1639,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53082,14 +53170,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1620
+            "line": 1622
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1621,
+        "line": 1623,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53101,14 +53189,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1630
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1631,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53120,14 +53208,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1638
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1639,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54588,7 +54676,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1125,
+        "line": 1127,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54597,7 +54685,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2045,
+        "line": 1988,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54606,7 +54694,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2048,
+        "line": 1991,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54615,7 +54703,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2051,
+        "line": 1994,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54624,7 +54712,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2054,
+        "line": 1997,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54633,7 +54721,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2057,
+        "line": 2000,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54642,7 +54730,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2060,
+        "line": 2003,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54651,7 +54739,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2063,
+        "line": 2006,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54660,7 +54748,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2066,
+        "line": 2009,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54669,7 +54757,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2069,
+        "line": 2012,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54678,7 +54766,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2072,
+        "line": 2015,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54687,7 +54775,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2075,
+        "line": 2018,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54696,7 +54784,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2078,
+        "line": 2021,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54705,7 +54793,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2081,
+        "line": 2024,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54714,7 +54802,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2084,
+        "line": 2027,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54723,7 +54811,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2087,
+        "line": 2030,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54732,7 +54820,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2090,
+        "line": 2033,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54741,7 +54829,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2094,
+        "line": 2037,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54750,7 +54838,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2097,
+        "line": 2040,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54759,7 +54847,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2101,
+        "line": 2044,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54768,7 +54856,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2104,
+        "line": 2047,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54777,7 +54865,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2108,
+        "line": 2051,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54786,7 +54874,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2111,
+        "line": 2054,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54795,7 +54883,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2114,
+        "line": 2057,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54804,7 +54892,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2117,
+        "line": 2060,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54813,7 +54901,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2120,
+        "line": 2063,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54822,7 +54910,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2123,
+        "line": 2066,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54831,7 +54919,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2130,
+        "line": 2073,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54840,7 +54928,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2136,
+        "line": 2079,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54849,7 +54937,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2141,
+        "line": 2084,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54858,7 +54946,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2145,
+        "line": 2088,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55372,13 +55460,13 @@
       },
       {
         "kind": "dict",
-        "line": 1187,
+        "line": 1189,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1176,
+        "line": 1178,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "6a5fd7bd2c369921e5ecb18791df187d578d6637",
+    "base_commit": "2abc54d12f96b784f2e63e07400522227f7affe3",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -54,7 +54,8 @@
       "B-11c21",
       "B-11c22",
       "B-11c23",
-      "B-11c24"
+      "B-11c24",
+      "B-11c25"
     ]
   },
   "enums": {
@@ -89,11 +90,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 296,
+    "nodes_canonical_bindings": 297,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 12,
+    "root_residual_functions": 11,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -567,6 +568,7 @@
     ],
     "_as_int": [
       "easyuse_anima.aio.generation_normalization",
+      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.postprocess",
@@ -845,6 +847,7 @@
       "easyuse_anima.aio.sampling"
     ],
     "_node_output_tuple": [
+      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling"
@@ -992,6 +995,7 @@
       "easyuse_anima.aio.model_preparation"
     ],
     "_require_custom_node_class": [
+      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.sampling"
@@ -2118,6 +2122,7 @@
         "_run_aio_detailer_stage": "_run_aio_detailer_stage",
         "_run_aio_highres_stage": "_run_aio_highres_stage",
         "_run_aio_legacy_generation": "_run_aio_legacy_generation",
+        "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
         "_run_aio_upscale_stage": "_run_aio_upscale_stage"
       },
       "classification": "transitional_private_seam",
@@ -2720,12 +2725,14 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.model_preparation",
         "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.model_preparation string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup"
@@ -4199,7 +4206,6 @@
         "_require_custom_node_class": "_require_custom_node_class",
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
         "_run_aio_detailer_target": "_run_aio_detailer_target",
-        "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
         "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
       },
       "classification": "transitional_private_seam",

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -33,6 +33,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             legacy_generation._run_aio_legacy_generation,
         )
         self.assertIs(
+            nodes._run_aio_resshift_upscale_stage,
+            legacy_generation._run_aio_resshift_upscale_stage,
+        )
+        self.assertIs(
             nodes._run_aio_detailer_stage,
             legacy_generation._run_aio_detailer_stage,
         )
@@ -56,6 +60,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             self.assertIs(
                 package_nodes._run_aio_legacy_generation,
                 canonical_module._run_aio_legacy_generation,
+            )
+            self.assertIs(
+                package_nodes._run_aio_resshift_upscale_stage,
+                canonical_module._run_aio_resshift_upscale_stage,
             )
             self.assertIs(
                 package_nodes._run_aio_detailer_stage,
@@ -691,6 +699,297 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         )
         self.assertNotIn("target:face", callback_trace)
         self.assertNotIn("context_value", callback_trace)
+
+    def test_resshift_stage_preserves_provider_argument_and_metadata_order(self):
+        trace = []
+        image = _Token("image")
+        output = _Token("output")
+        model = _Token("resshift_model")
+        sampler_settings = {"seed": "seed-input"}
+        upscale_settings = {
+            "resshift": {
+                "scale": "x4",
+                "student_name": "student.ckpt",
+                "dtype": "fp32",
+                "chop": "1024",
+                "overlap": "96",
+                "tile_batch": "2",
+            }
+        }
+
+        class Loader:
+            def __init__(self):
+                trace.append("construct:loader")
+
+            def load(self, *args):
+                trace.append(("call", "load", args))
+                return "loader-result"
+
+        class Upscaler:
+            def __init__(self):
+                trace.append("construct:upscaler")
+
+            def upscale(self, *args):
+                trace.append(("call", "upscale", args))
+                return "upscale-result"
+
+        def require(node_id, node_pack, install_hint):
+            trace.append(("call", "_require_custom_node_class", node_id))
+            self.assertEqual(node_pack, "ComfyUI-Distilled-ResShift")
+            self.assertEqual(
+                install_hint,
+                "Required for AiO Generator final Upscale > ResShift.",
+            )
+            return Loader if node_id == "ResShiftLoader" else Upscaler
+
+        tuple_results = iter(((model,), (output,)))
+
+        def node_output_tuple(value):
+            trace.append(("call", "_node_output_tuple", value))
+            return next(tuple_results)
+
+        def resolve_seed(value):
+            trace.append(("call", "_resolve_aio_runtime_seed", value))
+            return 321
+
+        def as_int(value, default):
+            trace.append(("call", "_as_int", value, default))
+            return int(value)
+
+        def image_size(value, fallback_width, fallback_height):
+            trace.append(("call", "_image_tensor_size"))
+            self.assertIs(value, output)
+            self.assertEqual((fallback_width, fallback_height), (0, 0))
+            return 2048, 3072
+
+        helpers = {
+            "_require_custom_node_class": require,
+            "_node_output_tuple": node_output_tuple,
+            "_resolve_aio_runtime_seed": resolve_seed,
+            "_as_int": as_int,
+            "_image_tensor_size": image_size,
+        }
+
+        def resolve(name):
+            trace.append(("resolve", name))
+            return helpers[name]
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            result = nodes._run_aio_resshift_upscale_stage(
+                image,
+                sampler_settings,
+                upscale_settings,
+                "unused-quality",
+                "unused-negative",
+                {"unused": True},
+                True,
+                True,
+            )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertIs(result[0], output)
+        self.assertEqual(
+            result[1],
+            {
+                "enabled": True,
+                "backend": "resshift",
+                "width": 2048,
+                "height": 3072,
+                "scale": "x4",
+            },
+        )
+        self.assertEqual(
+            list(result[1]),
+            ["enabled", "backend", "width", "height", "scale"],
+        )
+        self.assertEqual(
+            trace,
+            [
+                ("resolve", "_require_custom_node_class"),
+                ("call", "_require_custom_node_class", "ResShiftLoader"),
+                ("resolve", "_require_custom_node_class"),
+                ("call", "_require_custom_node_class", "ResShiftUpscale"),
+                "construct:loader",
+                ("resolve", "_node_output_tuple"),
+                (
+                    "call",
+                    "load",
+                    ("x4", "student.ckpt", "fp32"),
+                ),
+                ("call", "_node_output_tuple", "loader-result"),
+                "construct:upscaler",
+                ("resolve", "_node_output_tuple"),
+                ("resolve", "_resolve_aio_runtime_seed"),
+                ("call", "_resolve_aio_runtime_seed", "seed-input"),
+                ("resolve", "_as_int"),
+                ("call", "_as_int", "1024", 512),
+                ("resolve", "_as_int"),
+                ("call", "_as_int", "96", 64),
+                ("resolve", "_as_int"),
+                ("call", "_as_int", "2", 4),
+                (
+                    "call",
+                    "upscale",
+                    (model, image, 321, 1024, 96, 2),
+                ),
+                ("call", "_node_output_tuple", "upscale-result"),
+                ("resolve", "_image_tensor_size"),
+                ("call", "_image_tensor_size"),
+            ],
+        )
+
+    def test_resshift_stage_preserves_failure_boundaries(self):
+        image = _Token("image")
+
+        def execute(helpers, trace):
+            def resolve(name):
+                trace.append(f"resolve:{name}")
+                if name not in helpers:
+                    self.fail(f"failure case resolved unexpected helper: {name}")
+                return helpers[name]
+
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=resolve
+            )
+            try:
+                return nodes._run_aio_resshift_upscale_stage(
+                    image,
+                    {"seed": 7},
+                    {"resshift": {}},
+                )
+            finally:
+                legacy_generation._bind_aio_legacy_generation_runtime(
+                    resolve_helper=lambda name: getattr(nodes, name)
+                )
+
+        first_provider_trace = []
+
+        def fail_first_provider(*args):
+            first_provider_trace.append("require:loader")
+            raise LookupError("provider failed")
+
+        with self.assertRaisesRegex(LookupError, "provider failed"):
+            execute(
+                {"_require_custom_node_class": fail_first_provider},
+                first_provider_trace,
+            )
+        self.assertEqual(
+            first_provider_trace,
+            ["resolve:_require_custom_node_class", "require:loader"],
+        )
+
+        missing_load_trace = []
+
+        class MissingLoad:
+            def __init__(self):
+                missing_load_trace.append("construct:loader")
+
+        class UnusedUpscaler:
+            def __init__(self):
+                missing_load_trace.append("construct:upscaler")
+
+        def missing_load_provider(node_id, *args):
+            missing_load_trace.append(f"require:{node_id}")
+            return MissingLoad if node_id == "ResShiftLoader" else UnusedUpscaler
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] ResShiftLoader does not expose load\(\)\.$",
+        ):
+            execute(
+                {"_require_custom_node_class": missing_load_provider},
+                missing_load_trace,
+            )
+        self.assertEqual(
+            missing_load_trace,
+            [
+                "resolve:_require_custom_node_class",
+                "require:ResShiftLoader",
+                "resolve:_require_custom_node_class",
+                "require:ResShiftUpscale",
+                "construct:loader",
+            ],
+        )
+
+        empty_model_trace = []
+
+        class EmptyLoader:
+            def load(self, *args):
+                empty_model_trace.append("load")
+                return "loader-result"
+
+        class NeverConstructedUpscaler:
+            def __init__(self):
+                empty_model_trace.append("construct:upscaler")
+
+        def empty_model_provider(node_id, *args):
+            return EmptyLoader if node_id == "ResShiftLoader" else NeverConstructedUpscaler
+
+        def empty_tuple(value):
+            empty_model_trace.append(f"tuple:{value}")
+            return ()
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] ResShiftLoader returned no RESSHIFT_MODEL\.$",
+        ):
+            execute(
+                {
+                    "_require_custom_node_class": empty_model_provider,
+                    "_node_output_tuple": empty_tuple,
+                },
+                empty_model_trace,
+            )
+        self.assertNotIn("construct:upscaler", empty_model_trace)
+
+        seed_failure_trace = []
+
+        class Loader:
+            def load(self, *args):
+                seed_failure_trace.append("load")
+                return "loader-result"
+
+        class Upscaler:
+            def __init__(self):
+                seed_failure_trace.append("construct:upscaler")
+
+            def upscale(self, *args):
+                seed_failure_trace.append("upscale")
+                return "upscale-result"
+
+        def provider(node_id, *args):
+            return Loader if node_id == "ResShiftLoader" else Upscaler
+
+        tuple_results = iter(((object(),), (object(),)))
+
+        def tuple_helper(value):
+            seed_failure_trace.append(f"tuple:{value}")
+            return next(tuple_results)
+
+        def fail_seed(value):
+            seed_failure_trace.append("seed")
+            raise ValueError("seed failed")
+
+        with self.assertRaisesRegex(ValueError, "seed failed"):
+            execute(
+                {
+                    "_require_custom_node_class": provider,
+                    "_node_output_tuple": tuple_helper,
+                    "_resolve_aio_runtime_seed": fail_seed,
+                },
+                seed_failure_trace,
+            )
+        self.assertIn("construct:upscaler", seed_failure_trace)
+        self.assertEqual(
+            seed_failure_trace[-2:],
+            ["resolve:_resolve_aio_runtime_seed", "seed"],
+        )
+        self.assertNotIn("upscale", seed_failure_trace)
+        self.assertFalse(any(item == "resolve:_as_int" for item in seed_failure_trace))
 
     def test_upscale_dispatcher_preserves_lazy_branch_and_exception_contract(self):
         model = _Token("model")

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "6546a965e0c3f57704b074904d88ae8ed988af50")
-        # Issue #184 B-11c24 moves only the AiO Detailer stage to its
+        self.assertEqual(report["git_blob_sha1"], "3586d54ce9dc559eaa11a0f1233311e42c6e26ec")
+        # Issue #184 B-11c25 moves only the AiO ResShift leaf to its
         # canonical legacy-generation owner.
-        self.assertEqual(report["top_level"]["function_count"], 12)
+        self.assertEqual(report["top_level"]["function_count"], 11)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_149)
+        self.assertEqual(report["line_count"], 2_092)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "6a5fd7bd2c369921e5ecb18791df187d578d6637"
+BASE_COMMIT = "2abc54d12f96b784f2e63e07400522227f7affe3"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1327,6 +1327,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c22",
                 "B-11c23",
                 "B-11c24",
+                "B-11c25",
             ],
         },
         "enums": {
@@ -1339,11 +1340,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 296,
+            "nodes_canonical_bindings": 297,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 12,
+            "root_residual_functions": 11,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c25 단일 Move로 root `_run_aio_resshift_upscale_stage` leaf body만 roadmap의 temporary current-order orchestration owner `easyuse_anima.aio.legacy_generation`으로 이동합니다.
- USDU leaf와 dispatcher는 변경하지 않고, root `nodes.py`에는 relative/flat direct identity alias를 유지합니다.

## 작업 전 inventory

### Symbol / caller

- `_run_aio_resshift_upscale_stage`
  - 현재 surface: `nodes.py` private root definition
  - production consumer: canonical `easyuse_anima.aio.legacy_generation._run_aio_upscale_stage`가 ResShift branch에서 `_runtime_helper("_run_aio_resshift_upscale_stage")`로 매 호출 root seam 조회
  - 기존 direct behavior test는 ResShift 단독 선택, 두 provider의 인자와 metadata를 검증하고 dispatcher tests는 root monkeypatch seam을 소비
  - public mapping/export 없음
- canonical owner는 current-order stage ownership인 `easyuse_anima.aio.legacy_generation`입니다. 새 ResShift module/binder는 #169 Contract를 선점하므로 추가하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical leaf identity를 유지합니다.
- 기존 `_bind_aio_legacy_generation_runtime`과 `_RUNTIME_RESOLVER`만 재사용합니다. 새 binder/global/module은 추가하지 않습니다.
- canonical dispatcher는 기존 root string lookup을 유지해 monkeypatch seam을 보존합니다.
- leaf 자체 global/cache/lock/RNG/cleanup 소유는 없습니다. `quality_*`, `prompt_data`, exclude 인자는 현재 미사용이지만 signature 그대로 유지합니다.

### Call-time dependency inventory

- `_require_custom_node_class`
- `_node_output_tuple`
- `_resolve_aio_runtime_seed`
- `_as_int`
- `_image_tensor_size`

### 보존할 평가·예외 순서

1. `upscale_settings.get("resshift", {})`를 평가하고 dict가 아니면 `{}`로 대체합니다.
2. `ResShiftLoader` provider를 resolve한 뒤 `ResShiftUpscale` provider를 resolve합니다. 첫 조회 실패 시 두 번째는 실행하지 않습니다.
3. loader를 생성하고 `load` attribute를 조회하며, 없으면 기존 exact 오류를 즉시 발생시킵니다.
4. `_node_output_tuple`을 먼저 call-time resolve한 뒤 loader `load(scale, student_name, dtype)`를 호출하고 tuple helper를 적용합니다.
5. model output이 falsy면 기존 exact 오류를 발생시키며 upscaler를 생성하지 않습니다.
6. upscaler를 생성하고 `upscale` attribute를 조회하며, 없으면 기존 exact 오류를 즉시 발생시킵니다.
7. 두 번째 `_node_output_tuple`을 먼저 resolve한 뒤 model, image, runtime seed, chop, overlap, tile batch 순서로 인자를 평가해 upscaler를 호출하고 tuple helper를 적용합니다.
8. seed/coercion 실패 시 upscaler를 호출하지 않으며, upscaler 자체 예외 전에는 두 번째 tuple helper가 이미 resolve된 상태입니다.
9. output이 falsy면 기존 exact 오류를 발생시키고, 성공 시 `_image_tensor_size`를 resolve해 기존 metadata 순서로 반환합니다.
10. 예외 wrapping, fallback, cleanup은 추가하지 않고 helper lookup을 호출마다 반복합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/legacy_generation.py`, `nodes.py`
- contract/analyzer: `tests/test_aio_legacy_generation.py`, `tests/test_python_compatibility_surface.py`, `tests/test_nodes_module_analyzer.py`
- fixtures: `tests/fixtures/python_compatibility_surface.v1.json`, `tests/fixtures/python_backend_baseline.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`

## 예상 계약 delta

- base: `dev` / `2abc54d12f96b784f2e63e07400522227f7affe3`
- canonical bindings: `296 → 297`
- root/top-level residual functions: `12 → 11`
- runtime binders: `30` 유지
- runtime resolver names: `285` 유지
- legacy-generation resolver consumers: `49 → 52` (`_require_custom_node_class`, `_node_output_tuple`, `_as_int` consumer 추가)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6, direct root-import tests 21: 변화 없음
- `nodes.py` line count: `2,149 → 2,092` 예상, 구현 후 analyzer actual로 고정

## 금지 경계

- USDU leaf 또는 dispatcher 동시 이동 금지
- ResShift node IDs/install hint/error 문자열, signature/현재 미사용 인자 변경 금지
- fallback, seed/coercion/tuple-helper 평가 순서 변경 금지
- cleanup/예외 wrapping/validation 추가 금지
- settings/schema/default/workflow, #169 stage protocol/Contract/Behavior 변경 금지
- 새 ResShift owner/module/binder/provider 또는 public `__all__` 결합 금지

## 검증

- exact head: `37bfd0aa622b2ff6b25f17cc6bf6d317f90760e5`
- focused alias/provider lookup/loader/upscaler/seed/coercion/tuple/output/metadata/exception order와 기존 direct ResShift behavior/analyzer/import-boundary: 37 tests passed
- metadata key-order targeted 재확인: 1 test passed
- canonical `easyuse_anima/aio/legacy_generation.py` Ruff: clean
- 독립 diff review: 차단점 없음
- `tools/check_project.ps1 -Profile full` (exact worktree/head): Python unittest 927 passed, frontend 114 JS files passed, TypeScript 6.0.3, Pyright baseline passed, import-boundary 6 groups / 0 violations, `git diff --check` passed
- Ruff 전체 113건은 기존 G-01 report-only 진단이며 이번 Move의 차단 실패가 아님
- Live ComfyUI/browser smoke: private leaf Move 범위에서는 수행하지 않음

## 상태

- Ready
- Move-only boundary와 exact-head 검증을 충족했습니다.
