### PR TITLE
refactor: move AiO USDU upscale stage owner

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `5e2b33504a001351f8151f9042fff254cd3b6120`
+- Integrated `dev` snapshot commit: `4358ee3f5542a1d925846b726fdc84d102512bc6`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c25 / `5e2b335`; B-11c26 AiO Detailer target leaf Move in PR #320 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c26 / `4358ee3`; B-11c27 AiO USDU upscale leaf Move in PR #321 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,092
-  lines after B-11c25.
-- The mechanical extraction has removed 10,571
-  lines, approximately 83.5% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,012
+  lines after B-11c26.
+- The mechanical extraction has removed 10,651
+  lines, approximately 84.1% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -85,7 +85,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c23 moved only the AiO upscale dispatcher in PR #317 / `6a5fd7b`.
   B-11c24 moved only the AiO Detailer stage coordinator in PR #318 / `2abc54d`.
   B-11c25 moved only the AiO ResShift leaf in PR #319 / `5e2b335`.
-  B-11c26 moves only the AiO Detailer target leaf in PR #320.
+  B-11c26 moved only the AiO Detailer target leaf in PR #320 / `4358ee3`.
+  B-11c27 moves only the AiO USDU upscale leaf in PR #321.
 
 ### Current quality baseline
 
@@ -327,7 +328,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 PR #319 / `5e2b335`; B-11c26 AiO Detailer target leaf Move PR #320 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 PR #319 / `5e2b335`; B-11c26 PR #320 / `4358ee3`; B-11c27 AiO USDU upscale leaf Move PR #321 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -955,6 +956,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     coercion, cleanup, SEGS, and metadata helpers remain call-time root seams;
     kwargs, cleanup timing, result parsing, and exception behavior remain
     unchanged.
+  - B-11c27 moves only `_run_aio_usdu_upscale_stage` to the existing AiO legacy-
+    generation owner in PR #321. Provider lookup, model loading, tile planning,
+    logging, conditioning, model patching, seed/coercion, cleanup, tuple, image-
+    size, constant, and metadata helpers remain call-time root seams. The named
+    temporary owner exceeds the size review trigger; #169 owns later stage
+    decomposition after its Contract work, not this Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,14 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `5e2b33504a001351f8151f9042fff254cd3b6120`
+  `4358ee3f5542a1d925846b726fdc84d102512bc6`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c25 are integrated through PR #319. B-11c is
+- Current state: B-11a through B-11c26 are integrated through PR #320. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c26 AiO Detailer target leaf Move is tracked by PR #320.
+  the final root shim; B-11c27 AiO USDU upscale leaf Move is tracked by PR #321.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 298 in B-11c26
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 299 in B-11c27
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 10 functions, 0 classes, and 26 assigned
-  globals in B-11c26 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 9 functions, 0 classes, and 26 assigned
+  globals in B-11c27 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 287, including
+- root names reached by those canonical runtime resolvers: 290, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -555,6 +555,24 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #320 does not move or change the Detailer coordinator, SAM3/SEGS helpers,
   settings/schema/defaults, workflow behavior, the USDU leaf, or the later #169
   Contract/Behavior work.
+
+### B-11c27 AiO USDU upscale leaf alias
+
+- Canonical owner: `easyuse_anima.aio.legacy_generation` for
+  `_run_aio_usdu_upscale_stage`.
+- The private root leaf remains a transitional direct alias in relative package
+  and flat import modes. The canonical upscale dispatcher keeps resolving the
+  root name at call time to preserve its monkeypatch seam.
+- The existing legacy-generation binder resolves provider/model loading, stage
+  planning, coercion, tile/log/conditioning/model-patch operations, runtime seed,
+  cleanup, tuple/image-size handling, the prompt-mode default, and sampler
+  metadata conversion at use time. Provider and log order, external call kwargs,
+  cleanup timing and exception precedence, exact empty-output error, result
+  identity, lazy default lookup, and metadata order are unchanged.
+- The temporary owner remains over the roadmap size review trigger; #169 owns
+  later stage decomposition after its Contract work. PR #321 does not split the
+  function or change USDU planning/conditioning/provider ownership, schema,
+  defaults, seed/tile/log behavior, dispatcher behavior, or public `__all__`.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/aio/legacy_generation.py
+++ b/easyuse_anima/aio/legacy_generation.py
@@ -289,6 +289,174 @@ def _run_aio_detailer_target(
     }
 
 
+def _run_aio_usdu_upscale_stage(
+    model,
+    clip,
+    vae,
+    positive,
+    negative,
+    image,
+    sampler_settings: dict[str, Any],
+    upscale_settings: dict[str, Any],
+    quality_tags: str = "",
+    quality_neg: str = "",
+    prompt_data: str | dict | None = None,
+    exclude_positive_quality: bool = False,
+    exclude_negative_quality: bool = False,
+) -> tuple[Any, dict[str, Any]]:
+    usdu_settings = upscale_settings.get("usdu", {})
+    if not isinstance(usdu_settings, dict):
+        usdu_settings = {}
+    usdu_cls = _runtime_helper("_require_custom_node_class")(
+        "UltimateSDUpscale",
+        "ComfyUI_UltimateSDUpscale",
+        "Required for AiO Generator final Upscale > USDU.",
+    )
+    upscale_model = _runtime_helper("_load_upscale_model_with_comfy")(
+        str(usdu_settings.get("upscale_model_name") or "")
+    )
+    stage_sampler = _runtime_helper("_aio_stage_sampler_settings")(
+        sampler_settings,
+        upscale_settings,
+        scheduler_default="simple",
+    )
+    scale_by = _runtime_helper("_as_float")(
+        upscale_settings.get("scale_by"), 2.0
+    )
+    tile_plan = _runtime_helper("_aio_usdu_tile_plan")(
+        image, scale_by, usdu_settings
+    )
+    tile_width = int(tile_plan["tile_width"])
+    tile_height = int(tile_plan["tile_height"])
+    if tile_plan.get("auto"):
+        _runtime_helper("logger").info(
+            "[EasyUseAnima][AiO] USDU auto tile: input=%sx%s scale_by=%.3g expected=%sx%s target/min/max=%s/%s/%s resolved_tile=%sx%s",
+            tile_plan.get("input_width"),
+            tile_plan.get("input_height"),
+            scale_by,
+            tile_plan.get("target_width"),
+            tile_plan.get("target_height"),
+            tile_plan.get("preferred"),
+            tile_plan.get("min"),
+            tile_plan.get("max"),
+            tile_width,
+            tile_height,
+        )
+    else:
+        _runtime_helper("logger").info(
+            "[EasyUseAnima][AiO] USDU manual tile: input=%sx%s scale_by=%.3g expected=%sx%s tile=%sx%s",
+            tile_plan.get("input_width"),
+            tile_plan.get("input_height"),
+            scale_by,
+            tile_plan.get("target_width"),
+            tile_plan.get("target_height"),
+            tile_width,
+            tile_height,
+        )
+    _runtime_helper("logger").info(
+        "[EasyUseAnima][AiO] USDU sampler: steps=%s denoise=%.3f cfg=%.3g sampler=%s scheduler=%s",
+        _runtime_helper("_as_int")(stage_sampler.get("steps"), 20),
+        _runtime_helper("_as_float")(stage_sampler.get("denoise"), 0.2),
+        _runtime_helper("_as_float")(stage_sampler.get("cfg"), 8.0),
+        str(stage_sampler.get("sampler_name") or "euler"),
+        str(stage_sampler.get("scheduler") or "simple"),
+    )
+    usdu_positive, usdu_negative = _runtime_helper("_aio_usdu_conditioning")(
+        clip,
+        positive,
+        negative,
+        usdu_settings,
+        quality_tags,
+        quality_neg,
+        prompt_data,
+        exclude_positive_quality,
+        exclude_negative_quality,
+    )
+    stage_model = _runtime_helper(
+        "_apply_aio_spectrum_model_patches_for_comfy_sampler"
+    )(
+        model,
+        clip,
+        usdu_positive,
+        stage_sampler,
+    )
+    try:
+        result = usdu_cls().upscale(
+            image=image,
+            model=stage_model,
+            positive=usdu_positive,
+            negative=usdu_negative,
+            vae=vae,
+            upscale_by=scale_by,
+            seed=_runtime_helper("_resolve_aio_runtime_seed")(
+                stage_sampler.get("seed")
+            ),
+            steps=_runtime_helper("_as_int")(stage_sampler.get("steps"), 20),
+            cfg=_runtime_helper("_as_float")(stage_sampler.get("cfg"), 8.0),
+            sampler_name=str(stage_sampler.get("sampler_name") or "euler"),
+            scheduler=str(stage_sampler.get("scheduler") or "simple"),
+            denoise=_runtime_helper("_as_float")(
+                stage_sampler.get("denoise"), 0.2
+            ),
+            upscale_model=upscale_model,
+            mode_type=str(usdu_settings.get("mode_type") or "Linear"),
+            tile_width=tile_width,
+            tile_height=tile_height,
+            mask_blur=_runtime_helper("_as_int")(
+                usdu_settings.get("mask_blur"), 8
+            ),
+            tile_padding=_runtime_helper("_as_int")(
+                usdu_settings.get("tile_padding"), 32
+            ),
+            seam_fix_mode=str(usdu_settings.get("seam_fix_mode") or "None"),
+            seam_fix_denoise=_runtime_helper("_as_float")(
+                usdu_settings.get("seam_fix_denoise"), 1.0
+            ),
+            seam_fix_mask_blur=_runtime_helper("_as_int")(
+                usdu_settings.get("seam_fix_mask_blur"), 8
+            ),
+            seam_fix_width=_runtime_helper("_as_int")(
+                usdu_settings.get("seam_fix_width"), 64
+            ),
+            seam_fix_padding=_runtime_helper("_as_int")(
+                usdu_settings.get("seam_fix_padding"), 16
+            ),
+            force_uniform_tiles=_runtime_helper("_as_bool")(
+                usdu_settings.get("force_uniform_tiles"), True
+            ),
+            tiled_decode=_runtime_helper("_as_bool")(
+                usdu_settings.get("tiled_decode"), False
+            ),
+            batch_size=_runtime_helper("_as_int")(
+                usdu_settings.get("batch_size"), 1
+            ),
+        )
+    finally:
+        _runtime_helper("_cleanup_aio_ephemeral_model")(stage_model, model)
+    values = _runtime_helper("_node_output_tuple")(result)
+    if not values:
+        raise RuntimeError("[EasyUseAnima] UltimateSDUpscale returned no IMAGE.")
+    output = values[0]
+    width, height = _runtime_helper("_image_tensor_size")(output, 0, 0)
+    return output, {
+        "enabled": True,
+        "backend": "usdu",
+        "width": int(width),
+        "height": int(height),
+        "scale_by": scale_by,
+        "tile_width": int(tile_width),
+        "tile_height": int(tile_height),
+        "tile_auto": bool(tile_plan.get("auto")),
+        "tile_target_width": int(tile_plan.get("target_width") or 0),
+        "tile_target_height": int(tile_plan.get("target_height") or 0),
+        "prompt_mode": str(
+            usdu_settings.get("prompt_mode")
+            or _runtime_helper("AIO_USDU_PROMPT_FULL")
+        ),
+        "sampler": _runtime_helper("_prompt_data_json_safe")(stage_sampler),
+    }
+
+
 def _run_aio_resshift_upscale_stage(
     image,
     sampler_settings: dict[str, Any],

--- a/nodes.py
+++ b/nodes.py
@@ -27,6 +27,7 @@ try:
         _run_aio_legacy_generation as _run_aio_legacy_generation,
         _run_aio_resshift_upscale_stage as _run_aio_resshift_upscale_stage,
         _run_aio_upscale_stage as _run_aio_upscale_stage,
+        _run_aio_usdu_upscale_stage as _run_aio_usdu_upscale_stage,
     )
     from .easyuse_anima.aio.generation_normalization import (
         AIO_SPECIAL_SEEDS as AIO_SPECIAL_SEEDS,
@@ -586,6 +587,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _run_aio_legacy_generation as _run_aio_legacy_generation,
         _run_aio_resshift_upscale_stage as _run_aio_resshift_upscale_stage,
         _run_aio_upscale_stage as _run_aio_upscale_stage,
+        _run_aio_usdu_upscale_stage as _run_aio_usdu_upscale_stage,
     )
     from easyuse_anima.aio.generation_normalization import (
         AIO_SPECIAL_SEEDS as AIO_SPECIAL_SEEDS,
@@ -1687,141 +1689,6 @@ def _resize_image_to_size_if_needed(
     samples = image.movedim(-1, 1)
     resized = _common_upscale_image(samples, target_width, target_height, str(upscale_method or "bicubic"))
     return resized.movedim(1, -1), True
-
-
-def _run_aio_usdu_upscale_stage(
-    model,
-    clip,
-    vae,
-    positive,
-    negative,
-    image,
-    sampler_settings: dict[str, Any],
-    upscale_settings: dict[str, Any],
-    quality_tags: str = "",
-    quality_neg: str = "",
-    prompt_data: str | dict | None = None,
-    exclude_positive_quality: bool = False,
-    exclude_negative_quality: bool = False,
-) -> tuple[Any, dict[str, Any]]:
-    usdu_settings = upscale_settings.get("usdu", {})
-    if not isinstance(usdu_settings, dict):
-        usdu_settings = {}
-    usdu_cls = _require_custom_node_class(
-        "UltimateSDUpscale",
-        "ComfyUI_UltimateSDUpscale",
-        "Required for AiO Generator final Upscale > USDU.",
-    )
-    upscale_model = _load_upscale_model_with_comfy(str(usdu_settings.get("upscale_model_name") or ""))
-    stage_sampler = _aio_stage_sampler_settings(
-        sampler_settings,
-        upscale_settings,
-        scheduler_default="simple",
-    )
-    scale_by = _as_float(upscale_settings.get("scale_by"), 2.0)
-    tile_plan = _aio_usdu_tile_plan(image, scale_by, usdu_settings)
-    tile_width = int(tile_plan["tile_width"])
-    tile_height = int(tile_plan["tile_height"])
-    if tile_plan.get("auto"):
-        logger.info(
-            "[EasyUseAnima][AiO] USDU auto tile: input=%sx%s scale_by=%.3g expected=%sx%s target/min/max=%s/%s/%s resolved_tile=%sx%s",
-            tile_plan.get("input_width"),
-            tile_plan.get("input_height"),
-            scale_by,
-            tile_plan.get("target_width"),
-            tile_plan.get("target_height"),
-            tile_plan.get("preferred"),
-            tile_plan.get("min"),
-            tile_plan.get("max"),
-            tile_width,
-            tile_height,
-        )
-    else:
-        logger.info(
-            "[EasyUseAnima][AiO] USDU manual tile: input=%sx%s scale_by=%.3g expected=%sx%s tile=%sx%s",
-            tile_plan.get("input_width"),
-            tile_plan.get("input_height"),
-            scale_by,
-            tile_plan.get("target_width"),
-            tile_plan.get("target_height"),
-            tile_width,
-            tile_height,
-        )
-    logger.info(
-        "[EasyUseAnima][AiO] USDU sampler: steps=%s denoise=%.3f cfg=%.3g sampler=%s scheduler=%s",
-        _as_int(stage_sampler.get("steps"), 20),
-        _as_float(stage_sampler.get("denoise"), 0.2),
-        _as_float(stage_sampler.get("cfg"), 8.0),
-        str(stage_sampler.get("sampler_name") or "euler"),
-        str(stage_sampler.get("scheduler") or "simple"),
-    )
-    usdu_positive, usdu_negative = _aio_usdu_conditioning(
-        clip,
-        positive,
-        negative,
-        usdu_settings,
-        quality_tags,
-        quality_neg,
-        prompt_data,
-        exclude_positive_quality,
-        exclude_negative_quality,
-    )
-    stage_model = _apply_aio_spectrum_model_patches_for_comfy_sampler(
-        model,
-        clip,
-        usdu_positive,
-        stage_sampler,
-    )
-    try:
-        result = usdu_cls().upscale(
-            image=image,
-            model=stage_model,
-            positive=usdu_positive,
-            negative=usdu_negative,
-            vae=vae,
-            upscale_by=scale_by,
-            seed=_resolve_aio_runtime_seed(stage_sampler.get("seed")),
-            steps=_as_int(stage_sampler.get("steps"), 20),
-            cfg=_as_float(stage_sampler.get("cfg"), 8.0),
-            sampler_name=str(stage_sampler.get("sampler_name") or "euler"),
-            scheduler=str(stage_sampler.get("scheduler") or "simple"),
-            denoise=_as_float(stage_sampler.get("denoise"), 0.2),
-            upscale_model=upscale_model,
-            mode_type=str(usdu_settings.get("mode_type") or "Linear"),
-            tile_width=tile_width,
-            tile_height=tile_height,
-            mask_blur=_as_int(usdu_settings.get("mask_blur"), 8),
-            tile_padding=_as_int(usdu_settings.get("tile_padding"), 32),
-            seam_fix_mode=str(usdu_settings.get("seam_fix_mode") or "None"),
-            seam_fix_denoise=_as_float(usdu_settings.get("seam_fix_denoise"), 1.0),
-            seam_fix_mask_blur=_as_int(usdu_settings.get("seam_fix_mask_blur"), 8),
-            seam_fix_width=_as_int(usdu_settings.get("seam_fix_width"), 64),
-            seam_fix_padding=_as_int(usdu_settings.get("seam_fix_padding"), 16),
-            force_uniform_tiles=_as_bool(usdu_settings.get("force_uniform_tiles"), True),
-            tiled_decode=_as_bool(usdu_settings.get("tiled_decode"), False),
-            batch_size=_as_int(usdu_settings.get("batch_size"), 1),
-        )
-    finally:
-        _cleanup_aio_ephemeral_model(stage_model, model)
-    values = _node_output_tuple(result)
-    if not values:
-        raise RuntimeError("[EasyUseAnima] UltimateSDUpscale returned no IMAGE.")
-    output = values[0]
-    width, height = _image_tensor_size(output, 0, 0)
-    return output, {
-        "enabled": True,
-        "backend": "usdu",
-        "width": int(width),
-        "height": int(height),
-        "scale_by": scale_by,
-        "tile_width": int(tile_width),
-        "tile_height": int(tile_height),
-        "tile_auto": bool(tile_plan.get("auto")),
-        "tile_target_width": int(tile_plan.get("target_width") or 0),
-        "tile_target_height": int(tile_plan.get("target_height") or 0),
-        "prompt_mode": str(usdu_settings.get("prompt_mode") or AIO_USDU_PROMPT_FULL),
-        "sampler": _prompt_data_json_safe(stage_sampler),
-    }
 
 
 def _consume_reserved_wildcard_next_seed(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14826,6 +14826,37 @@
         "target": "easyuse_anima/aio/legacy_generation.py"
       },
       {
+        "alias": "_run_aio_usdu_upscale_stage",
+        "bound_name": "_run_aio_usdu_upscale_stage",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_usdu_upscale_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
+        "kind": "static_from",
+        "line": 22,
+        "name": "_run_aio_usdu_upscale_stage",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
         "alias": "AIO_SPECIAL_SEEDS",
         "bound_name": "AIO_SPECIAL_SEEDS",
         "branch_context": [
@@ -14847,7 +14878,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14878,7 +14909,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14909,7 +14940,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14940,7 +14971,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14971,7 +15002,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15002,7 +15033,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15033,7 +15064,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15064,7 +15095,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15095,7 +15126,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15126,7 +15157,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15157,7 +15188,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15188,7 +15219,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15219,7 +15250,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15250,7 +15281,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15281,7 +15312,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15312,7 +15343,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 31,
+        "line": 32,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15343,7 +15374,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 49,
+        "line": 50,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15374,7 +15405,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 52,
+        "line": 53,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15405,7 +15436,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 52,
+        "line": 53,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15436,7 +15467,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 52,
+        "line": 53,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15467,7 +15498,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15498,7 +15529,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15529,7 +15560,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15560,7 +15591,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 57,
+        "line": 58,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15591,7 +15622,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 459,
+        "line": 460,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 459,
+        "line": 460,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 459,
+        "line": 460,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24302,7 +24333,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24333,7 +24364,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24364,7 +24395,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24395,7 +24426,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24426,7 +24457,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24445,7 +24476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24460,7 +24491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24479,7 +24510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24494,7 +24525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24513,7 +24544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24528,7 +24559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24547,7 +24578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24562,7 +24593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24581,7 +24612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24596,7 +24627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24615,7 +24646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24630,7 +24661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24649,7 +24680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24664,7 +24695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24683,7 +24714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24698,7 +24729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24717,7 +24748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24732,7 +24763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24751,7 +24782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24766,7 +24797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24785,7 +24816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24800,7 +24831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24819,7 +24850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24834,7 +24865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24853,7 +24884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24868,7 +24899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24887,7 +24918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24902,7 +24933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24921,7 +24952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24936,8 +24967,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_upscale_stage",
+        "optional": false,
+        "requested": "easyuse_anima.aio.legacy_generation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "alias": "_run_aio_usdu_upscale_stage",
+        "bound_name": "_run_aio_usdu_upscale_stage",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_run_aio_usdu_upscale_stage",
+          "target": "easyuse_anima/aio/legacy_generation.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
+        "kind": "static_from",
+        "line": 582,
+        "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
         "role": "compatibility_fallback",
@@ -24955,7 +25020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -24970,7 +25035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -24989,7 +25054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25004,7 +25069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25023,7 +25088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25038,7 +25103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25057,7 +25122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25072,7 +25137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25091,7 +25156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25106,7 +25171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25125,7 +25190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25140,7 +25205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25159,7 +25224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25174,7 +25239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25193,7 +25258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25208,7 +25273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25227,7 +25292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25242,7 +25307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25261,7 +25326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25276,7 +25341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25295,7 +25360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25310,7 +25375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25329,7 +25394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25344,7 +25409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25363,7 +25428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25378,7 +25443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25397,7 +25462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25412,7 +25477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25431,7 +25496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25446,7 +25511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25465,7 +25530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25480,7 +25545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25499,7 +25564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25514,7 +25579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25533,7 +25598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25548,7 +25613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25567,7 +25632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25582,7 +25647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25601,7 +25666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25616,7 +25681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25635,7 +25700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25650,7 +25715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25669,7 +25734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25684,7 +25749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25703,7 +25768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25718,7 +25783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25737,7 +25802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25752,7 +25817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25771,7 +25836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25786,7 +25851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25805,7 +25870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25820,7 +25885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25839,7 +25904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25854,7 +25919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25873,7 +25938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25888,7 +25953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25907,7 +25972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25922,7 +25987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25941,7 +26006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25956,7 +26021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -25975,7 +26040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -25990,7 +26055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26009,7 +26074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26024,7 +26089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26043,7 +26108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26058,7 +26123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26077,7 +26142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26092,7 +26157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26111,7 +26176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26126,7 +26191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26145,7 +26210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26160,7 +26225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26179,7 +26244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26194,7 +26259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26213,7 +26278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26228,7 +26293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26247,7 +26312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26262,7 +26327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26281,7 +26346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26296,7 +26361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26315,7 +26380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26330,7 +26395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26349,7 +26414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26364,7 +26429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26383,7 +26448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26398,7 +26463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26417,7 +26482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26432,7 +26497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26451,7 +26516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26466,7 +26531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26485,7 +26550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26500,7 +26565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26519,7 +26584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26534,7 +26599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26553,7 +26618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26568,7 +26633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26587,7 +26652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26602,7 +26667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26621,7 +26686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26636,7 +26701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26655,7 +26720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26670,7 +26735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26689,7 +26754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26704,7 +26769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26723,7 +26788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26738,7 +26803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26757,7 +26822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26772,7 +26837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26791,7 +26856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26806,7 +26871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26825,7 +26890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26840,7 +26905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26859,7 +26924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26874,7 +26939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26893,7 +26958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26908,7 +26973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26927,7 +26992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26942,7 +27007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26961,7 +27026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -26976,7 +27041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26995,7 +27060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27010,7 +27075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27029,7 +27094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27044,7 +27109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27063,7 +27128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27078,7 +27143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27097,7 +27162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27112,7 +27177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27131,7 +27196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27146,7 +27211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27165,7 +27230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27180,7 +27245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27199,7 +27264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27214,7 +27279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27233,7 +27298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27248,7 +27313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27267,7 +27332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27282,7 +27347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27301,7 +27366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27316,7 +27381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27335,7 +27400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27350,7 +27415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27369,7 +27434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27384,7 +27449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27403,7 +27468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27418,7 +27483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27437,7 +27502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27452,7 +27517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27471,7 +27536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27486,7 +27551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27505,7 +27570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27520,7 +27585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27539,7 +27604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27554,7 +27619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27573,7 +27638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27588,7 +27653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27607,7 +27672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27622,7 +27687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27641,7 +27706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27656,7 +27721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27675,7 +27740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27690,7 +27755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27709,7 +27774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27724,7 +27789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27743,7 +27808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27758,7 +27823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27777,7 +27842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27792,7 +27857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27811,7 +27876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27826,7 +27891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27845,7 +27910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27860,7 +27925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27879,7 +27944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27894,7 +27959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27913,7 +27978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27928,7 +27993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27947,7 +28012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27962,7 +28027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27981,7 +28046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -27996,7 +28061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28015,7 +28080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28030,7 +28095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28049,7 +28114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28064,7 +28129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28083,7 +28148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28098,7 +28163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28117,7 +28182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28132,7 +28197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28151,7 +28216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28166,7 +28231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28185,7 +28250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28200,7 +28265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28219,7 +28284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28234,7 +28299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28253,7 +28318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28268,7 +28333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28287,7 +28352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28302,7 +28367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28321,7 +28386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28336,7 +28401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28355,7 +28420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28370,7 +28435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28389,7 +28454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28404,7 +28469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28423,7 +28488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28438,7 +28503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28457,7 +28522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28472,7 +28537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28491,7 +28556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28506,7 +28571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28525,7 +28590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28540,7 +28605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28559,7 +28624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28574,7 +28639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28593,7 +28658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28608,7 +28673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28627,7 +28692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28642,7 +28707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28661,7 +28726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28676,7 +28741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28695,7 +28760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28710,7 +28775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28729,7 +28794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28744,7 +28809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28763,7 +28828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28778,7 +28843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28797,7 +28862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28812,7 +28877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28831,7 +28896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28846,7 +28911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28865,7 +28930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28880,7 +28945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28899,7 +28964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28914,7 +28979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28933,7 +28998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28948,7 +29013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28967,7 +29032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -28982,7 +29047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29001,7 +29066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29016,7 +29081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29035,7 +29100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29050,7 +29115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29069,7 +29134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29084,7 +29149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29103,7 +29168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29118,7 +29183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29137,7 +29202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29152,7 +29217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29171,7 +29236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29186,7 +29251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29205,7 +29270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29220,7 +29285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29239,7 +29304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29254,7 +29319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29273,7 +29338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29288,7 +29353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29307,7 +29372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29322,7 +29387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29341,7 +29406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29356,7 +29421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29375,7 +29440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29390,7 +29455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29409,7 +29474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29424,7 +29489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29443,7 +29508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29458,7 +29523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29477,7 +29542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29492,7 +29557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29511,7 +29576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29526,7 +29591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29545,7 +29610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29560,7 +29625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29579,7 +29644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29594,7 +29659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29613,7 +29678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29628,7 +29693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29647,7 +29712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29662,7 +29727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29681,7 +29746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29696,7 +29761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29715,7 +29780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29730,7 +29795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29749,7 +29814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29764,7 +29829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29783,7 +29848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29798,7 +29863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29817,7 +29882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29832,7 +29897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29851,7 +29916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29866,7 +29931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29885,7 +29950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29900,7 +29965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29919,7 +29984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29934,7 +29999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29953,7 +30018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -29968,7 +30033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29987,7 +30052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30002,7 +30067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30021,7 +30086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30036,7 +30101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30055,7 +30120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30070,7 +30135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30089,7 +30154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30104,7 +30169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30123,7 +30188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30138,7 +30203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30157,7 +30222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30172,7 +30237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30191,7 +30256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30206,7 +30271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30225,7 +30290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30240,7 +30305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30259,7 +30324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30274,7 +30339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30293,7 +30358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30308,7 +30373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30327,7 +30392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30342,7 +30407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30361,7 +30426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30376,7 +30441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30395,7 +30460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30410,7 +30475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30429,7 +30494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30444,7 +30509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30463,7 +30528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30478,7 +30543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30497,7 +30562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30512,7 +30577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30531,7 +30596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30546,7 +30611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30565,7 +30630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30580,7 +30645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30599,7 +30664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30614,7 +30679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30633,7 +30698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30648,7 +30713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30667,7 +30732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30682,7 +30747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30701,7 +30766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30716,7 +30781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30735,7 +30800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30750,7 +30815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30769,7 +30834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30784,7 +30849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30803,7 +30868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30818,7 +30883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30837,7 +30902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30852,7 +30917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30871,7 +30936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30886,7 +30951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30905,7 +30970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30920,7 +30985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30939,7 +31004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30954,7 +31019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30973,7 +31038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -30988,7 +31053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31007,7 +31072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31022,7 +31087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31041,7 +31106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31056,7 +31121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31075,7 +31140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31090,7 +31155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31109,7 +31174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31124,7 +31189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31143,7 +31208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31158,7 +31223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31177,7 +31242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31192,7 +31257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31211,7 +31276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31226,7 +31291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31245,7 +31310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31260,7 +31325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31279,7 +31344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31294,7 +31359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31313,7 +31378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31328,7 +31393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31347,7 +31412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31362,7 +31427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31381,7 +31446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31396,7 +31461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31415,7 +31480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31430,7 +31495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31449,7 +31514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31464,7 +31529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31483,7 +31548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31498,7 +31563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31517,7 +31582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31532,7 +31597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31551,7 +31616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31566,7 +31631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31585,7 +31650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31600,7 +31665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31619,7 +31684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31634,7 +31699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31653,7 +31718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31668,7 +31733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31687,7 +31752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31702,7 +31767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31721,7 +31786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31736,7 +31801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31755,7 +31820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31770,7 +31835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31789,7 +31854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31804,7 +31869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31823,7 +31888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31838,7 +31903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31857,7 +31922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31872,7 +31937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31891,7 +31956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31906,7 +31971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31925,7 +31990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31940,7 +32005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31959,7 +32024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -31974,7 +32039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -31993,7 +32058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32008,7 +32073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32027,7 +32092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32042,7 +32107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32061,7 +32126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32076,7 +32141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32095,7 +32160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32110,7 +32175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32129,7 +32194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32144,7 +32209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32163,7 +32228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32178,7 +32243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32197,7 +32262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32212,7 +32277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32231,7 +32296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32246,7 +32311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32265,7 +32330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32280,7 +32345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32299,7 +32364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32314,7 +32379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32333,7 +32398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32348,7 +32413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32367,7 +32432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32382,7 +32447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32401,7 +32466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32416,7 +32481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32435,7 +32500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32450,7 +32515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32469,7 +32534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32484,7 +32549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32503,7 +32568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32518,7 +32583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32537,7 +32602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32552,7 +32617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32571,7 +32636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32586,7 +32651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32605,7 +32670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32620,7 +32685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32639,7 +32704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32654,7 +32719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32673,7 +32738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32688,7 +32753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32707,7 +32772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32722,7 +32787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32741,7 +32806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32756,7 +32821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32775,7 +32840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32790,7 +32855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32809,7 +32874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32824,7 +32889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32843,7 +32908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32858,7 +32923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32877,7 +32942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32892,7 +32957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32911,7 +32976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32926,7 +32991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -32945,7 +33010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32960,7 +33025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -32979,7 +33044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -32994,7 +33059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33013,7 +33078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33028,7 +33093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33047,7 +33112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33062,7 +33127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33081,7 +33146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33096,7 +33161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33115,7 +33180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33130,7 +33195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33149,7 +33214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33164,7 +33229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33183,7 +33248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33198,7 +33263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33217,7 +33282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33232,7 +33297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1015,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33251,7 +33316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33266,7 +33331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1015,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33285,7 +33350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33300,7 +33365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1015,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33319,7 +33384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33334,7 +33399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33353,7 +33418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33368,7 +33433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33387,7 +33452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33402,7 +33467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33421,7 +33486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33436,7 +33501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33455,7 +33520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33470,7 +33535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33489,7 +33554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33504,7 +33569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33523,7 +33588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33538,7 +33603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33557,7 +33622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33572,7 +33637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33591,7 +33656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33606,7 +33671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33625,7 +33690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33640,7 +33705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33659,7 +33724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33674,7 +33739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33693,7 +33758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33708,7 +33773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33727,7 +33792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33742,7 +33807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33761,7 +33826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33776,7 +33841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33795,7 +33860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33810,7 +33875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33829,7 +33894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33844,7 +33909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33863,7 +33928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33878,7 +33943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33897,7 +33962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33912,7 +33977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33931,7 +33996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33946,7 +34011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33965,7 +34030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -33980,7 +34045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33999,7 +34064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34014,7 +34079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34033,7 +34098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34048,7 +34113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34067,7 +34132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34082,7 +34147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34101,7 +34166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34116,7 +34181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34135,7 +34200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34150,7 +34215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34169,7 +34234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34184,7 +34249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34203,7 +34268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34218,7 +34283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34237,7 +34302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34252,7 +34317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34271,7 +34336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34286,7 +34351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34305,7 +34370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34320,7 +34385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34339,7 +34404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34354,7 +34419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34373,7 +34438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34388,7 +34453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34407,7 +34472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34422,7 +34487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34441,7 +34506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34456,7 +34521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34475,7 +34540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34490,7 +34555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34509,7 +34574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34524,7 +34589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34543,7 +34608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34558,7 +34623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34577,7 +34642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34592,7 +34657,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34611,7 +34676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34626,7 +34691,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34645,7 +34710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34660,7 +34725,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1102,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34679,7 +34744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34694,7 +34759,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34713,7 +34778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34728,7 +34793,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34747,7 +34812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34762,7 +34827,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34781,7 +34846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34796,7 +34861,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1108,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34815,7 +34880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34830,7 +34895,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1108,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34849,7 +34914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34864,7 +34929,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34883,7 +34948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34898,7 +34963,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34917,7 +34982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34932,7 +34997,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34951,7 +35016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -34966,7 +35031,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34985,7 +35050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35000,7 +35065,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35019,7 +35084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35034,7 +35099,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35053,7 +35118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35068,7 +35133,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35087,7 +35152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35102,7 +35167,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35121,7 +35186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35136,7 +35201,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35155,7 +35220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35170,7 +35235,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35189,7 +35254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35204,7 +35269,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35223,7 +35288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35238,7 +35303,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35257,7 +35322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35272,7 +35337,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35291,7 +35356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35306,7 +35371,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35325,7 +35390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35340,7 +35405,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35359,7 +35424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35374,7 +35439,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35393,7 +35458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35408,7 +35473,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35427,7 +35492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35442,7 +35507,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35461,7 +35526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -35476,7 +35541,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35494,7 +35559,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1624
+            "line": 1626
           }
         ],
         "classification": "external",
@@ -35502,7 +35567,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1625,
+        "line": 1627,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35519,7 +35584,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1632
+            "line": 1634
           }
         ],
         "classification": "external",
@@ -35527,7 +35592,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1633,
+        "line": 1635,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35544,7 +35609,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1640
+            "line": 1642
           }
         ],
         "classification": "external",
@@ -35552,7 +35617,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1641,
+        "line": 1643,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38536,13 +38601,13 @@
       },
       {
         "is_package": false,
-        "loc": 808,
+        "loc": 976,
         "module": "easyuse_anima.aio.legacy_generation",
-        "normalized_git_blob_sha1": "db4a8ac160e013ac5849eefd41317ad43121b4a3",
+        "normalized_git_blob_sha1": "a89b9902225b9c6844cf36d72edbc9a78bddd4a1",
         "path": "easyuse_anima/aio/legacy_generation.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 8,
+          "function_count": 9,
           "global_count": 3
         }
       },
@@ -39184,13 +39249,13 @@
       },
       {
         "is_package": false,
-        "loc": 2012,
+        "loc": 1879,
         "module": "nodes",
-        "normalized_git_blob_sha1": "8d3694386c24bf8933de274d8c37290416fac0a5",
+        "normalized_git_blob_sha1": "6de84ba721ad593af4b2d34634976822eb7358d1",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 10,
+          "function_count": 9,
           "global_count": 26
         }
       },
@@ -40550,7 +40615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40559,7 +40624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40573,7 +40638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40582,7 +40647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40596,7 +40661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40605,7 +40670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40619,7 +40684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40628,7 +40693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40642,7 +40707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40651,7 +40716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40665,7 +40730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40674,7 +40739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40688,7 +40753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40697,7 +40762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40711,7 +40776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40720,7 +40785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40734,7 +40799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40743,7 +40808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40757,7 +40822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40766,7 +40831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40780,7 +40845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40789,7 +40854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40803,7 +40868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40812,7 +40877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40826,7 +40891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40835,7 +40900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40849,7 +40914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40858,7 +40923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40872,7 +40937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40881,7 +40946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40895,7 +40960,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
+        "kind": "static_from",
+        "line": 582,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/legacy_generation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40904,7 +40992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40918,7 +41006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40927,7 +41015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40941,7 +41029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40950,7 +41038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40964,7 +41052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40973,7 +41061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40987,7 +41075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -40996,7 +41084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41010,7 +41098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41019,7 +41107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41033,7 +41121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41042,7 +41130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41056,7 +41144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41065,7 +41153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41079,7 +41167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41088,7 +41176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41102,7 +41190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41111,7 +41199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41125,7 +41213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41134,7 +41222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41148,7 +41236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41157,7 +41245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41171,7 +41259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41180,7 +41268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41194,7 +41282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41203,7 +41291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41217,7 +41305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41226,7 +41314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41240,7 +41328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41249,7 +41337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41263,7 +41351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41272,7 +41360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 608,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41286,7 +41374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41295,7 +41383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41309,7 +41397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41318,7 +41406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41332,7 +41420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41341,7 +41429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 611,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41355,7 +41443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41364,7 +41452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41378,7 +41466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41387,7 +41475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41401,7 +41489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41410,7 +41498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41424,7 +41512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41433,7 +41521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 616,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41447,7 +41535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41456,7 +41544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41470,7 +41558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41479,7 +41567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41493,7 +41581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41502,7 +41590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41516,7 +41604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41525,7 +41613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41539,7 +41627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41548,7 +41636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41562,7 +41650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41571,7 +41659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41585,7 +41673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41594,7 +41682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41608,7 +41696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41617,7 +41705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41631,7 +41719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41640,7 +41728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41654,7 +41742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41663,7 +41751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41677,7 +41765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41686,7 +41774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41700,7 +41788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41709,7 +41797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41723,7 +41811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41732,7 +41820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41746,7 +41834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41755,7 +41843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41769,7 +41857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41778,7 +41866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41792,7 +41880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41801,7 +41889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41815,7 +41903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41824,7 +41912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 628,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41838,7 +41926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41847,7 +41935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41861,7 +41949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41870,7 +41958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41884,7 +41972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41893,7 +41981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41907,7 +41995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41916,7 +42004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41930,7 +42018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41939,7 +42027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41953,7 +42041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41962,7 +42050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41976,7 +42064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -41985,7 +42073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41999,7 +42087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42008,7 +42096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42022,7 +42110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42031,7 +42119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42045,7 +42133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42054,7 +42142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42068,7 +42156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42077,7 +42165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42091,7 +42179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42100,7 +42188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 643,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42114,7 +42202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42123,7 +42211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42137,7 +42225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42146,7 +42234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42160,7 +42248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42169,7 +42257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42183,7 +42271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42192,7 +42280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42206,7 +42294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42215,7 +42303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42229,7 +42317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42238,7 +42326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42252,7 +42340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42261,7 +42349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42275,7 +42363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42284,7 +42372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42298,7 +42386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42307,7 +42395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42321,7 +42409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42330,7 +42418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 657,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42344,7 +42432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42353,7 +42441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42367,7 +42455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42376,7 +42464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42390,7 +42478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42399,7 +42487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42413,7 +42501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42422,7 +42510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42436,7 +42524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42445,7 +42533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42459,7 +42547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42468,7 +42556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42482,7 +42570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42491,7 +42579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42505,7 +42593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42514,7 +42602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42528,7 +42616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42537,7 +42625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42551,7 +42639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42560,7 +42648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 669,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42574,7 +42662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42583,7 +42671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42597,7 +42685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42606,7 +42694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42620,7 +42708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42629,7 +42717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42643,7 +42731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42652,7 +42740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42666,7 +42754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42675,7 +42763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42689,7 +42777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42698,7 +42786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42712,7 +42800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42721,7 +42809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42735,7 +42823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42744,7 +42832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42758,7 +42846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42767,7 +42855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42781,7 +42869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42790,7 +42878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42804,7 +42892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42813,7 +42901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42827,7 +42915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42836,7 +42924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42850,7 +42938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42859,7 +42947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42873,7 +42961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42882,7 +42970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42896,7 +42984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42905,7 +42993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42919,7 +43007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42928,7 +43016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42942,7 +43030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42951,7 +43039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42965,7 +43053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42974,7 +43062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42988,7 +43076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -42997,7 +43085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 699,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43011,7 +43099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43020,7 +43108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43034,7 +43122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43043,7 +43131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43057,7 +43145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43066,7 +43154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43080,7 +43168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43089,7 +43177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43103,7 +43191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43112,7 +43200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 704,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43126,7 +43214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43135,7 +43223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 711,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43149,7 +43237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43158,7 +43246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43172,7 +43260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43181,7 +43269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43195,7 +43283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43204,7 +43292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43218,7 +43306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43227,7 +43315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43241,7 +43329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43250,7 +43338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43264,7 +43352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43273,7 +43361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43287,7 +43375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43296,7 +43384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43310,7 +43398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43319,7 +43407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43333,7 +43421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43342,7 +43430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43356,7 +43444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43365,7 +43453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43379,7 +43467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43388,7 +43476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43402,7 +43490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43411,7 +43499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43425,7 +43513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43434,7 +43522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43448,7 +43536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43457,7 +43545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43471,7 +43559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43480,7 +43568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43494,7 +43582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43503,7 +43591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43517,7 +43605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43526,7 +43614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43540,7 +43628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43549,7 +43637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43563,7 +43651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43572,7 +43660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43586,7 +43674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43595,7 +43683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43609,7 +43697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43618,7 +43706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 732,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43632,7 +43720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43641,7 +43729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43655,7 +43743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43664,7 +43752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43678,7 +43766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43687,7 +43775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43701,7 +43789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43710,7 +43798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43724,7 +43812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43733,7 +43821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43747,7 +43835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43756,7 +43844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43770,7 +43858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43779,7 +43867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43793,7 +43881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43802,7 +43890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43816,7 +43904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43825,7 +43913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43839,7 +43927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43848,7 +43936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43862,7 +43950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43871,7 +43959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43885,7 +43973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43894,7 +43982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43908,7 +43996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43917,7 +44005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43931,7 +44019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43940,7 +44028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43954,7 +44042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43963,7 +44051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43977,7 +44065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -43986,7 +44074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44000,7 +44088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44009,7 +44097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44023,7 +44111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44032,7 +44120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44046,7 +44134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44055,7 +44143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44069,7 +44157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44078,7 +44166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44092,7 +44180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44101,7 +44189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44115,7 +44203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44124,7 +44212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44138,7 +44226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44147,7 +44235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44161,7 +44249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44170,7 +44258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44184,7 +44272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44193,7 +44281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44207,7 +44295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44216,7 +44304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44230,7 +44318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44239,7 +44327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44253,7 +44341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44262,7 +44350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44276,7 +44364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44285,7 +44373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44299,7 +44387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44308,7 +44396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44322,7 +44410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44331,7 +44419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44345,7 +44433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44354,7 +44442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44368,7 +44456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44377,7 +44465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44391,7 +44479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44400,7 +44488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44414,7 +44502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44423,7 +44511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44437,7 +44525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44446,7 +44534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44460,7 +44548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44469,7 +44557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44483,7 +44571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44492,7 +44580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44506,7 +44594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44515,7 +44603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44529,7 +44617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44538,7 +44626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44552,7 +44640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44561,7 +44649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44575,7 +44663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44584,7 +44672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44598,7 +44686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44607,7 +44695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44621,7 +44709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44630,7 +44718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44644,7 +44732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44653,7 +44741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 814,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44667,7 +44755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44676,7 +44764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44690,7 +44778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44699,7 +44787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44713,7 +44801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44722,7 +44810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44736,7 +44824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44745,7 +44833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44759,7 +44847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44768,7 +44856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44782,7 +44870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44791,7 +44879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44805,7 +44893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44814,7 +44902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44828,7 +44916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44837,7 +44925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44851,7 +44939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44860,7 +44948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44874,7 +44962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44883,7 +44971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44897,7 +44985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44906,7 +44994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44920,7 +45008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44929,7 +45017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44943,7 +45031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44952,7 +45040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44966,7 +45054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44975,7 +45063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44989,7 +45077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -44998,7 +45086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45012,7 +45100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45021,7 +45109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45035,7 +45123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45044,7 +45132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45058,7 +45146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45067,7 +45155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45081,7 +45169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45090,7 +45178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45104,7 +45192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45113,7 +45201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45127,7 +45215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45136,7 +45224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45150,7 +45238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45159,7 +45247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45173,7 +45261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45182,7 +45270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45196,7 +45284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45205,7 +45293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45219,7 +45307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45228,7 +45316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 830,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45242,7 +45330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45251,7 +45339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45265,7 +45353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45274,7 +45362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45288,7 +45376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45297,7 +45385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45311,7 +45399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45320,7 +45408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45334,7 +45422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45343,7 +45431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45357,7 +45445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45366,7 +45454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45380,7 +45468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45389,7 +45477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 916,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45403,7 +45491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45412,7 +45500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45426,7 +45514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45435,7 +45523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45449,7 +45537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45458,7 +45546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45472,7 +45560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45481,7 +45569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45495,7 +45583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45504,7 +45592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45518,7 +45606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45527,7 +45615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45541,7 +45629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45550,7 +45638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45564,7 +45652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45573,7 +45661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45587,7 +45675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45596,7 +45684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45610,7 +45698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45619,7 +45707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 927,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45633,7 +45721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45642,7 +45730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45656,7 +45744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45665,7 +45753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45679,7 +45767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45688,7 +45776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 936,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45702,7 +45790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45711,7 +45799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45725,7 +45813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45734,7 +45822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45748,7 +45836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45757,7 +45845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45771,7 +45859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45780,7 +45868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 947,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45794,7 +45882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45803,7 +45891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45817,7 +45905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45826,7 +45914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 960,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45840,7 +45928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45849,7 +45937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45863,7 +45951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45872,7 +45960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45886,7 +45974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45895,7 +45983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45909,7 +45997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45918,7 +46006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45932,7 +46020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45941,7 +46029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45955,7 +46043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45964,7 +46052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45978,7 +46066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -45987,7 +46075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46001,7 +46089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46010,7 +46098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 968,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46024,7 +46112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46033,7 +46121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46047,7 +46135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46056,7 +46144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46070,7 +46158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46079,7 +46167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46093,7 +46181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46102,7 +46190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 979,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46116,7 +46204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46125,7 +46213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46139,7 +46227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46148,7 +46236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46162,7 +46250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46171,7 +46259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46185,7 +46273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46194,7 +46282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46208,7 +46296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46217,7 +46305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 985,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46231,7 +46319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46240,7 +46328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46254,7 +46342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46263,7 +46351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 993,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46277,7 +46365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46286,7 +46374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 997,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46300,7 +46388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46309,7 +46397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46323,7 +46411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46332,7 +46420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46346,7 +46434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46355,7 +46443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1001,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46369,7 +46457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46378,7 +46466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46392,7 +46480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46401,7 +46489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46415,7 +46503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46424,7 +46512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46438,7 +46526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46447,7 +46535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46461,7 +46549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46470,7 +46558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46484,7 +46572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46493,7 +46581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46507,7 +46595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46516,7 +46604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46530,7 +46618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46539,7 +46627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46553,7 +46641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46562,7 +46650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46576,7 +46664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46585,7 +46673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46599,7 +46687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46608,7 +46696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46622,7 +46710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46631,7 +46719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46645,7 +46733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46654,7 +46742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46668,7 +46756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46677,7 +46765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46691,7 +46779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46700,7 +46788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46714,7 +46802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46723,7 +46811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1036,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46737,7 +46825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46746,7 +46834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46760,7 +46848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46769,7 +46857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1059,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46783,7 +46871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46792,7 +46880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46806,7 +46894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46815,7 +46903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46829,7 +46917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46838,7 +46926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46852,7 +46940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46861,7 +46949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46875,7 +46963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46884,7 +46972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46898,7 +46986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46907,7 +46995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46921,7 +47009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46930,7 +47018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46944,7 +47032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46953,7 +47041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46967,7 +47055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46976,7 +47064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46990,7 +47078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -46999,7 +47087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47013,7 +47101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47022,7 +47110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47036,7 +47124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47045,7 +47133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47059,7 +47147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47068,7 +47156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47082,7 +47170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47091,7 +47179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47105,7 +47193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47114,7 +47202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47128,7 +47216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47137,7 +47225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47151,7 +47239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47160,7 +47248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47174,7 +47262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47183,7 +47271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47197,7 +47285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47206,7 +47294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47220,7 +47308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47229,7 +47317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47243,7 +47331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47252,7 +47340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47266,7 +47354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47275,7 +47363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47289,7 +47377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47298,7 +47386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47312,7 +47400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47321,7 +47409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47335,7 +47423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47344,7 +47432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47358,7 +47446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47367,7 +47455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47381,7 +47469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47390,7 +47478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1095,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47404,7 +47492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47413,7 +47501,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47427,7 +47515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47436,7 +47524,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47450,7 +47538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47459,7 +47547,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47473,7 +47561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47482,7 +47570,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47496,7 +47584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47505,7 +47593,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47519,7 +47607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47528,7 +47616,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47542,7 +47630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47551,7 +47639,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47565,7 +47653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47574,7 +47662,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47588,7 +47676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47597,7 +47685,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47611,7 +47699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47620,7 +47708,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47634,7 +47722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47643,7 +47731,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47657,7 +47745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47666,7 +47754,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47680,7 +47768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47689,7 +47777,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47703,7 +47791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47712,7 +47800,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47726,7 +47814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47735,7 +47823,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47749,7 +47837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47758,7 +47846,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47772,7 +47860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47781,7 +47869,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47795,7 +47883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47804,7 +47892,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47818,7 +47906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47827,7 +47915,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47841,7 +47929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47850,7 +47938,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47864,7 +47952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47873,7 +47961,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47887,7 +47975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47896,7 +47984,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47910,7 +47998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47919,7 +48007,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47933,7 +48021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47942,7 +48030,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47956,7 +48044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47965,7 +48053,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47979,7 +48067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -47988,7 +48076,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48002,7 +48090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
             "line": 10
           }
@@ -48011,7 +48099,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51838,14 +51926,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1624
+            "line": 1626
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1625,
+        "line": 1627,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51857,14 +51945,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1632
+            "line": 1634
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1633,
+        "line": 1635,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51876,14 +51964,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1640
+            "line": 1642
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1641,
+        "line": 1643,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53258,14 +53346,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1624
+            "line": 1626
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1625,
+        "line": 1627,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53277,14 +53365,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1632
+            "line": 1634
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1633,
+        "line": 1635,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53296,14 +53384,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1640
+            "line": 1642
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1641,
+        "line": 1643,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54764,7 +54852,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1129,
+        "line": 1131,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54773,7 +54861,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1908,
+        "line": 1775,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54782,7 +54870,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1911,
+        "line": 1778,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54791,7 +54879,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1914,
+        "line": 1781,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54800,7 +54888,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1917,
+        "line": 1784,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54809,7 +54897,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1920,
+        "line": 1787,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54818,7 +54906,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1923,
+        "line": 1790,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54827,7 +54915,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1926,
+        "line": 1793,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54836,7 +54924,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1929,
+        "line": 1796,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54845,7 +54933,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1932,
+        "line": 1799,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54854,7 +54942,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1935,
+        "line": 1802,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54863,7 +54951,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1938,
+        "line": 1805,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54872,7 +54960,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1941,
+        "line": 1808,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54881,7 +54969,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1944,
+        "line": 1811,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54890,7 +54978,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1947,
+        "line": 1814,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54899,7 +54987,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1950,
+        "line": 1817,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54908,7 +54996,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1953,
+        "line": 1820,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54917,7 +55005,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1957,
+        "line": 1824,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54926,7 +55014,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1960,
+        "line": 1827,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54935,7 +55023,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1964,
+        "line": 1831,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54944,7 +55032,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1967,
+        "line": 1834,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54953,7 +55041,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1971,
+        "line": 1838,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54962,7 +55050,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1974,
+        "line": 1841,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54971,7 +55059,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1977,
+        "line": 1844,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54980,7 +55068,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1980,
+        "line": 1847,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54989,7 +55077,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1983,
+        "line": 1850,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54998,7 +55086,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1986,
+        "line": 1853,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55007,7 +55095,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1993,
+        "line": 1860,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55016,7 +55104,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1999,
+        "line": 1866,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55025,7 +55113,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2004,
+        "line": 1871,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55034,7 +55122,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 2008,
+        "line": 1875,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55548,13 +55636,13 @@
       },
       {
         "kind": "dict",
-        "line": 1191,
+        "line": 1193,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1180,
+        "line": 1182,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "5e2b33504a001351f8151f9042fff254cd3b6120",
+    "base_commit": "4358ee3f5542a1d925846b726fdc84d102512bc6",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -56,7 +56,8 @@
       "B-11c23",
       "B-11c24",
       "B-11c25",
-      "B-11c26"
+      "B-11c26",
+      "B-11c27"
     ]
   },
   "enums": {
@@ -91,11 +92,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 298,
+    "nodes_canonical_bindings": 299,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 10,
+    "root_residual_functions": 9,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -219,7 +220,8 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "AIO_USDU_PROMPT_FULL": [
-      "easyuse_anima.aio.conditioning"
+      "easyuse_anima.aio.conditioning",
+      "easyuse_anima.aio.legacy_generation"
     ],
     "AIO_USDU_PROMPT_MODES": [
       "easyuse_anima.aio.generation_normalization"
@@ -475,8 +477,14 @@
     "_aio_usdu_auto_tile_dimension": [
       "easyuse_anima.aio.usdu"
     ],
+    "_aio_usdu_conditioning": [
+      "easyuse_anima.aio.legacy_generation"
+    ],
     "_aio_usdu_prompt_without_general": [
       "easyuse_anima.aio.conditioning"
+    ],
+    "_aio_usdu_tile_plan": [
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_align_down": [
       "easyuse_anima.aio.postprocess"
@@ -816,6 +824,9 @@
     ],
     "_load_profile_data": [
       "easyuse_anima.lora.preset"
+    ],
+    "_load_upscale_model_with_comfy": [
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_load_vae_with_comfy": [
       "easyuse_anima.aio.resources"
@@ -1961,11 +1972,13 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.conditioning"
+        "canonical runtime resolver: easyuse_anima.aio.conditioning",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.conditioning string runtime lookup"
+        "AST:easyuse_anima.aio.conditioning string runtime lookup",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -2132,7 +2145,8 @@
         "_run_aio_highres_stage": "_run_aio_highres_stage",
         "_run_aio_legacy_generation": "_run_aio_legacy_generation",
         "_run_aio_resshift_upscale_stage": "_run_aio_resshift_upscale_stage",
-        "_run_aio_upscale_stage": "_run_aio_upscale_stage"
+        "_run_aio_upscale_stage": "_run_aio_upscale_stage",
+        "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -2446,10 +2460,12 @@
       "first_release": null,
       "known_consumers": [
         "nodes.py residual runtime",
+        "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.usdu"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
+        "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.usdu string runtime lookup"
       ],
       "removal_gates": [
@@ -3807,7 +3823,6 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.aio.first_pass_cache",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
@@ -3818,7 +3833,6 @@
         "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.aio.first_pass_cache string runtime lookup",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
@@ -4215,8 +4229,7 @@
         "_find_loaded_node_class": "_find_loaded_node_class",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class",
-        "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
-        "_run_aio_usdu_upscale_stage": "_run_aio_usdu_upscale_stage"
+        "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -52,6 +52,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             nodes._run_aio_upscale_stage,
             legacy_generation._run_aio_upscale_stage,
         )
+        self.assertIs(
+            nodes._run_aio_usdu_upscale_stage,
+            legacy_generation._run_aio_usdu_upscale_stage,
+        )
 
         with _loaded_package_entrypoint() as (package_entrypoint, package_nodes):
             canonical_module = sys.modules[
@@ -84,6 +88,10 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             self.assertIs(
                 package_nodes._run_aio_upscale_stage,
                 canonical_module._run_aio_upscale_stage,
+            )
+            self.assertIs(
+                package_nodes._run_aio_usdu_upscale_stage,
+                canonical_module._run_aio_usdu_upscale_stage,
             )
 
     def test_highres_stage_disabled_short_circuits_after_as_bool(self):
@@ -1089,6 +1097,457 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         self.assertEqual(metadata_trace[-2:], ["resolve:_segs_has_items", "segs"])
         self.assertFalse(
             any(item == "resolve:_prompt_data_json_safe" for item in metadata_trace)
+        )
+
+    def test_usdu_stage_preserves_dependencies_kwargs_cleanup_and_metadata_order(self):
+        trace = []
+        captured_kwargs = {}
+        model = _Token("model")
+        stage_model = _Token("stage_model")
+        clip = _Token("clip")
+        vae = _Token("vae")
+        positive = _Token("positive")
+        negative = _Token("negative")
+        usdu_positive = _Token("usdu_positive")
+        usdu_negative = _Token("usdu_negative")
+        image = _Token("image")
+        output = _Token("output")
+        upscale_model = _Token("upscale_model")
+        sampler_settings = {"seed": "base-seed"}
+        stage_sampler = {
+            "seed": "stage-seed",
+            "steps": "30",
+            "cfg": "5.5",
+            "sampler_name": "dpmpp_2m",
+            "scheduler": "simple",
+            "denoise": "0.25",
+        }
+        usdu_settings = {
+            "upscale_model_name": "upscale.safetensors",
+            "mode_type": "Chess",
+            "mask_blur": "9",
+            "tile_padding": "48",
+            "seam_fix_mode": "Band Pass",
+            "seam_fix_denoise": "0.8",
+            "seam_fix_mask_blur": "7",
+            "seam_fix_width": "80",
+            "seam_fix_padding": "20",
+            "force_uniform_tiles": True,
+            "tiled_decode": False,
+            "batch_size": "3",
+            "prompt_mode": "no_general",
+        }
+        upscale_settings = {"scale_by": "2.5", "usdu": usdu_settings}
+        tile_plan = {
+            "auto": True,
+            "input_width": 512,
+            "input_height": 768,
+            "target_width": 1280,
+            "target_height": 1920,
+            "preferred": 768,
+            "min": 512,
+            "max": 1536,
+            "tile_width": 640,
+            "tile_height": 960,
+        }
+        safe_sampler = {"safe": True}
+
+        class Logger:
+            def info(self, *args):
+                trace.append(("call", "logger.info", args))
+
+        class USDU:
+            def __init__(self):
+                trace.append("construct:usdu")
+
+            def upscale(self, **kwargs):
+                trace.append("call:upscale")
+                captured_kwargs.update(kwargs)
+                return "raw-usdu-result"
+
+        def require(node_id, node_pack, install_hint):
+            trace.append("call:_require_custom_node_class")
+            self.assertEqual(
+                (node_id, node_pack, install_hint),
+                (
+                    "UltimateSDUpscale",
+                    "ComfyUI_UltimateSDUpscale",
+                    "Required for AiO Generator final Upscale > USDU.",
+                ),
+            )
+            return USDU
+
+        def load_upscale(name):
+            trace.append("call:_load_upscale_model_with_comfy")
+            self.assertEqual(name, "upscale.safetensors")
+            return upscale_model
+
+        def stage_sampler_settings(base, stage, **kwargs):
+            trace.append("call:_aio_stage_sampler_settings")
+            self.assertIs(base, sampler_settings)
+            self.assertIs(stage, upscale_settings)
+            self.assertEqual(kwargs, {"scheduler_default": "simple"})
+            return stage_sampler
+
+        def as_int(value, default):
+            trace.append(("call", "_as_int", value, default))
+            return int(value)
+
+        def as_float(value, default):
+            trace.append(("call", "_as_float", value, default))
+            return float(value)
+
+        def as_bool(value, default):
+            trace.append(("call", "_as_bool", value, default))
+            return bool(value)
+
+        def plan_tiles(source_image, scale, settings):
+            trace.append("call:_aio_usdu_tile_plan")
+            self.assertEqual((source_image, scale, settings), (image, 2.5, usdu_settings))
+            return tile_plan
+
+        def conditioning(*args):
+            trace.append("call:_aio_usdu_conditioning")
+            self.assertEqual(
+                args,
+                (
+                    clip,
+                    positive,
+                    negative,
+                    usdu_settings,
+                    "quality",
+                    "quality-neg",
+                    {"fields": []},
+                    True,
+                    False,
+                ),
+            )
+            return usdu_positive, usdu_negative
+
+        def apply_patch(source_model, source_clip, conditioning_value, sampler):
+            trace.append("call:_apply_patch")
+            self.assertEqual(
+                (source_model, source_clip, conditioning_value, sampler),
+                (model, clip, usdu_positive, stage_sampler),
+            )
+            return stage_model
+
+        def resolve_seed(value):
+            trace.append("call:_resolve_aio_runtime_seed")
+            self.assertEqual(value, "stage-seed")
+            return 123
+
+        def cleanup(current_model, original_model):
+            trace.append("call:cleanup")
+            self.assertEqual((current_model, original_model), (stage_model, model))
+
+        def output_tuple(value):
+            trace.append("call:_node_output_tuple")
+            self.assertEqual(value, "raw-usdu-result")
+            return (output,)
+
+        def image_size(value, fallback_width, fallback_height):
+            trace.append("call:_image_tensor_size")
+            self.assertEqual((value, fallback_width, fallback_height), (output, 0, 0))
+            return 1280, 1920
+
+        def json_safe(value):
+            trace.append("call:_prompt_data_json_safe")
+            self.assertIs(value, stage_sampler)
+            return safe_sampler
+
+        helpers = {
+            "_require_custom_node_class": require,
+            "_load_upscale_model_with_comfy": load_upscale,
+            "_aio_stage_sampler_settings": stage_sampler_settings,
+            "_as_int": as_int,
+            "_as_float": as_float,
+            "_as_bool": as_bool,
+            "_aio_usdu_tile_plan": plan_tiles,
+            "logger": Logger(),
+            "_aio_usdu_conditioning": conditioning,
+            "_apply_aio_spectrum_model_patches_for_comfy_sampler": apply_patch,
+            "_resolve_aio_runtime_seed": resolve_seed,
+            "_cleanup_aio_ephemeral_model": cleanup,
+            "_node_output_tuple": output_tuple,
+            "_image_tensor_size": image_size,
+            "_prompt_data_json_safe": json_safe,
+        }
+
+        def resolve(name):
+            trace.append(f"resolve:{name}")
+            if name == "AIO_USDU_PROMPT_FULL":
+                self.fail("explicit prompt mode must not resolve the default constant")
+            return helpers[name]
+
+        legacy_generation._bind_aio_legacy_generation_runtime(resolve_helper=resolve)
+        try:
+            result = nodes._run_aio_usdu_upscale_stage(
+                model,
+                clip,
+                vae,
+                positive,
+                negative,
+                image,
+                sampler_settings,
+                upscale_settings,
+                "quality",
+                "quality-neg",
+                {"fields": []},
+                True,
+                False,
+            )
+        finally:
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=lambda name: getattr(nodes, name)
+            )
+
+        self.assertIs(result[0], output)
+        self.assertEqual(
+            result[1],
+            {
+                "enabled": True,
+                "backend": "usdu",
+                "width": 1280,
+                "height": 1920,
+                "scale_by": 2.5,
+                "tile_width": 640,
+                "tile_height": 960,
+                "tile_auto": True,
+                "tile_target_width": 1280,
+                "tile_target_height": 1920,
+                "prompt_mode": "no_general",
+                "sampler": safe_sampler,
+            },
+        )
+        self.assertEqual(
+            list(result[1]),
+            [
+                "enabled", "backend", "width", "height", "scale_by",
+                "tile_width", "tile_height", "tile_auto", "tile_target_width",
+                "tile_target_height", "prompt_mode", "sampler",
+            ],
+        )
+        self.assertEqual(
+            list(captured_kwargs),
+            [
+                "image", "model", "positive", "negative", "vae", "upscale_by",
+                "seed", "steps", "cfg", "sampler_name", "scheduler", "denoise",
+                "upscale_model", "mode_type", "tile_width", "tile_height",
+                "mask_blur", "tile_padding", "seam_fix_mode", "seam_fix_denoise",
+                "seam_fix_mask_blur", "seam_fix_width", "seam_fix_padding",
+                "force_uniform_tiles", "tiled_decode", "batch_size",
+            ],
+        )
+        self.assertEqual(
+            captured_kwargs,
+            {
+                "image": image,
+                "model": stage_model,
+                "positive": usdu_positive,
+                "negative": usdu_negative,
+                "vae": vae,
+                "upscale_by": 2.5,
+                "seed": 123,
+                "steps": 30,
+                "cfg": 5.5,
+                "sampler_name": "dpmpp_2m",
+                "scheduler": "simple",
+                "denoise": 0.25,
+                "upscale_model": upscale_model,
+                "mode_type": "Chess",
+                "tile_width": 640,
+                "tile_height": 960,
+                "mask_blur": 9,
+                "tile_padding": 48,
+                "seam_fix_mode": "Band Pass",
+                "seam_fix_denoise": 0.8,
+                "seam_fix_mask_blur": 7,
+                "seam_fix_width": 80,
+                "seam_fix_padding": 20,
+                "force_uniform_tiles": True,
+                "tiled_decode": False,
+                "batch_size": 3,
+            },
+        )
+        log_calls = [item for item in trace if isinstance(item, tuple) and item[:2] == ("call", "logger.info")]
+        self.assertEqual(len(log_calls), 2)
+        self.assertIn("USDU auto tile", log_calls[0][2][0])
+        self.assertIn("USDU sampler", log_calls[1][2][0])
+        resolved_helpers = [
+            item.removeprefix("resolve:")
+            for item in trace
+            if isinstance(item, str) and item.startswith("resolve:")
+        ]
+        self.assertEqual(
+            resolved_helpers,
+            [
+                "_require_custom_node_class",
+                "_load_upscale_model_with_comfy",
+                "_aio_stage_sampler_settings",
+                "_as_float",
+                "_aio_usdu_tile_plan",
+                "logger",
+                "logger",
+                "_as_int", "_as_float", "_as_float",
+                "_aio_usdu_conditioning",
+                "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+                "_resolve_aio_runtime_seed", "_as_int", "_as_float", "_as_float",
+                "_as_int", "_as_int", "_as_float", "_as_int", "_as_int",
+                "_as_int", "_as_bool", "_as_bool", "_as_int",
+                "_cleanup_aio_ephemeral_model",
+                "_node_output_tuple",
+                "_image_tensor_size",
+                "_prompt_data_json_safe",
+            ],
+        )
+        self.assertLess(trace.index("call:cleanup"), trace.index("call:_node_output_tuple"))
+
+    def test_usdu_stage_preserves_cleanup_output_and_lazy_default_boundaries(self):
+        model = _Token("model")
+        stage_model = _Token("stage_model")
+        output = _Token("output")
+        stage_sampler = {
+            "seed": 1,
+            "steps": 2,
+            "cfg": 3.0,
+            "sampler_name": "euler",
+            "scheduler": "simple",
+            "denoise": 0.4,
+        }
+
+        class Logger:
+            def info(self, *args):
+                return None
+
+        class USDU:
+            def upscale(self, **kwargs):
+                return "raw-result"
+
+        def execute(overrides, trace):
+            helpers = {
+                "_require_custom_node_class": lambda *args: USDU,
+                "_load_upscale_model_with_comfy": lambda name: object(),
+                "_aio_stage_sampler_settings": lambda *args, **kwargs: stage_sampler,
+                "_as_float": lambda value, default: default,
+                "_as_int": lambda value, default: default,
+                "_as_bool": lambda value, default: default,
+                "_aio_usdu_tile_plan": lambda *args: {
+                    "auto": False,
+                    "tile_width": 512,
+                    "tile_height": 512,
+                },
+                "logger": Logger(),
+                "_aio_usdu_conditioning": lambda *args: (object(), object()),
+                "_apply_aio_spectrum_model_patches_for_comfy_sampler": (
+                    lambda *args: stage_model
+                ),
+                "_resolve_aio_runtime_seed": lambda value: 1,
+                "_cleanup_aio_ephemeral_model": (
+                    lambda current, original: trace.append("cleanup")
+                ),
+                "_node_output_tuple": lambda value: (output,),
+                "_image_tensor_size": lambda *args: (1024, 1024),
+                "AIO_USDU_PROMPT_FULL": "full",
+                "_prompt_data_json_safe": lambda value: {"safe": True},
+                **overrides,
+            }
+
+            def resolve(name):
+                trace.append(f"resolve:{name}")
+                return helpers[name]
+
+            legacy_generation._bind_aio_legacy_generation_runtime(
+                resolve_helper=resolve
+            )
+            try:
+                return nodes._run_aio_usdu_upscale_stage(
+                    model,
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    object(),
+                    {},
+                    {"usdu": {}},
+                )
+            finally:
+                legacy_generation._bind_aio_legacy_generation_runtime(
+                    resolve_helper=lambda name: getattr(nodes, name)
+                )
+
+        patch_trace = []
+
+        def fail_patch(*args):
+            raise ValueError("patch failed")
+
+        with self.assertRaisesRegex(ValueError, "patch failed"):
+            execute(
+                {"_apply_aio_spectrum_model_patches_for_comfy_sampler": fail_patch},
+                patch_trace,
+            )
+        self.assertNotIn("cleanup", patch_trace)
+        self.assertNotIn("resolve:_cleanup_aio_ephemeral_model", patch_trace)
+
+        construct_trace = []
+
+        class FailingConstructor:
+            def __init__(self):
+                construct_trace.append("construct")
+                raise LookupError("constructor failed")
+
+        with self.assertRaisesRegex(LookupError, "constructor failed"):
+            execute(
+                {"_require_custom_node_class": lambda *args: FailingConstructor},
+                construct_trace,
+            )
+        self.assertEqual(
+            construct_trace[-2:],
+            ["resolve:_cleanup_aio_ephemeral_model", "cleanup"],
+        )
+
+        cleanup_trace = []
+
+        class FailingUSDU:
+            def upscale(self, **kwargs):
+                cleanup_trace.append("upscale")
+                raise ValueError("upscale failed")
+
+        def fail_cleanup(current, original):
+            cleanup_trace.append("cleanup")
+            raise RuntimeError("cleanup failed")
+
+        with self.assertRaisesRegex(RuntimeError, "cleanup failed"):
+            execute(
+                {
+                    "_require_custom_node_class": lambda *args: FailingUSDU,
+                    "_cleanup_aio_ephemeral_model": fail_cleanup,
+                },
+                cleanup_trace,
+            )
+        self.assertEqual(
+            cleanup_trace[-3:],
+            ["upscale", "resolve:_cleanup_aio_ephemeral_model", "cleanup"],
+        )
+
+        empty_trace = []
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] UltimateSDUpscale returned no IMAGE\.$",
+        ):
+            execute({"_node_output_tuple": lambda value: ()}, empty_trace)
+        self.assertIn("cleanup", empty_trace)
+        self.assertIn("resolve:_node_output_tuple", empty_trace)
+        self.assertNotIn("resolve:_image_tensor_size", empty_trace)
+        self.assertNotIn("resolve:AIO_USDU_PROMPT_FULL", empty_trace)
+
+        default_trace = []
+        result = execute({}, default_trace)
+        self.assertIs(result[0], output)
+        self.assertEqual(result[1]["prompt_mode"], "full")
+        self.assertLess(
+            default_trace.index("resolve:AIO_USDU_PROMPT_FULL"),
+            default_trace.index("resolve:_prompt_data_json_safe"),
         )
 
     def test_resshift_stage_preserves_provider_argument_and_metadata_order(self):

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "8d3694386c24bf8933de274d8c37290416fac0a5")
-        # Issue #184 B-11c26 moves only the AiO Detailer target leaf to its
+        self.assertEqual(report["git_blob_sha1"], "6de84ba721ad593af4b2d34634976822eb7358d1")
+        # Issue #184 B-11c27 moves only the AiO USDU upscale leaf to its
         # canonical legacy-generation owner.
-        self.assertEqual(report["top_level"]["function_count"], 10)
+        self.assertEqual(report["top_level"]["function_count"], 9)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 2_012)
+        self.assertEqual(report["line_count"], 1_879)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "5e2b33504a001351f8151f9042fff254cd3b6120"
+BASE_COMMIT = "4358ee3f5542a1d925846b726fdc84d102512bc6"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1329,6 +1329,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c24",
                 "B-11c25",
                 "B-11c26",
+                "B-11c27",
             ],
         },
         "enums": {
@@ -1341,11 +1342,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 298,
+            "nodes_canonical_bindings": 299,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 10,
+            "root_residual_functions": 9,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c27 단일 Move로 root `_run_aio_usdu_upscale_stage` 구현 본문만 기존 current-order orchestration owner `easyuse_anima.aio.legacy_generation`으로 이동합니다.
- Upscale dispatcher, USDU planning/conditioning/provider 구현, settings/schema는 변경하지 않고 root에는 relative/flat direct identity alias를 유지합니다.

## 작업 전 inventory

### Symbol / caller

- `_run_aio_usdu_upscale_stage`
  - 현재 surface: `nodes.py` private root definition
  - production caller: canonical `easyuse_anima.aio.legacy_generation._run_aio_upscale_stage`가 USDU branch에서 `_runtime_helper("_run_aio_usdu_upscale_stage")`로 root seam을 조회
  - 기존 direct behavior test는 no-general conditioning, Spectrum patch, tile/log/metadata와 cleanup을 검증하고 dispatcher tests는 branch·argument·exception seam을 검증
  - public mapping/`__all__` 없음
- canonical owner는 planning-only `easyuse_anima.aio.usdu`가 아니라 B-09b current-order stage owner `easyuse_anima.aio.legacy_generation`입니다. 새 module/binder/provider는 추가하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical leaf identity를 유지합니다.
- 기존 `_bind_aio_legacy_generation_runtime`과 `_RUNTIME_RESOLVER`만 재사용하며 `legacy_generation.__all__ = ()`를 유지합니다.
- 입력 dict를 변경하거나 mutable module state를 소유하지 않습니다. provider lookup, model load, logging, conditioning, external USDU 호출만 기존 위치에서 부수효과를 유지합니다.
- `stage_model` cleanup은 기존 `finally`가 소유하며 helper/constant/logger를 cache하지 않습니다.

### Call-time dependency inventory

- `_require_custom_node_class`
- `_load_upscale_model_with_comfy`
- `_aio_stage_sampler_settings`
- `_as_float`, `_as_int`, `_as_bool`
- `_aio_usdu_tile_plan`
- `logger`
- `_aio_usdu_conditioning`
- `_apply_aio_spectrum_model_patches_for_comfy_sampler`
- `_resolve_aio_runtime_seed`
- `_cleanup_aio_ephemeral_model`
- `_node_output_tuple`
- `_image_tensor_size`
- `AIO_USDU_PROMPT_FULL`
- `_prompt_data_json_safe`

### 보존할 평가·예외 순서

1. `upscale_settings["usdu"]`를 조회하고 dict가 아니면 `{}`로 대체합니다.
2. USDU provider, upscale-model loader, stage sampler planner, scale coercion, tile planner 순서로 각각 call-time resolve·호출합니다.
3. tile width/height를 계산한 뒤 auto/manual 분기에 해당하는 logger를 resolve·호출하고, 별도로 sampler logger를 다시 resolve·호출합니다.
4. sampler log 인자는 steps integer, denoise float, cfg float, sampler string, scheduler string 순서로 평가합니다.
5. USDU conditioning 이후 Spectrum model patch를 실행합니다. patch 성공과 `stage_model` 할당 뒤에만 `try`에 진입하므로 이전 실패에는 cleanup이 없습니다.
6. `try` 안에서 provider class를 생성하고 `upscale` method를 조회한 뒤 기존 keyword 순서로 seed/coercion과 settings를 평가해 호출합니다.
7. class 생성, method lookup, keyword 평가/coercion, external upscale 실패 모두 `finally` cleanup을 실행합니다. cleanup 예외는 진행 중 예외나 정상 결과를 대체합니다.
8. cleanup 성공 뒤에만 `_node_output_tuple(result)`를 실행하며 falsy면 exact `UltimateSDUpscale returned no IMAGE` 오류를 발생시킵니다.
9. output identity를 유지하고 image size를 구한 뒤 metadata를 `enabled`, `backend`, `width`, `height`, `scale_by`, tile fields, `prompt_mode`, `sampler` 순서로 조립합니다.
10. `AIO_USDU_PROMPT_FULL`은 prompt mode가 falsy일 때만 short-circuit로 resolve하며, `_prompt_data_json_safe`는 그 뒤에 호출합니다. postprocess 실패에는 cleanup을 다시 실행하지 않습니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/legacy_generation.py`, `nodes.py`
- contract/analyzer: `tests/test_aio_legacy_generation.py`, `tests/test_nodes_module_analyzer.py`, `tests/test_python_compatibility_surface.py`
- fixtures: `tests/fixtures/python_backend_baseline.json`, `tests/fixtures/python_compatibility_surface.v1.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`
- 기존 direct behavior test인 `tests/test_aio_nodes.py`는 실행만 하며 수정하지 않습니다.

## 예상 계약 delta

- base: `dev` / `4358ee3f5542a1d925846b726fdc84d102512bc6`
- canonical bindings: `298 → 299`
- root/top-level residual functions: `10 → 9`
- runtime binders: `30` 유지
- runtime resolver names: `287 → 290` (`_load_upscale_model_with_comfy`, `_aio_usdu_tile_plan`, `_aio_usdu_conditioning` 추가)
- legacy-generation resolver consumers: `55 → 59` (위 3개와 기존 `AIO_USDU_PROMPT_FULL` consumer 추가)
- shipped/runtime-closure modules: `83` 유지
- legacy bindings 27, mapped classes 18, unmapped classes 2, globals 26, preamble imports 6, direct root-import tests 21: 변화 없음
- `nodes.py` line count: `2,012 → 1,879` actual
- `legacy_generation.py`는 976줄이고 이동 함수 block은 약 168줄로 roadmap review trigger(800/120)를 넘지만, B-09b가 이 모듈을 #169 후속 분해가 소유하는 named temporary exception으로 명시합니다.

## 남은 위험 / 후속 owner

- #169가 stage protocol 안정화 뒤 `legacy_generation.py` decomposition을 소유합니다.
- 이번 Move는 temporary owner로 실행 본문을 모으는 단계이며 함수 분해·API adaptation·owner 재설계는 수행하지 않습니다.

## 금지 경계

- Upscale dispatcher, ResShift leaf 또는 postprocess 동시 이동 금지
- USDU planner/conditioning/provider owner, node ID/install hint, exact 오류·로그 문자열 변경 금지
- settings/schema/default, prompt quality-exclusion, tile/sampler/metadata 계산 변경 금지
- helper/logger/constant cache, cleanup 위치·조건, 예외 wrapping/fallback/retry 변경 금지
- 새 USDU stage module/binder/provider 또는 public `__all__` 결합 금지
- A169 stage protocol Contract/Behavior 변경 금지

## 검증

- exact head: `0d4b9d86eca8a425805efba7b16495ca68e1c303`
- focused alias/provider/model-load/tile/log/conditioning/patch/kwargs/cleanup/tuple/metadata/exception order와 기존 direct USDU behavior/analyzer/import-boundary: 52 tests passed
- canonical `easyuse_anima/aio/legacy_generation.py` Ruff: clean
- 독립 diff review: 차단점 없음
- `tools/check_project.ps1 -Profile full` (exact worktree/head): Python unittest 932 passed, frontend 114 JS files passed, TypeScript 6.0.3, Pyright baseline passed, import-boundary 6 groups / 0 violations, `git diff --check` passed
- Ruff 전체 113건은 기존 G-01 report-only 진단이며 이번 Move의 차단 실패가 아님
- Live ComfyUI/browser smoke: private leaf Move 범위에서는 수행하지 않음

## 상태

- Ready
- Move-only boundary와 exact-head 검증을 충족했습니다.
