### PR TITLE
refactor: move AiO Detailer target owner

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `2abc54d12f96b784f2e63e07400522227f7affe3`
+- Integrated `dev` snapshot commit: `5e2b33504a001351f8151f9042fff254cd3b6120`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c24 / `2abc54d`; B-11c25 AiO ResShift leaf Move in PR #319 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c25 / `5e2b335`; B-11c26 AiO Detailer target leaf Move in PR #320 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,149
-  lines after B-11c24.
-- The mechanical extraction has removed 10,514
-  lines, approximately 83.0% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,092
+  lines after B-11c25.
+- The mechanical extraction has removed 10,571
+  lines, approximately 83.5% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -84,7 +84,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   `8b3ba38`. B-11c22 moved only the AiO highres stage in PR #316 / `9250610`.
   B-11c23 moved only the AiO upscale dispatcher in PR #317 / `6a5fd7b`.
   B-11c24 moved only the AiO Detailer stage coordinator in PR #318 / `2abc54d`.
-  B-11c25 moves only the AiO ResShift leaf in PR #319.
+  B-11c25 moved only the AiO ResShift leaf in PR #319 / `5e2b335`.
+  B-11c26 moves only the AiO Detailer target leaf in PR #320.
 
 ### Current quality baseline
 
@@ -326,7 +327,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 AiO ResShift leaf Move PR #319 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 PR #319 / `5e2b335`; B-11c26 AiO Detailer target leaf Move PR #320 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -941,6 +942,19 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     generation owner in PR #317. Boolean coercion and both leaf stages remain
     call-time root seams; disabled, USDU, ResShift, unsupported-backend, and
     exception behavior remain unchanged.
+  - B-11c24 moves only `_run_aio_detailer_stage` to the existing AiO legacy-
+    generation owner in PR #318 / `2abc54d`. Target planning, SAM3 context,
+    target-leaf execution, callbacks, and metadata access remain call-time root
+    seams; order, chaining, and exception behavior remain unchanged.
+  - B-11c25 moves only `_run_aio_resshift_upscale_stage` to the existing AiO
+    legacy-generation owner in PR #319 / `5e2b335`. Provider lookup, tuple
+    normalization, seed/coercion, and image-size access remain call-time root
+    seams; exact errors and result identity remain unchanged.
+  - B-11c26 moves only `_run_aio_detailer_target` to the existing AiO legacy-
+    generation owner in PR #320. Sampler planning, model patching, SAM3 Detailer,
+    coercion, cleanup, SEGS, and metadata helpers remain call-time root seams;
+    kwargs, cleanup timing, result parsing, and exception behavior remain
+    unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `2abc54d12f96b784f2e63e07400522227f7affe3`
+  `5e2b33504a001351f8151f9042fff254cd3b6120`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c24 are integrated through PR #318. B-11c is
+- Current state: B-11a through B-11c25 are integrated through PR #319. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c25 AiO ResShift leaf Move is tracked by PR #319.
+  the final root shim; B-11c26 AiO Detailer target leaf Move is tracked by PR #320.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 297 in B-11c25
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 298 in B-11c26
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 11 functions, 0 classes, and 26 assigned
-  globals in B-11c25 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 10 functions, 0 classes, and 26 assigned
+  globals in B-11c26 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 285, including
+- root names reached by those canonical runtime resolvers: 287, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -538,6 +538,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
   propagation are unchanged.
 - PR #319 does not move or change the USDU leaf, dispatcher,
   settings/schema/defaults, workflow behavior, or the later #169
+  Contract/Behavior work.
+
+### B-11c26 AiO Detailer target leaf alias
+
+- Canonical owner: `easyuse_anima.aio.legacy_generation` for
+  `_run_aio_detailer_target`.
+- The private root leaf remains a transitional direct alias in relative package
+  and flat import modes. The canonical Detailer coordinator keeps resolving the
+  root name per enabled target to preserve its monkeypatch seam.
+- The existing legacy-generation binder resolves enabled coercion, sampler
+  planning, Spectrum model patching, the SAM3 Detailer class, argument coercion,
+  cleanup, SEGS detection, and sampler metadata conversion at use time. Keyword
+  order/defaults, cleanup timing and exception precedence, result identity and
+  parsing, metadata order, and exception propagation are unchanged.
+- PR #320 does not move or change the Detailer coordinator, SAM3/SEGS helpers,
+  settings/schema/defaults, workflow behavior, the USDU leaf, or the later #169
   Contract/Behavior work.
 
 ### `nodes.py` public node-class surface

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -163,6 +163,132 @@ def _run_aio_detailer_stage(
     }
 
 
+def _run_aio_detailer_target(
+    target_name: str,
+    target_settings: dict[str, Any],
+    image,
+    model,
+    clip,
+    vae,
+    positive,
+    negative,
+    sampler_settings: dict[str, Any],
+    sam3_context: dict[str, Any],
+) -> tuple[Any, dict[str, Any]]:
+    if not _runtime_helper("_as_bool")(
+        target_settings.get("enabled"), False
+    ):
+        return image, {"enabled": False}
+
+    stage_sampler = _runtime_helper("_aio_stage_sampler_settings")(
+        sampler_settings,
+        target_settings,
+        scheduler_default="sgm_uniform",
+    )
+    stage_model = _runtime_helper(
+        "_apply_aio_spectrum_model_patches_for_comfy_sampler"
+    )(
+        model,
+        clip,
+        positive,
+        stage_sampler,
+    )
+    try:
+        result = _runtime_helper("EasyUseAnimaSAM3Detailer")().doit(
+            enabled=True,
+            image=image,
+            ctx_SAM3=sam3_context,
+            detect_prompt=target_settings.get("detect_prompt", target_name),
+            detect_count=_runtime_helper("_as_int")(
+                target_settings.get("detect_count"), 1
+            ),
+            threshold=_runtime_helper("_as_float")(
+                target_settings.get("threshold"), 0.5
+            ),
+            refine_iterations=_runtime_helper("_as_int")(
+                target_settings.get("refine_iterations"), 2
+            ),
+            individual_masks=_runtime_helper("_as_bool")(
+                target_settings.get("individual_masks"), True
+            ),
+            combined=_runtime_helper("_as_bool")(
+                target_settings.get("combined"), False
+            ),
+            crop_factor=_runtime_helper("_as_float")(
+                target_settings.get("crop_factor"), 4.0
+            ),
+            bbox_fill=_runtime_helper("_as_bool")(
+                target_settings.get("bbox_fill"), False
+            ),
+            drop_size=_runtime_helper("_as_int")(
+                target_settings.get("drop_size"), 100
+            ),
+            contour_fill=_runtime_helper("_as_bool")(
+                target_settings.get("contour_fill"), True
+            ),
+            model=stage_model,
+            clip=clip,
+            vae=vae,
+            guide_size=_runtime_helper("_as_int")(
+                target_settings.get("guide_size"), 1024
+            ),
+            guide_size_for=_runtime_helper("_as_bool")(
+                target_settings.get("guide_size_for"), False
+            ),
+            max_size=_runtime_helper("_as_int")(
+                target_settings.get("max_size"), 2048
+            ),
+            seed=stage_sampler["seed"],
+            steps=stage_sampler["steps"],
+            cfg=stage_sampler["cfg"],
+            sampler_name=stage_sampler["sampler_name"],
+            scheduler=stage_sampler["scheduler"],
+            positive=positive,
+            negative=negative,
+            denoise=stage_sampler["denoise"],
+            feather=_runtime_helper("_as_int")(
+                target_settings.get("feather"), 5
+            ),
+            noise_mask=_runtime_helper("_as_bool")(
+                target_settings.get("noise_mask"), True
+            ),
+            force_inpaint=_runtime_helper("_as_bool")(
+                target_settings.get("force_inpaint"), True
+            ),
+            wildcard=str(target_settings.get("wildcard") or ""),
+            cycle=_runtime_helper("_as_int")(
+                target_settings.get("cycle"), 1
+            ),
+            alignment=str(target_settings.get("alignment") or "32"),
+            preserve_conditioning_metadata=True,
+            fail_on_unsupported_opt=False,
+            detailer_hook=None,
+            inpaint_model=_runtime_helper("_as_bool")(
+                target_settings.get("inpaint_model"), False
+            ),
+            noise_mask_feather=_runtime_helper("_as_int")(
+                target_settings.get("noise_mask_feather"), 0
+            ),
+            scheduler_func_opt=None,
+            tiled_encode=_runtime_helper("_as_bool")(
+                target_settings.get("tiled_encode"), False
+            ),
+            tiled_decode=_runtime_helper("_as_bool")(
+                target_settings.get("tiled_decode"), False
+            ),
+        )
+    finally:
+        _runtime_helper("_cleanup_aio_ephemeral_model")(stage_model, model)
+
+    detailed_image = result[0]
+    segs = result[1] if len(result) > 1 else None
+    return detailed_image, {
+        "enabled": True,
+        "detected": _runtime_helper("_segs_has_items")(segs),
+        "sampler": _runtime_helper("_prompt_data_json_safe")(stage_sampler),
+    }
+
+
 def _run_aio_resshift_upscale_stage(
     image,
     sampler_settings: dict[str, Any],

--- a/nodes.py
+++ b/nodes.py
@@ -22,6 +22,7 @@ try:
     from .easyuse_anima.aio.legacy_generation import (
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
         _run_aio_detailer_stage as _run_aio_detailer_stage,
+        _run_aio_detailer_target as _run_aio_detailer_target,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
         _run_aio_resshift_upscale_stage as _run_aio_resshift_upscale_stage,
@@ -580,6 +581,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.aio.legacy_generation import (
         _bind_aio_legacy_generation_runtime as _bind_aio_legacy_generation_runtime,
         _run_aio_detailer_stage as _run_aio_detailer_stage,
+        _run_aio_detailer_target as _run_aio_detailer_target,
         _run_aio_highres_stage as _run_aio_highres_stage,
         _run_aio_legacy_generation as _run_aio_legacy_generation,
         _run_aio_resshift_upscale_stage as _run_aio_resshift_upscale_stage,
@@ -1818,88 +1820,6 @@ def _run_aio_usdu_upscale_stage(
         "tile_target_width": int(tile_plan.get("target_width") or 0),
         "tile_target_height": int(tile_plan.get("target_height") or 0),
         "prompt_mode": str(usdu_settings.get("prompt_mode") or AIO_USDU_PROMPT_FULL),
-        "sampler": _prompt_data_json_safe(stage_sampler),
-    }
-
-
-def _run_aio_detailer_target(
-    target_name: str,
-    target_settings: dict[str, Any],
-    image,
-    model,
-    clip,
-    vae,
-    positive,
-    negative,
-    sampler_settings: dict[str, Any],
-    sam3_context: dict[str, Any],
-) -> tuple[Any, dict[str, Any]]:
-    if not _as_bool(target_settings.get("enabled"), False):
-        return image, {"enabled": False}
-
-    stage_sampler = _aio_stage_sampler_settings(
-        sampler_settings,
-        target_settings,
-        scheduler_default="sgm_uniform",
-    )
-    stage_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
-        model,
-        clip,
-        positive,
-        stage_sampler,
-    )
-    try:
-        result = EasyUseAnimaSAM3Detailer().doit(
-            enabled=True,
-            image=image,
-            ctx_SAM3=sam3_context,
-            detect_prompt=target_settings.get("detect_prompt", target_name),
-            detect_count=_as_int(target_settings.get("detect_count"), 1),
-            threshold=_as_float(target_settings.get("threshold"), 0.5),
-            refine_iterations=_as_int(target_settings.get("refine_iterations"), 2),
-            individual_masks=_as_bool(target_settings.get("individual_masks"), True),
-            combined=_as_bool(target_settings.get("combined"), False),
-            crop_factor=_as_float(target_settings.get("crop_factor"), 4.0),
-            bbox_fill=_as_bool(target_settings.get("bbox_fill"), False),
-            drop_size=_as_int(target_settings.get("drop_size"), 100),
-            contour_fill=_as_bool(target_settings.get("contour_fill"), True),
-            model=stage_model,
-            clip=clip,
-            vae=vae,
-            guide_size=_as_int(target_settings.get("guide_size"), 1024),
-            guide_size_for=_as_bool(target_settings.get("guide_size_for"), False),
-            max_size=_as_int(target_settings.get("max_size"), 2048),
-            seed=stage_sampler["seed"],
-            steps=stage_sampler["steps"],
-            cfg=stage_sampler["cfg"],
-            sampler_name=stage_sampler["sampler_name"],
-            scheduler=stage_sampler["scheduler"],
-            positive=positive,
-            negative=negative,
-            denoise=stage_sampler["denoise"],
-            feather=_as_int(target_settings.get("feather"), 5),
-            noise_mask=_as_bool(target_settings.get("noise_mask"), True),
-            force_inpaint=_as_bool(target_settings.get("force_inpaint"), True),
-            wildcard=str(target_settings.get("wildcard") or ""),
-            cycle=_as_int(target_settings.get("cycle"), 1),
-            alignment=str(target_settings.get("alignment") or "32"),
-            preserve_conditioning_metadata=True,
-            fail_on_unsupported_opt=False,
-            detailer_hook=None,
-            inpaint_model=_as_bool(target_settings.get("inpaint_model"), False),
-            noise_mask_feather=_as_int(target_settings.get("noise_mask_feather"), 0),
-            scheduler_func_opt=None,
-            tiled_encode=_as_bool(target_settings.get("tiled_encode"), False),
-            tiled_decode=_as_bool(target_settings.get("tiled_decode"), False),
-        )
-    finally:
-        _cleanup_aio_ephemeral_model(stage_model, model)
-
-    detailed_image = result[0]
-    segs = result[1] if len(result) > 1 else None
-    return detailed_image, {
-        "enabled": True,
-        "detected": _segs_has_items(segs),
         "sampler": _prompt_data_json_safe(stage_sampler),
     }
 

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14671,6 +14671,37 @@
         "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
+        "alias": "_run_aio_detailer_target",
+        "bound_name": "_run_aio_detailer_target",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_detailer_target",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_run_aio_detailer_target",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
         "alias": "_run_aio_highres_stage",
         "bound_name": "_run_aio_highres_stage",
         "branch_context": [
@@ -14816,7 +14847,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14847,7 +14878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14878,7 +14909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14909,7 +14940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14940,7 +14971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14971,7 +15002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15002,7 +15033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15033,7 +15064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15064,7 +15095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15095,7 +15126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15126,7 +15157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15157,7 +15188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15188,7 +15219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15219,7 +15250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15250,7 +15281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15281,7 +15312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15312,7 +15343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 48,
+        "line": 49,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15343,7 +15374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15374,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 62,
+        "line": 63,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 68,
+        "line": 69,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 83,
+        "line": 84,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 97,
+        "line": 98,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 109,
+        "line": 110,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 121,
+        "line": 122,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 139,
+        "line": 140,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 144,
+        "line": 145,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 151,
+        "line": 152,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 158,
+        "line": 159,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 172,
+        "line": 173,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 172,
+        "line": 173,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 172,
+        "line": 173,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 172,
+        "line": 173,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 172,
+        "line": 173,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 172,
+        "line": 173,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 172,
+        "line": 173,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 190,
+        "line": 191,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 226,
+        "line": 227,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 254,
+        "line": 255,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 270,
+        "line": 271,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 350,
+        "line": 351,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 356,
+        "line": 357,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 356,
+        "line": 357,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 356,
+        "line": 357,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 361,
+        "line": 362,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 367,
+        "line": 368,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 376,
+        "line": 377,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 376,
+        "line": 377,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 376,
+        "line": 377,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 387,
+        "line": 388,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 400,
+        "line": 401,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 408,
+        "line": 409,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 419,
+        "line": 420,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 425,
+        "line": 426,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 426,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 426,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 426,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 426,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 433,
+        "line": 434,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 437,
+        "line": 438,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 441,
+        "line": 442,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 446,
+        "line": 447,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 453,
+        "line": 454,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 453,
+        "line": 454,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 453,
+        "line": 454,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 458,
+        "line": 459,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 458,
+        "line": 459,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 458,
+        "line": 459,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 476,
+        "line": 477,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 476,
+        "line": 477,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 476,
+        "line": 477,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 476,
+        "line": 477,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 476,
+        "line": 477,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 499,
+        "line": 500,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 503,
+        "line": 504,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 508,
+        "line": 509,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 525,
+        "line": 526,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 535,
+        "line": 536,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 539,
+        "line": 540,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 546,
+        "line": 547,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24302,7 +24333,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24333,7 +24364,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24364,7 +24395,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24395,7 +24426,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24414,7 +24445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24429,7 +24460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24448,7 +24479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24463,7 +24494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24482,7 +24513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24497,7 +24528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24516,7 +24547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24531,7 +24562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24550,7 +24581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24565,7 +24596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24584,7 +24615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24599,7 +24630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24618,7 +24649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24633,7 +24664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24652,7 +24683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24667,7 +24698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24686,7 +24717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24701,7 +24732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24720,7 +24751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24735,8 +24766,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_run_aio_detailer_stage",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_detailer_target",
+        "bound_name": "_run_aio_detailer_target",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 569,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_detailer_target",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
+        "kind": "static_from",
+        "line": 581,
+        "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
         "role": "compatibility_fallback",
@@ -24754,7 +24819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24769,7 +24834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24788,7 +24853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24803,7 +24868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24822,7 +24887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24837,7 +24902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24856,7 +24921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24871,7 +24936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24890,7 +24955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24905,7 +24970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24924,7 +24989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24939,7 +25004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24958,7 +25023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -24973,7 +25038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24992,7 +25057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25007,7 +25072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25026,7 +25091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25041,7 +25106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25060,7 +25125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25075,7 +25140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25094,7 +25159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25109,7 +25174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25128,7 +25193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25143,7 +25208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25162,7 +25227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25177,7 +25242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25196,7 +25261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25211,7 +25276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25230,7 +25295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25245,7 +25310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25264,7 +25329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25279,7 +25344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25298,7 +25363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25313,7 +25378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25332,7 +25397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25347,7 +25412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25366,7 +25431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25381,7 +25446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25400,7 +25465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25415,7 +25480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25434,7 +25499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25449,7 +25514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25468,7 +25533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25483,7 +25548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 609,
+        "line": 611,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25502,7 +25567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25517,7 +25582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 609,
+        "line": 611,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25536,7 +25601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25551,7 +25616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 611,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25570,7 +25635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25585,7 +25650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25604,7 +25669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25619,7 +25684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25638,7 +25703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25653,7 +25718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25672,7 +25737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25687,7 +25752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25706,7 +25771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25721,7 +25786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25740,7 +25805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25755,7 +25820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25774,7 +25839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25789,7 +25854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25808,7 +25873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25823,7 +25888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25842,7 +25907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25857,7 +25922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25876,7 +25941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25891,7 +25956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25910,7 +25975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25925,7 +25990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25944,7 +26009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25959,7 +26024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25978,7 +26043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -25993,7 +26058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26012,7 +26077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26027,7 +26092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26046,7 +26111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26061,7 +26126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26080,7 +26145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26095,7 +26160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26114,7 +26179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26129,7 +26194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26148,7 +26213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26163,7 +26228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26182,7 +26247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26197,7 +26262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26216,7 +26281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26231,7 +26296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26250,7 +26315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26265,7 +26330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26284,7 +26349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26299,7 +26364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26318,7 +26383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26333,7 +26398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26352,7 +26417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26367,7 +26432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26386,7 +26451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26401,7 +26466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26420,7 +26485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26435,7 +26500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26454,7 +26519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26469,7 +26534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26488,7 +26553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26503,7 +26568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26522,7 +26587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26537,7 +26602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26556,7 +26621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26571,7 +26636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26590,7 +26655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26605,7 +26670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26624,7 +26689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26639,7 +26704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26658,7 +26723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26673,7 +26738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26692,7 +26757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26707,7 +26772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26726,7 +26791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26741,7 +26806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26760,7 +26825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26775,7 +26840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26794,7 +26859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26809,7 +26874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26828,7 +26893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26843,7 +26908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26862,7 +26927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26877,7 +26942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26896,7 +26961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26911,7 +26976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26930,7 +26995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26945,7 +27010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26964,7 +27029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -26979,7 +27044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26998,7 +27063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27013,7 +27078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27032,7 +27097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27047,7 +27112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27066,7 +27131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27081,7 +27146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27100,7 +27165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27115,7 +27180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27134,7 +27199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27149,7 +27214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27168,7 +27233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27183,7 +27248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27202,7 +27267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27217,7 +27282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27236,7 +27301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27251,7 +27316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27270,7 +27335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27285,7 +27350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27304,7 +27369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27319,7 +27384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27338,7 +27403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27353,7 +27418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27372,7 +27437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27387,7 +27452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27406,7 +27471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27421,7 +27486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27440,7 +27505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27455,7 +27520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27474,7 +27539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27489,7 +27554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27508,7 +27573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27523,7 +27588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27542,7 +27607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27557,7 +27622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27576,7 +27641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27591,7 +27656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27610,7 +27675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27625,7 +27690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27644,7 +27709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27659,7 +27724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27678,7 +27743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27693,7 +27758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27712,7 +27777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27727,7 +27792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27746,7 +27811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27761,7 +27826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27780,7 +27845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27795,7 +27860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27814,7 +27879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27829,7 +27894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27848,7 +27913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27863,7 +27928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27882,7 +27947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27897,7 +27962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27916,7 +27981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27931,7 +27996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27950,7 +28015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27965,7 +28030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -27984,7 +28049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -27999,7 +28064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28018,7 +28083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28033,7 +28098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28052,7 +28117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28067,7 +28132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28086,7 +28151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28101,7 +28166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28120,7 +28185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28135,7 +28200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28154,7 +28219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28169,7 +28234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28188,7 +28253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28203,7 +28268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 709,
+        "line": 711,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28222,7 +28287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28237,7 +28302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28256,7 +28321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28271,7 +28336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28290,7 +28355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28305,7 +28370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28324,7 +28389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28339,7 +28404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28358,7 +28423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28373,7 +28438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28392,7 +28457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28407,7 +28472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28426,7 +28491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28441,7 +28506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28460,7 +28525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28475,7 +28540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28494,7 +28559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28509,7 +28574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28528,7 +28593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28543,7 +28608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28562,7 +28627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28577,7 +28642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28596,7 +28661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28611,7 +28676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28630,7 +28695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28645,7 +28710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28664,7 +28729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28679,7 +28744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28698,7 +28763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28713,7 +28778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28732,7 +28797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28747,7 +28812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28766,7 +28831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28781,7 +28846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28800,7 +28865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28815,7 +28880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28834,7 +28899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28849,7 +28914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28868,7 +28933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28883,7 +28948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28902,7 +28967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28917,7 +28982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28936,7 +29001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28951,7 +29016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -28970,7 +29035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -28985,7 +29050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29004,7 +29069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29019,7 +29084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29038,7 +29103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29053,7 +29118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29072,7 +29137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29087,7 +29152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29106,7 +29171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29121,7 +29186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29140,7 +29205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29155,7 +29220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29174,7 +29239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29189,7 +29254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29208,7 +29273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29223,7 +29288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29242,7 +29307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29257,7 +29322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29276,7 +29341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29291,7 +29356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29310,7 +29375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29325,7 +29390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29344,7 +29409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29359,7 +29424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29378,7 +29443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29393,7 +29458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29412,7 +29477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29427,7 +29492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29446,7 +29511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29461,7 +29526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29480,7 +29545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29495,7 +29560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29514,7 +29579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29529,7 +29594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29548,7 +29613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29563,7 +29628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29582,7 +29647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29597,7 +29662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29616,7 +29681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29631,7 +29696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29650,7 +29715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29665,7 +29730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29684,7 +29749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29699,7 +29764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29718,7 +29783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29733,7 +29798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29752,7 +29817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29767,7 +29832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29786,7 +29851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29801,7 +29866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29820,7 +29885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29835,7 +29900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29854,7 +29919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29869,7 +29934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29888,7 +29953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29903,7 +29968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29922,7 +29987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29937,7 +30002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29956,7 +30021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -29971,7 +30036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29990,7 +30055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30005,7 +30070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30024,7 +30089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30039,7 +30104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30058,7 +30123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30073,7 +30138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30092,7 +30157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30107,7 +30172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30126,7 +30191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30141,7 +30206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30160,7 +30225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30175,7 +30240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30194,7 +30259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30209,7 +30274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30228,7 +30293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30243,7 +30308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30262,7 +30327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30277,7 +30342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30296,7 +30361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30311,7 +30376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30330,7 +30395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30345,7 +30410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30364,7 +30429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30379,7 +30444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30398,7 +30463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30413,7 +30478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30432,7 +30497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30447,7 +30512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30466,7 +30531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30481,7 +30546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30500,7 +30565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30515,7 +30580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30534,7 +30599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30549,7 +30614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30568,7 +30633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30583,7 +30648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30602,7 +30667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30617,7 +30682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30636,7 +30701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30651,7 +30716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30670,7 +30735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30685,7 +30750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30704,7 +30769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30719,7 +30784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30738,7 +30803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30753,7 +30818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30772,7 +30837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30787,7 +30852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30806,7 +30871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30821,7 +30886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30840,7 +30905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30855,7 +30920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30874,7 +30939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30889,7 +30954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30908,7 +30973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30923,7 +30988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30942,7 +31007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30957,7 +31022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30976,7 +31041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -30991,7 +31056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31010,7 +31075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31025,7 +31090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31044,7 +31109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31059,7 +31124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31078,7 +31143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31093,7 +31158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31112,7 +31177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31127,7 +31192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31146,7 +31211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31161,7 +31226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31180,7 +31245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31195,7 +31260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31214,7 +31279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31229,7 +31294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31248,7 +31313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31263,7 +31328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31282,7 +31347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31297,7 +31362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31316,7 +31381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31331,7 +31396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31350,7 +31415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31365,7 +31430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31384,7 +31449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31399,7 +31464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31418,7 +31483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31433,7 +31498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31452,7 +31517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31467,7 +31532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31486,7 +31551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31501,7 +31566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31520,7 +31585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31535,7 +31600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31554,7 +31619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31569,7 +31634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31588,7 +31653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31603,7 +31668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31622,7 +31687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31637,7 +31702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31656,7 +31721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31671,7 +31736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31690,7 +31755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31705,7 +31770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31724,7 +31789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31739,7 +31804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31758,7 +31823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31773,7 +31838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31792,7 +31857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31807,7 +31872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31826,7 +31891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31841,7 +31906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31860,7 +31925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31875,7 +31940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31894,7 +31959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31909,7 +31974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31928,7 +31993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31943,7 +32008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31962,7 +32027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -31977,7 +32042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31996,7 +32061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32011,7 +32076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32030,7 +32095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32045,7 +32110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32064,7 +32129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32079,7 +32144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32098,7 +32163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32113,7 +32178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32132,7 +32197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32147,7 +32212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32166,7 +32231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32181,7 +32246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32200,7 +32265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32215,7 +32280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32234,7 +32299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32249,7 +32314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32268,7 +32333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32283,7 +32348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32302,7 +32367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32317,7 +32382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32336,7 +32401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32351,7 +32416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32370,7 +32435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32385,7 +32450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32404,7 +32469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32419,7 +32484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32438,7 +32503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32453,7 +32518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32472,7 +32537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32487,7 +32552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32506,7 +32571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32521,7 +32586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32540,7 +32605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32555,7 +32620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32574,7 +32639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32589,7 +32654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32608,7 +32673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32623,7 +32688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32642,7 +32707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32657,7 +32722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32676,7 +32741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32691,7 +32756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32710,7 +32775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32725,7 +32790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32744,7 +32809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32759,7 +32824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32778,7 +32843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32793,7 +32858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32812,7 +32877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32827,7 +32892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32846,7 +32911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32861,7 +32926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32880,7 +32945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32895,7 +32960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32914,7 +32979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32929,7 +32994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32948,7 +33013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32963,7 +33028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32982,7 +33047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -32997,7 +33062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33016,7 +33081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33031,7 +33096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33050,7 +33115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33065,7 +33130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33084,7 +33149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33099,7 +33164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33118,7 +33183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33133,7 +33198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33152,7 +33217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33167,7 +33232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1013,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33186,7 +33251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33201,7 +33266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1013,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33220,7 +33285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33235,7 +33300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1013,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33254,7 +33319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33269,7 +33334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33288,7 +33353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33303,7 +33368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33322,7 +33387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33337,7 +33402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33356,7 +33421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33371,7 +33436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33390,7 +33455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33405,7 +33470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33424,7 +33489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33439,7 +33504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33458,7 +33523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33473,7 +33538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33492,7 +33557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33507,7 +33572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33526,7 +33591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33541,7 +33606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33560,7 +33625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33575,7 +33640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33594,7 +33659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33609,7 +33674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33628,7 +33693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33643,7 +33708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33662,7 +33727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33677,7 +33742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33696,7 +33761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33711,7 +33776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33730,7 +33795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33745,7 +33810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33764,7 +33829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33779,7 +33844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33798,7 +33863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33813,7 +33878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33832,7 +33897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33847,7 +33912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33866,7 +33931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33881,7 +33946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33900,7 +33965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33915,7 +33980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33934,7 +33999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33949,7 +34014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33968,7 +34033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -33983,7 +34048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34002,7 +34067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34017,7 +34082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34036,7 +34101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34051,7 +34116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34070,7 +34135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34085,7 +34150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34104,7 +34169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34119,7 +34184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34138,7 +34203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34153,7 +34218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34172,7 +34237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34187,7 +34252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34206,7 +34271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34221,7 +34286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34240,7 +34305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34255,7 +34320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34274,7 +34339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34289,7 +34354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34308,7 +34373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34323,7 +34388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34342,7 +34407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34357,7 +34422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34376,7 +34441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34391,7 +34456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34410,7 +34475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34425,7 +34490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34444,7 +34509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34459,7 +34524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34478,7 +34543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34493,7 +34558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34512,7 +34577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34527,7 +34592,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34546,7 +34611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34561,7 +34626,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34580,7 +34645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34595,7 +34660,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1100,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34614,7 +34679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34629,7 +34694,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34648,7 +34713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34663,7 +34728,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34682,7 +34747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34697,7 +34762,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34716,7 +34781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34731,7 +34796,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1106,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34750,7 +34815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34765,7 +34830,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1106,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34784,7 +34849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34799,7 +34864,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34818,7 +34883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34833,7 +34898,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34852,7 +34917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34867,7 +34932,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34886,7 +34951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34901,7 +34966,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34920,7 +34985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34935,7 +35000,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34954,7 +35019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -34969,7 +35034,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34988,7 +35053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35003,7 +35068,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35022,7 +35087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35037,7 +35102,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35056,7 +35121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35071,7 +35136,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35090,7 +35155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35105,7 +35170,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35124,7 +35189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35139,7 +35204,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35158,7 +35223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35173,7 +35238,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35192,7 +35257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35207,7 +35272,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35226,7 +35291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35241,7 +35306,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35260,7 +35325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35275,7 +35340,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35294,7 +35359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35309,7 +35374,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35328,7 +35393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35343,7 +35408,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35362,7 +35427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35377,7 +35442,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35396,7 +35461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -35411,7 +35476,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35429,7 +35494,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1622
+            "line": 1624
           }
         ],
         "classification": "external",
@@ -35437,7 +35502,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1623,
+        "line": 1625,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35454,7 +35519,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1630
+            "line": 1632
           }
         ],
         "classification": "external",
@@ -35462,7 +35527,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1631,
+        "line": 1633,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35479,7 +35544,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1638
+            "line": 1640
           }
         ],
         "classification": "external",
@@ -35487,7 +35552,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1639,
+        "line": 1641,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38471,13 +38536,13 @@
       },
       {
         "is_package": false,
-        "loc": 682,
+        "loc": 808,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "9ae2e782c541ad32e8d684f37909cedcffca4a84",
+        "normalized_git_blob_sha1": "db4a8ac160e013ac5849eefd41317ad43121b4a3",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 7,
+          "function_count": 8,
           "global_count": 3
         }
       },
@@ -39119,13 +39184,13 @@
       },
       {
         "is_package": false,
-        "loc": 2092,
+        "loc": 2012,
         "module": "nodes",
-        "normalized_git_blob_sha1": "3586d54ce9dc559eaa11a0f1233311e42c6e26ec",
+        "normalized_git_blob_sha1": "8d3694386c24bf8933de274d8c37290416fac0a5",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 11,
+          "function_count": 10,
           "global_count": 26
         }
       },
@@ -40485,7 +40550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40494,7 +40559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40508,7 +40573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40517,7 +40582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40531,7 +40596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40540,7 +40605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40554,7 +40619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40563,7 +40628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40577,7 +40642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40586,7 +40651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40600,7 +40665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40609,7 +40674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40623,7 +40688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40632,7 +40697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40646,7 +40711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40655,7 +40720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40669,7 +40734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40678,7 +40743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40692,7 +40757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40701,7 +40766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40715,7 +40780,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
+        "kind": "static_from",
+        "line": 581,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40724,7 +40812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40738,7 +40826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40747,7 +40835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40761,7 +40849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40770,7 +40858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40784,7 +40872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40793,7 +40881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40807,7 +40895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40816,7 +40904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40830,7 +40918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40839,7 +40927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40853,7 +40941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40862,7 +40950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40876,7 +40964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40885,7 +40973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40899,7 +40987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40908,7 +40996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40922,7 +41010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40931,7 +41019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40945,7 +41033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40954,7 +41042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40968,7 +41056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -40977,7 +41065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40991,7 +41079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41000,7 +41088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41014,7 +41102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41023,7 +41111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41037,7 +41125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41046,7 +41134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41060,7 +41148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41069,7 +41157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41083,7 +41171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41092,7 +41180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41106,7 +41194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41115,7 +41203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41129,7 +41217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41138,7 +41226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41152,7 +41240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41161,7 +41249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 588,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41175,7 +41263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41184,7 +41272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 606,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41198,7 +41286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41207,7 +41295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 609,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41221,7 +41309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41230,7 +41318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 609,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41244,7 +41332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41253,7 +41341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41267,7 +41355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41276,7 +41364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41290,7 +41378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41299,7 +41387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41313,7 +41401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41322,7 +41410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41336,7 +41424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41345,7 +41433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 614,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41359,7 +41447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41368,7 +41456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41382,7 +41470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41391,7 +41479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41405,7 +41493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41414,7 +41502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41428,7 +41516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41437,7 +41525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41451,7 +41539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41460,7 +41548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41474,7 +41562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41483,7 +41571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41497,7 +41585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41506,7 +41594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41520,7 +41608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41529,7 +41617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41543,7 +41631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41552,7 +41640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41566,7 +41654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41575,7 +41663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41589,7 +41677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41598,7 +41686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41612,7 +41700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41621,7 +41709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41635,7 +41723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41644,7 +41732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41658,7 +41746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41667,7 +41755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41681,7 +41769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41690,7 +41778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41704,7 +41792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41713,7 +41801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41727,7 +41815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41736,7 +41824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 626,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41750,7 +41838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41759,7 +41847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41773,7 +41861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41782,7 +41870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41796,7 +41884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41805,7 +41893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41819,7 +41907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41828,7 +41916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41842,7 +41930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41851,7 +41939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41865,7 +41953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41874,7 +41962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41888,7 +41976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41897,7 +41985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41911,7 +41999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41920,7 +42008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41934,7 +42022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41943,7 +42031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41957,7 +42045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41966,7 +42054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41980,7 +42068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -41989,7 +42077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42003,7 +42091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42012,7 +42100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 641,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42026,7 +42114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42035,7 +42123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42049,7 +42137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42058,7 +42146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42072,7 +42160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42081,7 +42169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42095,7 +42183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42104,7 +42192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42118,7 +42206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42127,7 +42215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42141,7 +42229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42150,7 +42238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42164,7 +42252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42173,7 +42261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42187,7 +42275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42196,7 +42284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42210,7 +42298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42219,7 +42307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42233,7 +42321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42242,7 +42330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 655,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42256,7 +42344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42265,7 +42353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42279,7 +42367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42288,7 +42376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42302,7 +42390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42311,7 +42399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42325,7 +42413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42334,7 +42422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42348,7 +42436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42357,7 +42445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42371,7 +42459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42380,7 +42468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42394,7 +42482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42403,7 +42491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42417,7 +42505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42426,7 +42514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42440,7 +42528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42449,7 +42537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42463,7 +42551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42472,7 +42560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 667,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42486,7 +42574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42495,7 +42583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42509,7 +42597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42518,7 +42606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42532,7 +42620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42541,7 +42629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42555,7 +42643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42564,7 +42652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42578,7 +42666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42587,7 +42675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42601,7 +42689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42610,7 +42698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42624,7 +42712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42633,7 +42721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42647,7 +42735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42656,7 +42744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42670,7 +42758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42679,7 +42767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42693,7 +42781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42702,7 +42790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42716,7 +42804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42725,7 +42813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42739,7 +42827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42748,7 +42836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42762,7 +42850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42771,7 +42859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42785,7 +42873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42794,7 +42882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42808,7 +42896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42817,7 +42905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42831,7 +42919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42840,7 +42928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 679,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42854,7 +42942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42863,7 +42951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42877,7 +42965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42886,7 +42974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42900,7 +42988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42909,7 +42997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 697,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42923,7 +43011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42932,7 +43020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42946,7 +43034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42955,7 +43043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42969,7 +43057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -42978,7 +43066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42992,7 +43080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43001,7 +43089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43015,7 +43103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43024,7 +43112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 702,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43038,7 +43126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43047,7 +43135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 709,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43061,7 +43149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43070,7 +43158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43084,7 +43172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43093,7 +43181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43107,7 +43195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43116,7 +43204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43130,7 +43218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43139,7 +43227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 710,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43153,7 +43241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43162,7 +43250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43176,7 +43264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43185,7 +43273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43199,7 +43287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43208,7 +43296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43222,7 +43310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43231,7 +43319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43245,7 +43333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43254,7 +43342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43268,7 +43356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43277,7 +43365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43291,7 +43379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43300,7 +43388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43314,7 +43402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43323,7 +43411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43337,7 +43425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43346,7 +43434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43360,7 +43448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43369,7 +43457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 716,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43383,7 +43471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43392,7 +43480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43406,7 +43494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43415,7 +43503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43429,7 +43517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43438,7 +43526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43452,7 +43540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43461,7 +43549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43475,7 +43563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43484,7 +43572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43498,7 +43586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43507,7 +43595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43521,7 +43609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43530,7 +43618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 730,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43544,7 +43632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43553,7 +43641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43567,7 +43655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43576,7 +43664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43590,7 +43678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43599,7 +43687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43613,7 +43701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43622,7 +43710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43636,7 +43724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43645,7 +43733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43659,7 +43747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43668,7 +43756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43682,7 +43770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43691,7 +43779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43705,7 +43793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43714,7 +43802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43728,7 +43816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43737,7 +43825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43751,7 +43839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43760,7 +43848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43774,7 +43862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43783,7 +43871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43797,7 +43885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43806,7 +43894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43820,7 +43908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43829,7 +43917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43843,7 +43931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43852,7 +43940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43866,7 +43954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43875,7 +43963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43889,7 +43977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43898,7 +43986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43912,7 +44000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43921,7 +44009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43935,7 +44023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43944,7 +44032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43958,7 +44046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43967,7 +44055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43981,7 +44069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -43990,7 +44078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44004,7 +44092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44013,7 +44101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44027,7 +44115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44036,7 +44124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 748,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44050,7 +44138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44059,7 +44147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44073,7 +44161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44082,7 +44170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44096,7 +44184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44105,7 +44193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44119,7 +44207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44128,7 +44216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44142,7 +44230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44151,7 +44239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44165,7 +44253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44174,7 +44262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44188,7 +44276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44197,7 +44285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44211,7 +44299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44220,7 +44308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44234,7 +44322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44243,7 +44331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44257,7 +44345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44266,7 +44354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44280,7 +44368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44289,7 +44377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44303,7 +44391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44312,7 +44400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44326,7 +44414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44335,7 +44423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44349,7 +44437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44358,7 +44446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 784,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44372,7 +44460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44381,7 +44469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44395,7 +44483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44404,7 +44492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44418,7 +44506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44427,7 +44515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44441,7 +44529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44450,7 +44538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44464,7 +44552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44473,7 +44561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44487,7 +44575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44496,7 +44584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44510,7 +44598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44519,7 +44607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44533,7 +44621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44542,7 +44630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44556,7 +44644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44565,7 +44653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 812,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44579,7 +44667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44588,7 +44676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44602,7 +44690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44611,7 +44699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44625,7 +44713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44634,7 +44722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44648,7 +44736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44657,7 +44745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44671,7 +44759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44680,7 +44768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44694,7 +44782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44703,7 +44791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44717,7 +44805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44726,7 +44814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44740,7 +44828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44749,7 +44837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44763,7 +44851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44772,7 +44860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44786,7 +44874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44795,7 +44883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44809,7 +44897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44818,7 +44906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44832,7 +44920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44841,7 +44929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44855,7 +44943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44864,7 +44952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44878,7 +44966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44887,7 +44975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44901,7 +44989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44910,7 +44998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44924,7 +45012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44933,7 +45021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44947,7 +45035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44956,7 +45044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44970,7 +45058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -44979,7 +45067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44993,7 +45081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45002,7 +45090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45016,7 +45104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45025,7 +45113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45039,7 +45127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45048,7 +45136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45062,7 +45150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45071,7 +45159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45085,7 +45173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45094,7 +45182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45108,7 +45196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45117,7 +45205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45131,7 +45219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45140,7 +45228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 828,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45154,7 +45242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45163,7 +45251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45177,7 +45265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45186,7 +45274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45200,7 +45288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45209,7 +45297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45223,7 +45311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45232,7 +45320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 908,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45246,7 +45334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45255,7 +45343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45269,7 +45357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45278,7 +45366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45292,7 +45380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45301,7 +45389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 914,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45315,7 +45403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45324,7 +45412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45338,7 +45426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45347,7 +45435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45361,7 +45449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45370,7 +45458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 919,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45384,7 +45472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45393,7 +45481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45407,7 +45495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45416,7 +45504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45430,7 +45518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45439,7 +45527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45453,7 +45541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45462,7 +45550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45476,7 +45564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45485,7 +45573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45499,7 +45587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45508,7 +45596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45522,7 +45610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45531,7 +45619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 925,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45545,7 +45633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45554,7 +45642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45568,7 +45656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45577,7 +45665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45591,7 +45679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45600,7 +45688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 934,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45614,7 +45702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45623,7 +45711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45637,7 +45725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45646,7 +45734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45660,7 +45748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45669,7 +45757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45683,7 +45771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45692,7 +45780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 945,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45706,7 +45794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45715,7 +45803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45729,7 +45817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45738,7 +45826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 958,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45752,7 +45840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45761,7 +45849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45775,7 +45863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45784,7 +45872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45798,7 +45886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45807,7 +45895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45821,7 +45909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45830,7 +45918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45844,7 +45932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45853,7 +45941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45867,7 +45955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45876,7 +45964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45890,7 +45978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45899,7 +45987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45913,7 +46001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45922,7 +46010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 966,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45936,7 +46024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45945,7 +46033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45959,7 +46047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45968,7 +46056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45982,7 +46070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -45991,7 +46079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46005,7 +46093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46014,7 +46102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 977,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46028,7 +46116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46037,7 +46125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46051,7 +46139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46060,7 +46148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46074,7 +46162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46083,7 +46171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46097,7 +46185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46106,7 +46194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46120,7 +46208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46129,7 +46217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 983,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46143,7 +46231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46152,7 +46240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46166,7 +46254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46175,7 +46263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 991,
+        "line": 993,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46189,7 +46277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46198,7 +46286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46212,7 +46300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46221,7 +46309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46235,7 +46323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46244,7 +46332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46258,7 +46346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46267,7 +46355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46281,7 +46369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46290,7 +46378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46304,7 +46392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46313,7 +46401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46327,7 +46415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46336,7 +46424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46350,7 +46438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46359,7 +46447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46373,7 +46461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46382,7 +46470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46396,7 +46484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46405,7 +46493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46419,7 +46507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46428,7 +46516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46442,7 +46530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46451,7 +46539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46465,7 +46553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46474,7 +46562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46488,7 +46576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46497,7 +46585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46511,7 +46599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46520,7 +46608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46534,7 +46622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46543,7 +46631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46557,7 +46645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46566,7 +46654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46580,7 +46668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46589,7 +46677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46603,7 +46691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46612,7 +46700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46626,7 +46714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46635,7 +46723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1034,
+        "line": 1036,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46649,7 +46737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46658,7 +46746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46672,7 +46760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46681,7 +46769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1057,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46695,7 +46783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46704,7 +46792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46718,7 +46806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46727,7 +46815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46741,7 +46829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46750,7 +46838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46764,7 +46852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46773,7 +46861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46787,7 +46875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46796,7 +46884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46810,7 +46898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46819,7 +46907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46833,7 +46921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46842,7 +46930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46856,7 +46944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46865,7 +46953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46879,7 +46967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46888,7 +46976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46902,7 +46990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46911,7 +46999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46925,7 +47013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46934,7 +47022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46948,7 +47036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46957,7 +47045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46971,7 +47059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -46980,7 +47068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46994,7 +47082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47003,7 +47091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47017,7 +47105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47026,7 +47114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47040,7 +47128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47049,7 +47137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47063,7 +47151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47072,7 +47160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47086,7 +47174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47095,7 +47183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47109,7 +47197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47118,7 +47206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47132,7 +47220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47141,7 +47229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47155,7 +47243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47164,7 +47252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47178,7 +47266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47187,7 +47275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47201,7 +47289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47210,7 +47298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47224,7 +47312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47233,7 +47321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47247,7 +47335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47256,7 +47344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1083,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47270,7 +47358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47279,7 +47367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47293,7 +47381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47302,7 +47390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1093,
+        "line": 1095,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47316,7 +47404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47325,7 +47413,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47339,7 +47427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47348,7 +47436,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47362,7 +47450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47371,7 +47459,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47385,7 +47473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47394,7 +47482,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47408,7 +47496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47417,7 +47505,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47431,7 +47519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47440,7 +47528,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47454,7 +47542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47463,7 +47551,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47477,7 +47565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47486,7 +47574,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47500,7 +47588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47509,7 +47597,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47523,7 +47611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47532,7 +47620,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47546,7 +47634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47555,7 +47643,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47569,7 +47657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47578,7 +47666,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47592,7 +47680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47601,7 +47689,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47615,7 +47703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47624,7 +47712,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47638,7 +47726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47647,7 +47735,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47661,7 +47749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47670,7 +47758,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47684,7 +47772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47693,7 +47781,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47707,7 +47795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47716,7 +47804,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47730,7 +47818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47739,7 +47827,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47753,7 +47841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47762,7 +47850,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47776,7 +47864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47785,7 +47873,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47799,7 +47887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47808,7 +47896,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47822,7 +47910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47831,7 +47919,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47845,7 +47933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47854,7 +47942,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47868,7 +47956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47877,7 +47965,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47891,7 +47979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47900,7 +47988,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47914,7 +48002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 569,
             "kind": "try",
             "line": 10
           }
@@ -47923,7 +48011,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51750,14 +51838,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1622
+            "line": 1624
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1623,
+        "line": 1625,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51769,14 +51857,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1630
+            "line": 1632
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1631,
+        "line": 1633,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51788,14 +51876,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1638
+            "line": 1640
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1639,
+        "line": 1641,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53170,14 +53258,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1622
+            "line": 1624
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1623,
+        "line": 1625,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53189,14 +53277,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1630
+            "line": 1632
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1631,
+        "line": 1633,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53208,14 +53296,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1638
+            "line": 1640
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1639,
+        "line": 1641,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54676,7 +54764,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1127,
+        "line": 1129,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54685,7 +54773,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1988,
+        "line": 1908,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54694,7 +54782,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1991,
+        "line": 1911,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54703,7 +54791,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1994,
+        "line": 1914,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54712,7 +54800,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1997,
+        "line": 1917,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54721,7 +54809,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2000,
+        "line": 1920,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54730,7 +54818,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2003,
+        "line": 1923,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54739,7 +54827,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2006,
+        "line": 1926,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54748,7 +54836,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2009,
+        "line": 1929,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54757,7 +54845,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2012,
+        "line": 1932,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54766,7 +54854,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2015,
+        "line": 1935,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54775,7 +54863,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2018,
+        "line": 1938,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54784,7 +54872,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2021,
+        "line": 1941,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54793,7 +54881,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2024,
+        "line": 1944,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54802,7 +54890,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2027,
+        "line": 1947,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54811,7 +54899,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2030,
+        "line": 1950,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54820,7 +54908,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2033,
+        "line": 1953,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54829,7 +54917,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2037,
+        "line": 1957,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54838,7 +54926,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2040,
+        "line": 1960,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54847,7 +54935,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2044,
+        "line": 1964,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54856,7 +54944,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2047,
+        "line": 1967,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54865,7 +54953,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2051,
+        "line": 1971,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54874,7 +54962,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2054,
+        "line": 1974,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54883,7 +54971,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2057,
+        "line": 1977,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54892,7 +54980,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2060,
+        "line": 1980,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54901,7 +54989,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2063,
+        "line": 1983,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54910,7 +54998,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2066,
+        "line": 1986,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54919,7 +55007,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2073,
+        "line": 1993,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54928,7 +55016,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2079,
+        "line": 1999,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54937,7 +55025,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2084,
+        "line": 2004,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54946,7 +55034,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2088,
+        "line": 2008,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55460,13 +55548,13 @@
       },
       {
         "kind": "dict",
-        "line": 1189,
+        "line": 1191,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1178,
+        "line": 1180,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "2abc54d12f96b784f2e63e07400522227f7affe3",
+    "base_commit": "5e2b33504a001351f8151f9042fff254cd3b6120",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -55,7 +55,8 @@
       "B-11c22",
       "B-11c23",
       "B-11c24",
-      "B-11c25"
+      "B-11c25",
+      "B-11c26"
     ]
   },
   "enums": {
@@ -90,11 +91,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 297,
+    "nodes_canonical_bindings": 298,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 11,
+    "root_residual_functions": 10,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -311,6 +312,9 @@
     ],
     "EasyUseAnimaNAIARandomPrompt": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
+    ],
+    "EasyUseAnimaSAM3Detailer": [
+      "easyuse_anima.aio.legacy_generation"
     ],
     "IMAGE_SCALE_MULTIPLES": [
       "easyuse_anima.aio.generation_normalization"
@@ -559,6 +563,7 @@
     ],
     "_as_float": [
       "easyuse_anima.aio.generation_normalization",
+      "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.aio.model_preparation",
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.postprocess",
@@ -1072,6 +1077,9 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_save_image_with_image_saver": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
+    "_segs_has_items": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_select_profile_values": [
@@ -2120,6 +2128,7 @@
       "symbols": {
         "_bind_aio_legacy_generation_runtime": "_bind_aio_legacy_generation_runtime",
         "_run_aio_detailer_stage": "_run_aio_detailer_stage",
+        "_run_aio_detailer_target": "_run_aio_detailer_target",
         "_run_aio_highres_stage": "_run_aio_highres_stage",
         "_run_aio_legacy_generation": "_run_aio_legacy_generation",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
@@ -3495,10 +3504,12 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "historical SAM3 convenience-node compatibility"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "docs/version-plans/0.1.6-Detailer.md"
       ],
       "removal_gates": [
@@ -4205,7 +4216,6 @@
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class",
         "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
-        "_run_aio_detailer_target": "_run_aio_detailer_target",
         "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
       },
       "classification": "transitional_private_seam",

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -41,6 +41,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             legacy_generation._run_aio_detailer_stage,
         )
         self.assertIs(
+            nodes._run_aio_detailer_target,
+            legacy_generation._run_aio_detailer_target,
+        )
+        self.assertIs(
             nodes._run_aio_highres_stage,
             legacy_generation._run_aio_highres_stage,
         )
@@ -68,6 +72,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             self.assertIs(
                 package_nodes._run_aio_detailer_stage,
                 canonical_module._run_aio_detailer_stage,
+            )
+            self.assertIs(
+                package_nodes._run_aio_detailer_target,
+                canonical_module._run_aio_detailer_target,
             )
             self.assertIs(
                 package_nodes._run_aio_highres_stage,
@@ -699,6 +707,389 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         )
         self.assertNotIn("target:face", callback_trace)
         self.assertNotIn("context_value", callback_trace)
+
+    def test_detailer_target_disabled_short_circuits_after_as_bool(self):
+        trace: list[str] = []
+        image = object()
+
+        def resolve(name):
+            trace.append(f"resolve:{name}")
+            if name == "_as_bool":
+                return lambda value, default: trace.append("call:_as_bool") or False
+            self.fail(f"disabled Detailer target resolved unexpected helper: {name}")
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            result = nodes._run_aio_detailer_target(
+                "face",
+                {"enabled": False},
+                image,
+                object(),
+                object(),
+                object(),
+                object(),
+                object(),
+                {},
+                {},
+            )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertIs(result[0], image)
+        self.assertEqual(result[1], {"enabled": False})
+        self.assertEqual(trace, ["resolve:_as_bool", "call:_as_bool"])
+
+    def test_detailer_target_preserves_kwargs_cleanup_and_metadata_order(self):
+        trace: list[str] = []
+        captured_kwargs = {}
+        model = _Token("model")
+        stage_model = _Token("stage_model")
+        clip = _Token("clip")
+        vae = _Token("vae")
+        positive = _Token("positive")
+        negative = _Token("negative")
+        image = _Token("image")
+        detailed_image = _Token("detailed_image")
+        sam3_context = {"model": _Token("sam3_model")}
+        segs = ((1, 1), ["seg"])
+        sampler_settings = {"seed": 11}
+        stage_sampler = {
+            "seed": 101,
+            "steps": 22,
+            "cfg": 6.5,
+            "sampler_name": "euler",
+            "scheduler": "sgm_uniform",
+            "denoise": 0.31,
+        }
+        target_settings = {
+            "enabled": True,
+            "detect_prompt": "portrait face",
+            "detect_count": "2",
+            "threshold": "0.63",
+            "refine_iterations": "3",
+            "individual_masks": True,
+            "combined": False,
+            "crop_factor": "3.5",
+            "bbox_fill": True,
+            "drop_size": "88",
+            "contour_fill": False,
+            "guide_size": "896",
+            "guide_size_for": True,
+            "max_size": "1792",
+            "feather": "7",
+            "noise_mask": False,
+            "force_inpaint": True,
+            "wildcard": "detail wildcard",
+            "cycle": "2",
+            "alignment": "64",
+            "inpaint_model": True,
+            "noise_mask_feather": "4",
+            "tiled_encode": True,
+            "tiled_decode": False,
+        }
+
+        def as_bool(value, default):
+            trace.append(("call", "_as_bool", value, default))
+            return bool(value)
+
+        def as_int(value, default):
+            trace.append(("call", "_as_int", value, default))
+            return int(value)
+
+        def as_float(value, default):
+            trace.append(("call", "_as_float", value, default))
+            return float(value)
+
+        def stage_sampler_settings(base, target, **kwargs):
+            trace.append("call:_aio_stage_sampler_settings")
+            self.assertIs(base, sampler_settings)
+            self.assertIs(target, target_settings)
+            self.assertEqual(kwargs, {"scheduler_default": "sgm_uniform"})
+            return stage_sampler
+
+        def apply_patch(source_model, source_clip, conditioning, sampler):
+            trace.append("call:_apply_patch")
+            self.assertEqual(
+                (source_model, source_clip, conditioning, sampler),
+                (model, clip, positive, stage_sampler),
+            )
+            return stage_model
+
+        class Detailer:
+            def __init__(self):
+                trace.append("construct:detailer")
+
+            def doit(self, **kwargs):
+                trace.append("call:doit")
+                captured_kwargs.update(kwargs)
+                return detailed_image, segs, object(), object()
+
+        def cleanup(current_model, original_model):
+            trace.append("call:cleanup")
+            self.assertEqual((current_model, original_model), (stage_model, model))
+
+        def segs_has_items(value):
+            trace.append("call:_segs_has_items")
+            self.assertIs(value, segs)
+            return True
+
+        safe_sampler = {"safe": True}
+
+        def json_safe(value):
+            trace.append("call:_prompt_data_json_safe")
+            self.assertIs(value, stage_sampler)
+            return safe_sampler
+
+        helpers = {
+            "_as_bool": as_bool,
+            "_as_int": as_int,
+            "_as_float": as_float,
+            "_aio_stage_sampler_settings": stage_sampler_settings,
+            "_apply_aio_spectrum_model_patches_for_comfy_sampler": apply_patch,
+            "EasyUseAnimaSAM3Detailer": Detailer,
+            "_cleanup_aio_ephemeral_model": cleanup,
+            "_segs_has_items": segs_has_items,
+            "_prompt_data_json_safe": json_safe,
+        }
+
+        def resolve(name):
+            trace.append(f"resolve:{name}")
+            return helpers[name]
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            result = nodes._run_aio_detailer_target(
+                "face",
+                target_settings,
+                image,
+                model,
+                clip,
+                vae,
+                positive,
+                negative,
+                sampler_settings,
+                sam3_context,
+            )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertIs(result[0], detailed_image)
+        self.assertEqual(
+            result[1],
+            {"enabled": True, "detected": True, "sampler": safe_sampler},
+        )
+        self.assertEqual(list(result[1]), ["enabled", "detected", "sampler"])
+        self.assertIs(result[1]["sampler"], safe_sampler)
+        self.assertEqual(
+            list(captured_kwargs),
+            [
+                "enabled", "image", "ctx_SAM3", "detect_prompt", "detect_count",
+                "threshold", "refine_iterations", "individual_masks", "combined",
+                "crop_factor", "bbox_fill", "drop_size", "contour_fill", "model",
+                "clip", "vae", "guide_size", "guide_size_for", "max_size", "seed",
+                "steps", "cfg", "sampler_name", "scheduler", "positive", "negative",
+                "denoise", "feather", "noise_mask", "force_inpaint", "wildcard",
+                "cycle", "alignment", "preserve_conditioning_metadata",
+                "fail_on_unsupported_opt", "detailer_hook", "inpaint_model",
+                "noise_mask_feather", "scheduler_func_opt", "tiled_encode",
+                "tiled_decode",
+            ],
+        )
+        self.assertEqual(
+            captured_kwargs,
+            {
+                "enabled": True,
+                "image": image,
+                "ctx_SAM3": sam3_context,
+                "detect_prompt": "portrait face",
+                "detect_count": 2,
+                "threshold": 0.63,
+                "refine_iterations": 3,
+                "individual_masks": True,
+                "combined": False,
+                "crop_factor": 3.5,
+                "bbox_fill": True,
+                "drop_size": 88,
+                "contour_fill": False,
+                "model": stage_model,
+                "clip": clip,
+                "vae": vae,
+                "guide_size": 896,
+                "guide_size_for": True,
+                "max_size": 1792,
+                "seed": 101,
+                "steps": 22,
+                "cfg": 6.5,
+                "sampler_name": "euler",
+                "scheduler": "sgm_uniform",
+                "positive": positive,
+                "negative": negative,
+                "denoise": 0.31,
+                "feather": 7,
+                "noise_mask": False,
+                "force_inpaint": True,
+                "wildcard": "detail wildcard",
+                "cycle": 2,
+                "alignment": "64",
+                "preserve_conditioning_metadata": True,
+                "fail_on_unsupported_opt": False,
+                "detailer_hook": None,
+                "inpaint_model": True,
+                "noise_mask_feather": 4,
+                "scheduler_func_opt": None,
+                "tiled_encode": True,
+                "tiled_decode": False,
+            },
+        )
+        resolved_helpers = [
+            item.removeprefix("resolve:")
+            for item in trace
+            if isinstance(item, str) and item.startswith("resolve:")
+        ]
+        self.assertEqual(
+            resolved_helpers,
+            [
+                "_as_bool",
+                "_aio_stage_sampler_settings",
+                "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+                "EasyUseAnimaSAM3Detailer",
+                "_as_int", "_as_float", "_as_int", "_as_bool", "_as_bool",
+                "_as_float", "_as_bool", "_as_int", "_as_bool", "_as_int",
+                "_as_bool", "_as_int", "_as_int", "_as_bool", "_as_bool",
+                "_as_int", "_as_bool", "_as_int", "_as_bool", "_as_bool",
+                "_cleanup_aio_ephemeral_model",
+                "_segs_has_items",
+                "_prompt_data_json_safe",
+            ],
+        )
+        self.assertLess(trace.index("call:cleanup"), trace.index("call:_segs_has_items"))
+        self.assertLess(
+            trace.index("call:_segs_has_items"),
+            trace.index("call:_prompt_data_json_safe"),
+        )
+
+    def test_detailer_target_preserves_cleanup_and_metadata_failure_boundaries(self):
+        image = _Token("image")
+        model = _Token("model")
+        stage_model = _Token("stage_model")
+        stage_sampler = {
+            "seed": 1,
+            "steps": 2,
+            "cfg": 3.0,
+            "sampler_name": "euler",
+            "scheduler": "sgm_uniform",
+            "denoise": 0.4,
+        }
+
+        def execute(overrides, trace):
+            class Detailer:
+                def doit(self, **kwargs):
+                    trace.append("doit")
+                    return _Token("output"), ((1, 1), ["seg"])
+
+            helpers = {
+                "_as_bool": lambda value, default: bool(value),
+                "_as_int": lambda value, default: default,
+                "_as_float": lambda value, default: default,
+                "_aio_stage_sampler_settings": lambda *args, **kwargs: stage_sampler,
+                "_apply_aio_spectrum_model_patches_for_comfy_sampler": (
+                    lambda *args: stage_model
+                ),
+                "EasyUseAnimaSAM3Detailer": Detailer,
+                "_cleanup_aio_ephemeral_model": (
+                    lambda current, original: trace.append("cleanup")
+                ),
+                "_segs_has_items": lambda value: True,
+                "_prompt_data_json_safe": lambda value: value,
+                **overrides,
+            }
+
+            def resolve(name):
+                trace.append(f"resolve:{name}")
+                return helpers[name]
+
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=resolve
+            )
+            try:
+                return nodes._run_aio_detailer_target(
+                    "face",
+                    {"enabled": True},
+                    image,
+                    model,
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    {},
+                    {},
+                )
+            finally:
+                legacy_generation._bind_aio_legacy_generation_runtime(
+                    resolve_helper=lambda name: getattr(nodes, name)
+                )
+
+        planner_trace = []
+
+        def fail_planner(*args, **kwargs):
+            planner_trace.append("planner")
+            raise ValueError("planner failed")
+
+        with self.assertRaisesRegex(ValueError, "planner failed"):
+            execute({"_aio_stage_sampler_settings": fail_planner}, planner_trace)
+        self.assertNotIn("cleanup", planner_trace)
+        self.assertFalse(
+            any(item == "resolve:_cleanup_aio_ephemeral_model" for item in planner_trace)
+        )
+
+        class_trace = []
+
+        def fail_class():
+            class_trace.append("construct")
+            raise LookupError("class failed")
+
+        with self.assertRaisesRegex(LookupError, "class failed"):
+            execute({"EasyUseAnimaSAM3Detailer": fail_class}, class_trace)
+        self.assertEqual(class_trace[-2:], ["resolve:_cleanup_aio_ephemeral_model", "cleanup"])
+
+        cleanup_trace = []
+
+        class FailingDetailer:
+            def doit(self, **kwargs):
+                cleanup_trace.append("doit")
+                raise ValueError("detailer failed")
+
+        def fail_cleanup(current, original):
+            cleanup_trace.append("cleanup")
+            raise RuntimeError("cleanup failed")
+
+        with self.assertRaisesRegex(RuntimeError, "cleanup failed"):
+            execute(
+                {
+                    "EasyUseAnimaSAM3Detailer": FailingDetailer,
+                    "_cleanup_aio_ephemeral_model": fail_cleanup,
+                },
+                cleanup_trace,
+            )
+        self.assertEqual(cleanup_trace[-3:], ["doit", "resolve:_cleanup_aio_ephemeral_model", "cleanup"])
+
+        metadata_trace = []
+
+        def fail_segs(value):
+            metadata_trace.append("segs")
+            raise ArithmeticError("segs failed")
+
+        with self.assertRaisesRegex(ArithmeticError, "segs failed"):
+            execute({"_segs_has_items": fail_segs}, metadata_trace)
+        self.assertIn("cleanup", metadata_trace)
+        self.assertEqual(metadata_trace[-2:], ["resolve:_segs_has_items", "segs"])
+        self.assertFalse(
+            any(item == "resolve:_prompt_data_json_safe" for item in metadata_trace)
+        )
 
     def test_resshift_stage_preserves_provider_argument_and_metadata_order(self):
         trace = []

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "3586d54ce9dc559eaa11a0f1233311e42c6e26ec")
-        # Issue #184 B-11c25 moves only the AiO ResShift leaf to its
+        self.assertEqual(report["git_blob_sha1"], "8d3694386c24bf8933de274d8c37290416fac0a5")
+        # Issue #184 B-11c26 moves only the AiO Detailer target leaf to its
         # canonical legacy-generation owner.
-        self.assertEqual(report["top_level"]["function_count"], 11)
+        self.assertEqual(report["top_level"]["function_count"], 10)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_092)
+        self.assertEqual(report["line_count"], 2_012)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "2abc54d12f96b784f2e63e07400522227f7affe3"
+BASE_COMMIT = "5e2b33504a001351f8151f9042fff254cd3b6120"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1328,6 +1328,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c23",
                 "B-11c24",
                 "B-11c25",
+                "B-11c26",
             ],
         },
         "enums": {
@@ -1340,11 +1341,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 297,
+            "nodes_canonical_bindings": 298,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 11,
+            "root_residual_functions": 10,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c26 단일 Move로 root `_run_aio_detailer_target` 구현 본문만 기존 current-order orchestration owner `easyuse_anima.aio.legacy_generation`으로 이동합니다.
- Detailer coordinator, SAM3 구현, settings/schema와 USDU leaf는 변경하지 않고 root에는 relative/flat direct identity alias를 유지합니다.

## 작업 전 inventory

### Symbol / caller

- `_run_aio_detailer_target`
  - 현재 surface: `nodes.py` private root definition
  - production caller: canonical `easyuse_anima.aio.legacy_generation._run_aio_detailer_stage`가 각 enabled target마다 `_runtime_helper("_run_aio_detailer_target")`로 root seam을 조회
  - 기존 direct behavior test는 Spectrum model patch, Detailer kwargs, cleanup과 metadata를 검증하고 coordinator tests는 target 순서·output chaining·예외 전파를 검증
  - public mapping/`__all__` 없음
- canonical owner는 B-09b current-order stage ownership인 `easyuse_anima.aio.legacy_generation`입니다. 새 Detailer module/binder/provider는 추가하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical leaf identity를 유지합니다.
- 기존 `_bind_aio_legacy_generation_runtime`과 `_RUNTIME_RESOLVER`만 재사용하며 `legacy_generation.__all__ = ()`를 유지합니다.
- leaf 자체 mutable global/cache/lock/RNG는 없습니다. `target_settings`, `sampler_settings`, `sam3_context`는 읽기만 하며 `stage_model` cleanup은 기존 `finally`가 소유합니다.

### Call-time dependency inventory

- `_as_bool`
- `_aio_stage_sampler_settings`
- `_apply_aio_spectrum_model_patches_for_comfy_sampler`
- `EasyUseAnimaSAM3Detailer`
- `_as_int`
- `_as_float`
- `_cleanup_aio_ephemeral_model`
- `_segs_has_items`
- `_prompt_data_json_safe`

### 보존할 평가·예외 순서

1. `_as_bool`을 resolve한 뒤 enabled 값을 평가하며, 비활성이면 다른 helper/cleanup 없이 원본 image와 disabled metadata를 반환합니다.
2. enabled이면 stage sampler planner, Spectrum model patch 순서로 실행하며 두 단계 실패에는 cleanup이 없습니다.
3. `try` 안에서 Detailer class를 call-time resolve·생성하고 `doit` method를 조회한 뒤 기존 keyword 순서대로 coercion과 sampler indexing을 평가합니다.
4. class resolve/생성, method lookup, keyword 평가, `doit` 실패 모두 기존 `finally` cleanup을 실행합니다.
5. cleanup은 call-time resolve 후 `(stage_model, model)`로 실행하며 cleanup 예외가 진행 중 예외나 정상 결과를 대체하는 Python semantics를 유지합니다.
6. cleanup 완료 뒤에만 `result[0]`, optional `result[1]`을 평가합니다. result parsing 실패에는 추가 cleanup이 없습니다.
7. metadata는 `enabled`, `detected`, `sampler` 순서이며 `_segs_has_items`가 `_prompt_data_json_safe`보다 먼저 resolve·호출됩니다.
8. helper를 cache하거나 예외 wrapping/fallback/retry를 추가하지 않습니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/legacy_generation.py`, `nodes.py`
- contract/analyzer: `tests/test_aio_legacy_generation.py`, `tests/test_nodes_module_analyzer.py`, `tests/test_python_compatibility_surface.py`
- fixtures: `tests/fixtures/python_backend_baseline.json`, `tests/fixtures/python_compatibility_surface.v1.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`
- 기존 direct behavior test인 `tests/test_aio_nodes.py`는 실행만 하며 수정하지 않습니다.

## 예상 계약 delta

- base: `dev` / `5e2b33504a001351f8151f9042fff254cd3b6120`
- canonical bindings: `297 → 298`
- root/top-level residual functions: `11 → 10`
- runtime binders: `30` 유지
- runtime resolver names: `285 → 287` (`EasyUseAnimaSAM3Detailer`, `_segs_has_items` 추가)
- legacy-generation resolver consumers: `52 → 55` (`_as_float` consumer 추가 포함)
- shipped/runtime-closure modules: `83` 유지
- globals 26, preamble imports 6, direct root-import tests 21: 변화 없음
- `nodes.py` line count: `2,092 → 2,012` actual

## 금지 경계

- Detailer coordinator 또는 USDU leaf 동시 이동 금지
- SAM3 class·SEGS helper 구현, Detailer kwargs/default/호출 순서 변경 금지
- cleanup 위치·조건, metadata 키·순서 변경 금지
- settings/schema/normalizer 또는 A169 stage protocol Contract/Behavior 변경 금지
- 예외 wrapping/fallback/retry 금지
- 새 Detailer module/binder/provider 또는 public `__all__` 결합 금지

## 검증

- exact head: `6513dd985182e8db2a9ef80687d1c200171b4725`
- focused alias/disabled/enabled helper·kwargs·metadata/cleanup/exception order와 기존 direct Detailer behavior/analyzer/import-boundary: 50 tests passed
- 초기 focused 시도는 의존성이 불완전한 venv를 선택해 import 수집 중 NumPy 누락으로 중단됐으며, 프로젝트 정책의 Codex test Python으로 교정한 실행은 통과
- canonical `easyuse_anima/aio/legacy_generation.py` Ruff: clean
- 독립 diff review: 차단점 없음
- `tools/check_project.ps1 -Profile full` (exact worktree/head): Python unittest 930 passed, frontend 114 JS files passed, TypeScript 6.0.3, Pyright baseline passed, import-boundary 6 groups / 0 violations, `git diff --check` passed
- Ruff 전체 113건은 기존 G-01 report-only 진단이며 이번 Move의 차단 실패가 아님
- Live ComfyUI/browser smoke: private leaf Move 범위에서는 수행하지 않음

## 상태

- Ready
- Move-only boundary와 exact-head 검증을 충족했습니다.
