### PR TITLE
refactor: move shared AiO image resize helper

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `4358ee3f5542a1d925846b726fdc84d102512bc6`
+- Integrated `dev` snapshot commit: `eb0843d3e8c26c326e34e5c77dd1eb302b4a9933`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c26 / `4358ee3`; B-11c27 AiO USDU upscale leaf Move in PR #321 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c27 / `eb0843d`; B-11c28 shared image-resize helper Move in PR #322 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 2,012
-  lines after B-11c26.
-- The mechanical extraction has removed 10,651
-  lines, approximately 84.1% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,879
+  lines after B-11c27.
+- The mechanical extraction has removed 10,784
+  lines, approximately 85.2% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -86,7 +86,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c24 moved only the AiO Detailer stage coordinator in PR #318 / `2abc54d`.
   B-11c25 moved only the AiO ResShift leaf in PR #319 / `5e2b335`.
   B-11c26 moved only the AiO Detailer target leaf in PR #320 / `4358ee3`.
-  B-11c27 moves only the AiO USDU upscale leaf in PR #321.
+  B-11c27 moved only the AiO USDU upscale leaf in PR #321 / `eb0843d`.
+  B-11c28 moves only the shared AiO image-resize helper in PR #322.
 
 ### Current quality baseline
 
@@ -328,7 +329,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 PR #319 / `5e2b335`; B-11c26 PR #320 / `4358ee3`; B-11c27 AiO USDU upscale leaf Move PR #321 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 PR #319 / `5e2b335`; B-11c26 PR #320 / `4358ee3`; B-11c27 PR #321 / `eb0843d`; B-11c28 shared image-resize helper Move PR #322 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -962,6 +963,13 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     size, constant, and metadata helpers remain call-time root seams. The named
     temporary owner exceeds the size review trigger; #169 owns later stage
     decomposition after its Contract work, not this Move.
+  - B-11c28 moves only `_resize_image_to_size_if_needed` to the existing AiO
+    postprocess owner in PR #322. Root and canonical identity remain a direct
+    alias while the existing postprocess binder resolves image size and the
+    Comfy upscale adapter at call time. Clamp and tensor-layout order, the
+    same-size identity short-circuit, method fallback, return tuple, and raw
+    exception propagation remain unchanged. Host-provider, stage, schema,
+    seed-reservation, and RuntimeServices contracts remain separate.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,14 +3,15 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `4358ee3f5542a1d925846b726fdc84d102512bc6`
+  `eb0843d3e8c26c326e34e5c77dd1eb302b4a9933`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c26 are integrated through PR #320. B-11c is
+- Current state: B-11a through B-11c27 are integrated through PR #321. B-11c is
   split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c27 AiO USDU upscale leaf Move is tracked by PR #321.
+  the final root shim; B-11c28 shared image-resize helper Move is tracked by PR
+  #322.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
   `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 299 in B-11c27
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 300 in B-11c28
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 9 functions, 0 classes, and 26 assigned
-  globals in B-11c27 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 8 functions, 0 classes, and 26 assigned
+  globals in B-11c28 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 290, including
+- root names reached by those canonical runtime resolvers: 291, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -573,6 +574,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
   later stage decomposition after its Contract work. PR #321 does not split the
   function or change USDU planning/conditioning/provider ownership, schema,
   defaults, seed/tile/log behavior, dispatcher behavior, or public `__all__`.
+
+### B-11c28 shared AiO image-resize helper alias
+
+- Canonical owner: `easyuse_anima.aio.postprocess` for
+  `_resize_image_to_size_if_needed`.
+- The private root helper remains a transitional direct alias in relative
+  package and flat import modes. Postprocess and legacy-generation consumers
+  continue to resolve the root name at call time, preserving the existing
+  monkeypatch seam.
+- The existing postprocess binder resolves `_image_tensor_size` and
+  `_common_upscale_image` at use time. Width/height clamp order, BHWC-to-BCHW
+  and BCHW-to-BHWC moves, same-size image identity and `False` result, bicubic
+  fallback, resize boolean, and raw exception propagation are unchanged.
+- PR #322 does not move or change the Comfy upscale adapter, image-size helper,
+  final-fit/highres/stage logic, schema/defaults, provider/RuntimeServices
+  contract, wildcard seed reservation, or public `__all__`.
 
 ### `nodes.py` public node-class surface
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -73,8 +73,8 @@ The versioned fixture records the exact post-B-09b2 surface rather than
 inferring public support from spelling or test imports:
 
 - root `__init__.py` permanent entrypoints: 3;
-- `nodes.py` preamble implementation imports: 6 (`json`, `logging`, `random`,
-  `ceil`, `sqrt`, and `Any`), excluded from compatibility classification
+- `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
+  `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
 - `nodes.py` bindings with an `easyuse_anima` canonical target: 300 in B-11c28
   (258 at the integrated B-10b20 baseline), with exact

--- a/easyuse_anima/aio/postprocess.py
+++ b/easyuse_anima/aio/postprocess.py
@@ -25,6 +25,31 @@ def _runtime_helper(name: str) -> Any:
     return resolver(name)
 
 
+def _resize_image_to_size_if_needed(
+    image,
+    target_width: int,
+    target_height: int,
+    upscale_method: str = "bicubic",
+) -> tuple[Any, bool]:
+    target_width = max(1, int(target_width))
+    target_height = max(1, int(target_height))
+    width, height = _runtime_helper("_image_tensor_size")(
+        image,
+        target_width,
+        target_height,
+    )
+    if width == target_width and height == target_height:
+        return image, False
+    samples = image.movedim(-1, 1)
+    resized = _runtime_helper("_common_upscale_image")(
+        samples,
+        target_width,
+        target_height,
+        str(upscale_method or "bicubic"),
+    )
+    return resized.movedim(1, -1), True
+
+
 def _aio_final_fit_size(
     width: int,
     height: int,

--- a/nodes.py
+++ b/nodes.py
@@ -5,8 +5,6 @@ import json
 import logging
 import random
 from math import ceil, sqrt
-from typing import Any
-
 try:
     from .easyuse_anima.aio.first_pass_cache import (
         AIO_FIRST_PASS_CACHE_MAX_ENTRIES as AIO_FIRST_PASS_CACHE_MAX_ENTRIES,

--- a/nodes.py
+++ b/nodes.py
@@ -5,6 +5,7 @@ import json
 import logging
 import random
 from math import ceil, sqrt
+
 try:
     from .easyuse_anima.aio.first_pass_cache import (
         AIO_FIRST_PASS_CACHE_MAX_ENTRIES as AIO_FIRST_PASS_CACHE_MAX_ENTRIES,

--- a/nodes.py
+++ b/nodes.py
@@ -59,6 +59,7 @@ try:
         _apply_aio_final_fit as _apply_aio_final_fit,
         _aio_final_fit_size as _aio_final_fit_size,
         _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
+        _resize_image_to_size_if_needed as _resize_image_to_size_if_needed,
         _run_aio_postprocess_stage as _run_aio_postprocess_stage,
     )
     from .easyuse_anima.aio.conditioning import (
@@ -619,6 +620,7 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _apply_aio_final_fit as _apply_aio_final_fit,
         _aio_final_fit_size as _aio_final_fit_size,
         _bind_aio_postprocess_runtime as _bind_aio_postprocess_runtime,
+        _resize_image_to_size_if_needed as _resize_image_to_size_if_needed,
         _run_aio_postprocess_stage as _run_aio_postprocess_stage,
     )
     from easyuse_anima.aio.conditioning import (
@@ -1673,22 +1675,6 @@ def _find_loaded_node_class(node_id: str):
     return _adapter_find_loaded_node_class(node_id, _find_comfy_node_class)
 
 
-
-
-def _resize_image_to_size_if_needed(
-    image,
-    target_width: int,
-    target_height: int,
-    upscale_method: str = "bicubic",
-) -> tuple[Any, bool]:
-    target_width = max(1, int(target_width))
-    target_height = max(1, int(target_height))
-    width, height = _image_tensor_size(image, target_width, target_height)
-    if width == target_width and height == target_height:
-        return image, False
-    samples = image.movedim(-1, 1)
-    resized = _common_upscale_image(samples, target_width, target_height, str(upscale_method or "bicubic"))
-    return resized.movedim(1, -1), True
 
 
 def _consume_reserved_wildcard_next_seed(

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14352,7 +14352,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14360,12 +14360,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14383,7 +14383,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14391,12 +14391,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14414,7 +14414,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14422,12 +14422,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14445,7 +14445,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14453,12 +14453,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14476,7 +14476,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14484,12 +14484,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_first_pass_cache_runtime",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14507,7 +14507,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14515,12 +14515,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14538,7 +14538,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14546,12 +14546,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14569,7 +14569,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14577,12 +14577,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14600,7 +14600,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14608,12 +14608,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_legacy_generation_runtime",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14631,7 +14631,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14639,12 +14639,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14662,7 +14662,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14670,12 +14670,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14693,7 +14693,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14701,12 +14701,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14724,7 +14724,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14732,12 +14732,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14755,7 +14755,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14763,12 +14763,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14786,7 +14786,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14794,12 +14794,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14817,7 +14817,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14825,12 +14825,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 20,
+        "line": 21,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14848,7 +14848,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14856,12 +14856,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14879,7 +14879,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14887,12 +14887,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14910,7 +14910,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14918,12 +14918,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14941,7 +14941,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14949,12 +14949,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14972,7 +14972,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -14980,12 +14980,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15003,7 +15003,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15011,12 +15011,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15034,7 +15034,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15042,12 +15042,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15065,7 +15065,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15073,12 +15073,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15096,7 +15096,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15104,12 +15104,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15127,7 +15127,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15135,12 +15135,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_generation_normalization_runtime",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15158,7 +15158,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15166,12 +15166,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15189,7 +15189,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15197,12 +15197,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15220,7 +15220,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15228,12 +15228,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15251,7 +15251,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15259,12 +15259,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15282,7 +15282,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15290,12 +15290,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15313,7 +15313,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15321,12 +15321,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 30,
+        "line": 31,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15344,7 +15344,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15352,12 +15352,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 48,
+        "line": 49,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15375,7 +15375,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15383,12 +15383,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15406,7 +15406,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15414,12 +15414,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15437,7 +15437,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15445,12 +15445,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_usdu_planning_runtime",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15468,7 +15468,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15476,12 +15476,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15499,7 +15499,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15507,12 +15507,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15530,7 +15530,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15538,12 +15538,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_postprocess_runtime",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15561,7 +15561,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15569,12 +15569,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15592,7 +15592,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15600,12 +15600,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 56,
+        "line": 57,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15623,7 +15623,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15631,12 +15631,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15654,7 +15654,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15662,12 +15662,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15685,7 +15685,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15693,12 +15693,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15716,7 +15716,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15724,12 +15724,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_conditioning_runtime",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 63,
+        "line": 64,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15747,7 +15747,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15755,12 +15755,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15778,7 +15778,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15786,12 +15786,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15809,7 +15809,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15817,12 +15817,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15840,7 +15840,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15848,12 +15848,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15871,7 +15871,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15879,12 +15879,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15902,7 +15902,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15910,12 +15910,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15933,7 +15933,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15941,12 +15941,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15964,7 +15964,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -15972,12 +15972,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15995,7 +15995,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16003,12 +16003,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16026,7 +16026,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16034,12 +16034,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_model_preparation_runtime",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16057,7 +16057,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16065,12 +16065,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16088,7 +16088,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16096,12 +16096,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16119,7 +16119,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16127,12 +16127,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 69,
+        "line": 70,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16150,7 +16150,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16158,12 +16158,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16181,7 +16181,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16189,12 +16189,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16212,7 +16212,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16220,12 +16220,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_sampling_runtime",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16243,7 +16243,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16251,12 +16251,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16274,7 +16274,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16282,12 +16282,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16305,7 +16305,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16313,12 +16313,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16336,7 +16336,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16344,12 +16344,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16367,7 +16367,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16375,12 +16375,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16398,7 +16398,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16406,12 +16406,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16429,7 +16429,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16437,12 +16437,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16460,7 +16460,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16468,12 +16468,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16491,7 +16491,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16499,12 +16499,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 84,
+        "line": 85,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16522,7 +16522,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16530,12 +16530,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16553,7 +16553,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16561,12 +16561,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16584,7 +16584,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16592,12 +16592,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16615,7 +16615,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16623,12 +16623,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16646,7 +16646,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16654,12 +16654,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16677,7 +16677,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16685,12 +16685,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16708,7 +16708,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16716,12 +16716,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_preview_runtime",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16739,7 +16739,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16747,12 +16747,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16770,7 +16770,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16778,12 +16778,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16801,7 +16801,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16809,12 +16809,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 98,
+        "line": 99,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16832,7 +16832,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16840,12 +16840,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16863,7 +16863,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16871,12 +16871,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16894,7 +16894,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16902,12 +16902,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16925,7 +16925,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16933,12 +16933,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16956,7 +16956,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16964,12 +16964,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16987,7 +16987,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -16995,12 +16995,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_output_runtime",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17018,7 +17018,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17026,12 +17026,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17049,7 +17049,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17057,12 +17057,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17080,7 +17080,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17088,12 +17088,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17111,7 +17111,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17119,12 +17119,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 110,
+        "line": 111,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17142,7 +17142,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17150,12 +17150,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_resource_runtime",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17173,7 +17173,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17181,12 +17181,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17204,7 +17204,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17212,12 +17212,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17235,7 +17235,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17243,12 +17243,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17266,7 +17266,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17274,12 +17274,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17297,7 +17297,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17305,12 +17305,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17328,7 +17328,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17336,12 +17336,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17359,7 +17359,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17367,12 +17367,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17390,7 +17390,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17398,12 +17398,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17421,7 +17421,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17429,12 +17429,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17452,7 +17452,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17460,12 +17460,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17483,7 +17483,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17491,12 +17491,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17514,7 +17514,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17522,12 +17522,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17545,7 +17545,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17553,12 +17553,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17576,7 +17576,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17584,12 +17584,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17607,7 +17607,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17615,12 +17615,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 122,
+        "line": 123,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17638,7 +17638,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17646,12 +17646,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17669,7 +17669,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17677,12 +17677,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17700,7 +17700,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17708,12 +17708,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 140,
+        "line": 141,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17731,7 +17731,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17739,12 +17739,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17762,7 +17762,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17770,12 +17770,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17793,7 +17793,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17801,12 +17801,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17824,7 +17824,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17832,12 +17832,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17855,7 +17855,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17863,12 +17863,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 145,
+        "line": 146,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17886,7 +17886,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17894,12 +17894,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 152,
+        "line": 153,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17917,7 +17917,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17925,12 +17925,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_correction_runtime",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17948,7 +17948,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17956,12 +17956,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17979,7 +17979,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -17987,12 +17987,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -18010,7 +18010,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18018,12 +18018,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -18041,7 +18041,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18049,12 +18049,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18072,7 +18072,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18080,12 +18080,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18103,7 +18103,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18111,12 +18111,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18134,7 +18134,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18142,12 +18142,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_fields_runtime",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18165,7 +18165,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18173,12 +18173,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18196,7 +18196,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18204,12 +18204,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18227,7 +18227,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18235,12 +18235,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18258,7 +18258,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18266,12 +18266,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18289,7 +18289,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18297,12 +18297,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18320,7 +18320,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18328,12 +18328,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 159,
+        "line": 160,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18351,7 +18351,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18359,12 +18359,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18382,7 +18382,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18390,12 +18390,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18413,7 +18413,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18421,12 +18421,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18444,7 +18444,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18452,12 +18452,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18475,7 +18475,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18483,12 +18483,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18506,7 +18506,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18514,12 +18514,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18537,7 +18537,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18545,12 +18545,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 173,
+        "line": 174,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18568,7 +18568,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18576,12 +18576,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18599,7 +18599,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18607,12 +18607,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18630,7 +18630,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18638,12 +18638,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18661,7 +18661,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18669,12 +18669,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18692,7 +18692,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18700,12 +18700,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18723,7 +18723,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18731,12 +18731,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18754,7 +18754,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18762,12 +18762,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18785,7 +18785,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18793,12 +18793,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18816,7 +18816,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18824,12 +18824,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18847,7 +18847,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18855,12 +18855,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18878,7 +18878,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18886,12 +18886,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18909,7 +18909,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18917,12 +18917,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18940,7 +18940,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18948,12 +18948,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_advanced_runtime",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18971,7 +18971,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -18979,12 +18979,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19002,7 +19002,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19010,12 +19010,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19033,7 +19033,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19041,12 +19041,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19064,7 +19064,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19072,12 +19072,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19095,7 +19095,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19103,12 +19103,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19126,7 +19126,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19134,12 +19134,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19157,7 +19157,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19165,12 +19165,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19188,7 +19188,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19196,12 +19196,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19219,7 +19219,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19227,12 +19227,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 191,
+        "line": 192,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19250,7 +19250,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19258,12 +19258,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19281,7 +19281,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19289,12 +19289,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_runtime",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19312,7 +19312,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19320,12 +19320,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19343,7 +19343,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19351,12 +19351,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19374,7 +19374,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19382,12 +19382,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19405,7 +19405,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19413,12 +19413,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19436,7 +19436,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19444,12 +19444,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19467,7 +19467,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19475,12 +19475,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19498,7 +19498,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19506,12 +19506,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19529,7 +19529,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19537,12 +19537,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19560,7 +19560,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19568,12 +19568,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19591,7 +19591,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19599,12 +19599,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19622,7 +19622,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19630,12 +19630,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19653,7 +19653,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19661,12 +19661,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 227,
+        "line": 228,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19684,7 +19684,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19692,12 +19692,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19715,7 +19715,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19723,12 +19723,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19746,7 +19746,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19754,12 +19754,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19777,7 +19777,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19785,12 +19785,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19808,7 +19808,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19816,12 +19816,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19839,7 +19839,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19847,12 +19847,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_conditioning_runtime",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19870,7 +19870,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19878,12 +19878,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19901,7 +19901,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19909,12 +19909,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19932,7 +19932,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19940,12 +19940,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 255,
+        "line": 256,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19963,7 +19963,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -19971,12 +19971,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19994,7 +19994,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20002,12 +20002,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20025,7 +20025,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20033,12 +20033,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20056,7 +20056,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20064,12 +20064,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20087,7 +20087,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20095,12 +20095,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20118,7 +20118,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20126,12 +20126,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20149,7 +20149,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20157,12 +20157,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20180,7 +20180,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20188,12 +20188,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20211,7 +20211,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20219,12 +20219,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20242,7 +20242,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20250,12 +20250,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20273,7 +20273,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20281,12 +20281,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20304,7 +20304,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20312,12 +20312,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20335,7 +20335,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20343,12 +20343,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20366,7 +20366,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20374,12 +20374,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20397,7 +20397,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20405,12 +20405,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_artist_mix_runtime",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20428,7 +20428,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20436,12 +20436,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20459,7 +20459,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20467,12 +20467,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20490,7 +20490,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20498,12 +20498,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20521,7 +20521,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20529,12 +20529,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20552,7 +20552,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20560,12 +20560,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20583,7 +20583,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20591,12 +20591,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20614,7 +20614,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20622,12 +20622,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20645,7 +20645,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20653,12 +20653,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20676,7 +20676,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20684,12 +20684,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20707,7 +20707,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20715,12 +20715,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 271,
+        "line": 272,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20738,7 +20738,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20746,12 +20746,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20769,7 +20769,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20777,12 +20777,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20800,7 +20800,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20808,12 +20808,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20831,7 +20831,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20839,12 +20839,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_data_node_runtime",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 351,
+        "line": 352,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20862,7 +20862,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20870,12 +20870,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20893,7 +20893,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20901,12 +20901,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20924,7 +20924,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20932,12 +20932,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 357,
+        "line": 358,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20955,7 +20955,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20963,12 +20963,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20986,7 +20986,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -20994,12 +20994,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21017,7 +21017,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21025,12 +21025,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_advanced_node_runtime",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 362,
+        "line": 363,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21048,7 +21048,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21056,12 +21056,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21079,7 +21079,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21087,12 +21087,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21110,7 +21110,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21118,12 +21118,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21141,7 +21141,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21149,12 +21149,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21172,7 +21172,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21180,12 +21180,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_node_runtime",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21203,7 +21203,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21211,12 +21211,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21234,7 +21234,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21242,12 +21242,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 368,
+        "line": 369,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21265,7 +21265,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21273,12 +21273,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21296,7 +21296,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21304,12 +21304,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21327,7 +21327,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21335,12 +21335,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 377,
+        "line": 378,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21358,7 +21358,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21366,12 +21366,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_runtime",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21389,7 +21389,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21397,12 +21397,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21420,7 +21420,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21428,12 +21428,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21451,7 +21451,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21459,12 +21459,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 388,
+        "line": 389,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21482,7 +21482,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21490,12 +21490,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21513,7 +21513,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21521,12 +21521,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 401,
+        "line": 402,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21544,7 +21544,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21552,12 +21552,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_max_resolution",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21575,7 +21575,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21583,12 +21583,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21606,7 +21606,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21614,12 +21614,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21637,7 +21637,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21645,12 +21645,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_comfy_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21668,7 +21668,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21676,12 +21676,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_loaded_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21699,7 +21699,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21707,12 +21707,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21730,7 +21730,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21738,12 +21738,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_any_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21761,7 +21761,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21769,12 +21769,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 409,
+        "line": 410,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21792,7 +21792,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21800,12 +21800,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21823,7 +21823,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21831,12 +21831,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21854,7 +21854,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21862,12 +21862,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_encode_with_comfy_clip",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21885,7 +21885,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21893,12 +21893,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 420,
+        "line": 421,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21916,7 +21916,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21924,12 +21924,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21947,7 +21947,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21955,12 +21955,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21978,7 +21978,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -21986,12 +21986,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22009,7 +22009,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22017,12 +22017,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22040,7 +22040,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22048,12 +22048,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 427,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22071,7 +22071,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22079,12 +22079,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22102,7 +22102,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22110,12 +22110,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 434,
+        "line": 435,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22133,7 +22133,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22141,12 +22141,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_impact_detailer_node_runtime",
           "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 438,
+        "line": 439,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22164,7 +22164,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22172,12 +22172,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22195,7 +22195,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22203,12 +22203,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22226,7 +22226,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22234,12 +22234,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_node_runtime",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 442,
+        "line": 443,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22257,7 +22257,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22265,12 +22265,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22288,7 +22288,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22296,12 +22296,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22319,7 +22319,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22327,12 +22327,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22350,7 +22350,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22358,12 +22358,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22381,7 +22381,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22389,12 +22389,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_node_runtime",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 447,
+        "line": 448,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22412,7 +22412,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22420,12 +22420,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22443,7 +22443,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22451,12 +22451,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22474,7 +22474,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22482,12 +22482,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_node_runtime",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 454,
+        "line": 455,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22505,7 +22505,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22513,12 +22513,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 459,
+        "line": 460,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22536,7 +22536,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22544,12 +22544,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 459,
+        "line": 460,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22567,7 +22567,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22575,12 +22575,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 459,
+        "line": 460,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22598,7 +22598,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22606,12 +22606,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22629,7 +22629,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22637,12 +22637,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22660,7 +22660,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22668,12 +22668,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22691,7 +22691,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22699,12 +22699,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22722,7 +22722,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22730,12 +22730,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 477,
+        "line": 478,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22753,7 +22753,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22761,12 +22761,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22784,7 +22784,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22792,12 +22792,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 501,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22815,7 +22815,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22823,12 +22823,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22846,7 +22846,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22854,12 +22854,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 504,
+        "line": 505,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22877,7 +22877,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22885,12 +22885,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22908,7 +22908,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22916,12 +22916,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_metadata_runtime",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22939,7 +22939,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22947,12 +22947,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22970,7 +22970,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -22978,12 +22978,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23001,7 +23001,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23009,12 +23009,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23032,7 +23032,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23040,12 +23040,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23063,7 +23063,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23071,12 +23071,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23094,7 +23094,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23102,12 +23102,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23125,7 +23125,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23133,12 +23133,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23156,7 +23156,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23164,12 +23164,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23187,7 +23187,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23195,12 +23195,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23218,7 +23218,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23226,12 +23226,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23249,7 +23249,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23257,12 +23257,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23280,7 +23280,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23288,12 +23288,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23311,7 +23311,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23319,12 +23319,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 509,
+        "line": 510,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23342,7 +23342,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23350,12 +23350,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_preset_runtime",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23373,7 +23373,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23381,12 +23381,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23404,7 +23404,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23412,12 +23412,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23435,7 +23435,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23443,12 +23443,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23466,7 +23466,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23474,12 +23474,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23497,7 +23497,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23505,12 +23505,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23528,7 +23528,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23536,12 +23536,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23559,7 +23559,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23567,12 +23567,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 526,
+        "line": 527,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23590,7 +23590,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23598,12 +23598,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23621,7 +23621,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23629,12 +23629,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_node_runtime",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 536,
+        "line": 537,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23652,7 +23652,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23660,12 +23660,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23683,7 +23683,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23691,12 +23691,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 540,
+        "line": 541,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23714,7 +23714,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23722,12 +23722,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23745,7 +23745,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23753,12 +23753,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23776,7 +23776,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23784,12 +23784,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23807,7 +23807,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23815,12 +23815,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23838,7 +23838,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23846,12 +23846,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23869,7 +23869,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23877,12 +23877,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 547,
+        "line": 548,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23900,7 +23900,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23908,12 +23908,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23931,7 +23931,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23939,12 +23939,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23962,7 +23962,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -23970,12 +23970,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23993,7 +23993,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24001,12 +24001,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24024,7 +24024,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24032,12 +24032,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24055,7 +24055,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24063,12 +24063,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24086,7 +24086,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24094,12 +24094,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24117,7 +24117,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24125,12 +24125,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24148,7 +24148,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24156,12 +24156,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24179,7 +24179,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24187,12 +24187,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24210,7 +24210,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24218,12 +24218,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24241,7 +24241,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24249,12 +24249,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24272,7 +24272,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24280,12 +24280,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24303,7 +24303,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24311,12 +24311,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24334,7 +24334,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24342,12 +24342,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24365,7 +24365,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24373,12 +24373,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24396,7 +24396,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24404,12 +24404,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24427,7 +24427,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24435,12 +24435,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24458,7 +24458,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "internal",
@@ -24466,12 +24466,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24490,9 +24490,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24500,12 +24500,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24524,9 +24524,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24534,12 +24534,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24558,9 +24558,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24568,12 +24568,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24592,9 +24592,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24602,12 +24602,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24626,9 +24626,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24636,12 +24636,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_first_pass_cache_runtime",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24660,9 +24660,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24670,12 +24670,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24694,9 +24694,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24704,12 +24704,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24728,9 +24728,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24738,12 +24738,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24762,9 +24762,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24772,12 +24772,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_legacy_generation_runtime",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24796,9 +24796,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24806,12 +24806,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24830,9 +24830,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24840,12 +24840,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24864,9 +24864,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24874,12 +24874,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24898,9 +24898,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24908,12 +24908,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24932,9 +24932,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24942,12 +24942,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24966,9 +24966,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -24976,12 +24976,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25000,9 +25000,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25010,12 +25010,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25034,9 +25034,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25044,12 +25044,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25068,9 +25068,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25078,12 +25078,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25102,9 +25102,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25112,12 +25112,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25136,9 +25136,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25146,12 +25146,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25170,9 +25170,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25180,12 +25180,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25204,9 +25204,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25214,12 +25214,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25238,9 +25238,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25248,12 +25248,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25272,9 +25272,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25282,12 +25282,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25306,9 +25306,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25316,12 +25316,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25340,9 +25340,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25350,12 +25350,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_generation_normalization_runtime",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25374,9 +25374,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25384,12 +25384,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25408,9 +25408,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25418,12 +25418,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25442,9 +25442,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25452,12 +25452,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25476,9 +25476,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25486,12 +25486,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25510,9 +25510,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25520,12 +25520,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25544,9 +25544,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25554,12 +25554,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25578,9 +25578,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25588,12 +25588,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25612,9 +25612,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25622,12 +25622,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25646,9 +25646,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25656,12 +25656,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25680,9 +25680,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25690,12 +25690,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_usdu_planning_runtime",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25714,9 +25714,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25724,12 +25724,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25748,9 +25748,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25758,12 +25758,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25782,9 +25782,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25792,12 +25792,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_postprocess_runtime",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25816,9 +25816,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25826,12 +25826,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25850,9 +25850,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25860,12 +25860,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25884,9 +25884,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25894,12 +25894,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25918,9 +25918,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25928,12 +25928,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25952,9 +25952,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25962,12 +25962,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25986,9 +25986,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -25996,12 +25996,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_conditioning_runtime",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26020,9 +26020,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26030,12 +26030,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26054,9 +26054,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26064,12 +26064,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26088,9 +26088,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26098,12 +26098,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26122,9 +26122,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26132,12 +26132,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26156,9 +26156,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26166,12 +26166,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26190,9 +26190,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26200,12 +26200,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26224,9 +26224,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26234,12 +26234,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26258,9 +26258,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26268,12 +26268,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26292,9 +26292,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26302,12 +26302,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26326,9 +26326,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26336,12 +26336,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_model_preparation_runtime",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26360,9 +26360,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26370,12 +26370,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26394,9 +26394,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26404,12 +26404,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26428,9 +26428,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26438,12 +26438,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26462,9 +26462,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26472,12 +26472,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26496,9 +26496,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26506,12 +26506,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26530,9 +26530,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26540,12 +26540,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_sampling_runtime",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26564,9 +26564,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26574,12 +26574,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26598,9 +26598,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26608,12 +26608,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26632,9 +26632,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26642,12 +26642,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26666,9 +26666,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26676,12 +26676,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26700,9 +26700,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26710,12 +26710,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26734,9 +26734,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26744,12 +26744,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26768,9 +26768,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26778,12 +26778,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26802,9 +26802,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26812,12 +26812,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26836,9 +26836,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26846,12 +26846,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26870,9 +26870,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26880,12 +26880,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26904,9 +26904,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26914,12 +26914,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26938,9 +26938,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26948,12 +26948,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26972,9 +26972,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -26982,12 +26982,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27006,9 +27006,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27016,12 +27016,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27040,9 +27040,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27050,12 +27050,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27074,9 +27074,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27084,12 +27084,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_preview_runtime",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27108,9 +27108,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27118,12 +27118,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27142,9 +27142,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27152,12 +27152,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27176,9 +27176,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27186,12 +27186,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27210,9 +27210,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27220,12 +27220,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27244,9 +27244,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27254,12 +27254,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27278,9 +27278,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27288,12 +27288,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27312,9 +27312,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27322,12 +27322,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27346,9 +27346,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27356,12 +27356,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27380,9 +27380,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27390,12 +27390,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_output_runtime",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27414,9 +27414,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27424,12 +27424,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27448,9 +27448,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27458,12 +27458,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27482,9 +27482,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27492,12 +27492,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27516,9 +27516,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27526,12 +27526,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27550,9 +27550,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27560,12 +27560,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_resource_runtime",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27584,9 +27584,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27594,12 +27594,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27618,9 +27618,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27628,12 +27628,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27652,9 +27652,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27662,12 +27662,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27686,9 +27686,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27696,12 +27696,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27720,9 +27720,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27730,12 +27730,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27754,9 +27754,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27764,12 +27764,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27788,9 +27788,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27798,12 +27798,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27822,9 +27822,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27832,12 +27832,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27856,9 +27856,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27866,12 +27866,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27890,9 +27890,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27900,12 +27900,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27924,9 +27924,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27934,12 +27934,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27958,9 +27958,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -27968,12 +27968,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27992,9 +27992,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28002,12 +28002,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28026,9 +28026,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28036,12 +28036,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28060,9 +28060,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28070,12 +28070,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28094,9 +28094,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28104,12 +28104,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 701,
+        "line": 702,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28128,9 +28128,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28138,12 +28138,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 701,
+        "line": 702,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28162,9 +28162,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28172,12 +28172,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 702,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28196,9 +28196,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28206,12 +28206,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28230,9 +28230,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28240,12 +28240,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28264,9 +28264,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28274,12 +28274,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28298,9 +28298,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28308,12 +28308,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28332,9 +28332,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28342,12 +28342,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28366,9 +28366,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28376,12 +28376,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 713,
+        "line": 714,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28400,9 +28400,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28410,12 +28410,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_correction_runtime",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28434,9 +28434,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28444,12 +28444,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28468,9 +28468,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28478,12 +28478,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28502,9 +28502,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28512,12 +28512,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28536,9 +28536,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28546,12 +28546,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28570,9 +28570,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28580,12 +28580,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28604,9 +28604,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28614,12 +28614,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28638,9 +28638,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28648,12 +28648,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_fields_runtime",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28672,9 +28672,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28682,12 +28682,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28706,9 +28706,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28716,12 +28716,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28740,9 +28740,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28750,12 +28750,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28774,9 +28774,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28784,12 +28784,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28808,9 +28808,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28818,12 +28818,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28842,9 +28842,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28852,12 +28852,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28876,9 +28876,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28886,12 +28886,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28910,9 +28910,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28920,12 +28920,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28944,9 +28944,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28954,12 +28954,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28978,9 +28978,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -28988,12 +28988,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29012,9 +29012,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29022,12 +29022,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29046,9 +29046,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29056,12 +29056,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29080,9 +29080,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29090,12 +29090,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29114,9 +29114,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29124,12 +29124,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29148,9 +29148,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29158,12 +29158,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29182,9 +29182,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29192,12 +29192,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29216,9 +29216,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29226,12 +29226,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29250,9 +29250,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29260,12 +29260,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29284,9 +29284,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29294,12 +29294,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29318,9 +29318,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29328,12 +29328,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29352,9 +29352,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29362,12 +29362,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29386,9 +29386,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29396,12 +29396,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29420,9 +29420,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29430,12 +29430,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29454,9 +29454,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29464,12 +29464,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29488,9 +29488,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29498,12 +29498,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29522,9 +29522,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29532,12 +29532,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_advanced_runtime",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29556,9 +29556,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29566,12 +29566,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29590,9 +29590,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29600,12 +29600,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29624,9 +29624,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29634,12 +29634,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29658,9 +29658,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29668,12 +29668,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29692,9 +29692,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29702,12 +29702,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29726,9 +29726,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29736,12 +29736,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29760,9 +29760,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29770,12 +29770,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29794,9 +29794,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29804,12 +29804,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29828,9 +29828,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29838,12 +29838,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29862,9 +29862,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29872,12 +29872,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29896,9 +29896,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29906,12 +29906,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_runtime",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29930,9 +29930,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29940,12 +29940,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29964,9 +29964,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -29974,12 +29974,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29998,9 +29998,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30008,12 +30008,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30032,9 +30032,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30042,12 +30042,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30066,9 +30066,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30076,12 +30076,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30100,9 +30100,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30110,12 +30110,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30134,9 +30134,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30144,12 +30144,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30168,9 +30168,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30178,12 +30178,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30202,9 +30202,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30212,12 +30212,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30236,9 +30236,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30246,12 +30246,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30270,9 +30270,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30280,12 +30280,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30304,9 +30304,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30314,12 +30314,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30338,9 +30338,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30348,12 +30348,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30372,9 +30372,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30382,12 +30382,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30406,9 +30406,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30416,12 +30416,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30440,9 +30440,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30450,12 +30450,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30474,9 +30474,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30484,12 +30484,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30508,9 +30508,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30518,12 +30518,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_conditioning_runtime",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30542,9 +30542,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30552,12 +30552,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30576,9 +30576,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30586,12 +30586,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30610,9 +30610,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30620,12 +30620,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30644,9 +30644,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30654,12 +30654,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30678,9 +30678,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30688,12 +30688,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30712,9 +30712,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30722,12 +30722,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30746,9 +30746,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30756,12 +30756,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30780,9 +30780,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30790,12 +30790,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30814,9 +30814,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30824,12 +30824,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30848,9 +30848,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30858,12 +30858,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30882,9 +30882,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30892,12 +30892,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30916,9 +30916,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30926,12 +30926,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30950,9 +30950,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30960,12 +30960,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30984,9 +30984,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -30994,12 +30994,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31018,9 +31018,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31028,12 +31028,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31052,9 +31052,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31062,12 +31062,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31086,9 +31086,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31096,12 +31096,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31120,9 +31120,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31130,12 +31130,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_artist_mix_runtime",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31154,9 +31154,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31164,12 +31164,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31188,9 +31188,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31198,12 +31198,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31222,9 +31222,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31232,12 +31232,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31256,9 +31256,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31266,12 +31266,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31290,9 +31290,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31300,12 +31300,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31324,9 +31324,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31334,12 +31334,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31358,9 +31358,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31368,12 +31368,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31392,9 +31392,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31402,12 +31402,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31426,9 +31426,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31436,12 +31436,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31460,9 +31460,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31470,12 +31470,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31494,9 +31494,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31504,12 +31504,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31528,9 +31528,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31538,12 +31538,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31562,9 +31562,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31572,12 +31572,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31596,9 +31596,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31606,12 +31606,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_data_node_runtime",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31630,9 +31630,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31640,12 +31640,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 918,
+        "line": 919,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31664,9 +31664,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31674,12 +31674,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 918,
+        "line": 919,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31698,9 +31698,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31708,12 +31708,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 918,
+        "line": 919,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31732,9 +31732,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31742,12 +31742,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 923,
+        "line": 924,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31766,9 +31766,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31776,12 +31776,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 923,
+        "line": 924,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31800,9 +31800,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31810,12 +31810,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_advanced_node_runtime",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 924,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31834,9 +31834,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31844,12 +31844,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31868,9 +31868,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31878,12 +31878,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31902,9 +31902,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31912,12 +31912,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31936,9 +31936,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31946,12 +31946,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31970,9 +31970,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -31980,12 +31980,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_node_runtime",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32004,9 +32004,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32014,12 +32014,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32038,9 +32038,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32048,12 +32048,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32072,9 +32072,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32082,12 +32082,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 938,
+        "line": 939,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32106,9 +32106,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32116,12 +32116,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 938,
+        "line": 939,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32140,9 +32140,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32150,12 +32150,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 938,
+        "line": 939,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32174,9 +32174,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32184,12 +32184,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_runtime",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32208,9 +32208,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32218,12 +32218,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32242,9 +32242,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32252,12 +32252,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32276,9 +32276,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32286,12 +32286,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32310,9 +32310,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32320,12 +32320,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 962,
+        "line": 963,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32344,9 +32344,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32354,12 +32354,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 962,
+        "line": 963,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32378,9 +32378,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32388,12 +32388,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_max_resolution",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32412,9 +32412,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32422,12 +32422,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32446,9 +32446,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32456,12 +32456,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32480,9 +32480,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32490,12 +32490,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_comfy_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32514,9 +32514,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32524,12 +32524,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_loaded_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32548,9 +32548,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32558,12 +32558,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32582,9 +32582,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32592,12 +32592,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_any_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32616,9 +32616,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32626,12 +32626,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32650,9 +32650,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32660,12 +32660,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32684,9 +32684,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32694,12 +32694,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32718,9 +32718,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32728,12 +32728,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_encode_with_comfy_clip",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32752,9 +32752,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32762,12 +32762,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32786,9 +32786,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32796,12 +32796,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32820,9 +32820,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32830,12 +32830,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32854,9 +32854,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32864,12 +32864,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32888,9 +32888,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32898,12 +32898,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32922,9 +32922,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32932,12 +32932,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32956,9 +32956,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -32966,12 +32966,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 996,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32990,9 +32990,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33000,12 +33000,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 996,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33024,9 +33024,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33034,12 +33034,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_impact_detailer_node_runtime",
           "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1000,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33058,9 +33058,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33068,12 +33068,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1004,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33092,9 +33092,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33102,12 +33102,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1004,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33126,9 +33126,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33136,12 +33136,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_node_runtime",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1004,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33160,9 +33160,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33170,12 +33170,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33194,9 +33194,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33204,12 +33204,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33228,9 +33228,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33238,12 +33238,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33262,9 +33262,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33272,12 +33272,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33296,9 +33296,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33306,12 +33306,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_node_runtime",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33330,9 +33330,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33340,12 +33340,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1016,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33364,9 +33364,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33374,12 +33374,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1016,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33398,9 +33398,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33408,12 +33408,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_node_runtime",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1016,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33432,9 +33432,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33442,12 +33442,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1021,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33466,9 +33466,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33476,12 +33476,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1021,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33500,9 +33500,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33510,12 +33510,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1021,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33534,9 +33534,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33544,12 +33544,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33568,9 +33568,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33578,12 +33578,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33602,9 +33602,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33612,12 +33612,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33636,9 +33636,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33646,12 +33646,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33670,9 +33670,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33680,12 +33680,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33704,9 +33704,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33714,12 +33714,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1062,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33738,9 +33738,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33748,12 +33748,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1062,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33772,9 +33772,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33782,12 +33782,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1066,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33806,9 +33806,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33816,12 +33816,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1066,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33840,9 +33840,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33850,12 +33850,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33874,9 +33874,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33884,12 +33884,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_metadata_runtime",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33908,9 +33908,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33918,12 +33918,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33942,9 +33942,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33952,12 +33952,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33976,9 +33976,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -33986,12 +33986,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34010,9 +34010,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34020,12 +34020,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34044,9 +34044,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34054,12 +34054,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34078,9 +34078,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34088,12 +34088,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34112,9 +34112,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34122,12 +34122,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34146,9 +34146,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34156,12 +34156,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34180,9 +34180,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34190,12 +34190,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34214,9 +34214,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34224,12 +34224,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34248,9 +34248,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34258,12 +34258,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34282,9 +34282,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34292,12 +34292,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34316,9 +34316,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34326,12 +34326,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34350,9 +34350,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34360,12 +34360,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_preset_runtime",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34384,9 +34384,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34394,12 +34394,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34418,9 +34418,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34428,12 +34428,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34452,9 +34452,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34462,12 +34462,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34486,9 +34486,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34496,12 +34496,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34520,9 +34520,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34530,12 +34530,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34554,9 +34554,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34564,12 +34564,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34588,9 +34588,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34598,12 +34598,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34622,9 +34622,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34632,12 +34632,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1098,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34656,9 +34656,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34666,12 +34666,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_node_runtime",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1098,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34690,9 +34690,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34700,12 +34700,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1102,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34724,9 +34724,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34734,12 +34734,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1102,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34758,9 +34758,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34768,12 +34768,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1103,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34792,9 +34792,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34802,12 +34802,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1104,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34826,9 +34826,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34836,12 +34836,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1104,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34860,9 +34860,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34870,12 +34870,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1104,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34894,9 +34894,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34904,12 +34904,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1109,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34928,9 +34928,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34938,12 +34938,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1109,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34962,9 +34962,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -34972,12 +34972,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34996,9 +34996,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35006,12 +35006,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35030,9 +35030,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35040,12 +35040,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35064,9 +35064,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35074,12 +35074,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35098,9 +35098,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35108,12 +35108,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35132,9 +35132,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35142,12 +35142,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35166,9 +35166,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35176,12 +35176,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35200,9 +35200,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35210,12 +35210,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35234,9 +35234,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35244,12 +35244,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35268,9 +35268,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35278,12 +35278,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35302,9 +35302,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35312,12 +35312,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35336,9 +35336,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35346,12 +35346,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35370,9 +35370,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35380,12 +35380,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35404,9 +35404,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35414,12 +35414,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35438,9 +35438,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35448,12 +35448,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35472,9 +35472,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35482,12 +35482,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35506,9 +35506,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35516,12 +35516,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35540,9 +35540,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35550,12 +35550,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35574,9 +35574,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
@@ -35584,12 +35584,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 8
+          "try_line": 9
         },
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35607,7 +35607,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1627
           }
         ],
         "classification": "external",
@@ -35615,7 +35615,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1628,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35632,7 +35632,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1635
           }
         ],
         "classification": "external",
@@ -35640,7 +35640,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1636,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35657,7 +35657,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1643
           }
         ],
         "classification": "external",
@@ -35665,7 +35665,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1644,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -39297,9 +39297,9 @@
       },
       {
         "is_package": false,
-        "loc": 1863,
+        "loc": 1864,
         "module": "nodes",
-        "normalized_git_blob_sha1": "10cb7e31fd9f8a4f85ecd65515881ae3ecafd3c3",
+        "normalized_git_blob_sha1": "ddc55db1b1676a9aacd858dd36596ff2cd11f897",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -40663,16 +40663,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40686,16 +40686,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40709,16 +40709,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40732,16 +40732,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40755,16 +40755,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40778,16 +40778,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40801,16 +40801,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40824,16 +40824,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 571,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40847,16 +40847,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40870,16 +40870,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40893,16 +40893,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40916,16 +40916,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40939,16 +40939,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40962,16 +40962,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40985,16 +40985,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41008,16 +41008,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 582,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41031,16 +41031,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41054,16 +41054,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41077,16 +41077,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41100,16 +41100,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41123,16 +41123,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41146,16 +41146,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41169,16 +41169,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41192,16 +41192,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41215,16 +41215,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41238,16 +41238,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41261,16 +41261,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41284,16 +41284,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41307,16 +41307,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41330,16 +41330,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41353,16 +41353,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41376,16 +41376,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41399,16 +41399,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 609,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41422,16 +41422,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41445,16 +41445,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41468,16 +41468,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41491,16 +41491,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41514,16 +41514,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41537,16 +41537,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41560,16 +41560,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41583,16 +41583,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 617,
+        "line": 618,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41606,16 +41606,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41629,16 +41629,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41652,16 +41652,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41675,16 +41675,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 625,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41698,16 +41698,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41721,16 +41721,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41744,16 +41744,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41767,16 +41767,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41790,16 +41790,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41813,16 +41813,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41836,16 +41836,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41859,16 +41859,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41882,16 +41882,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41905,16 +41905,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41928,16 +41928,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41951,16 +41951,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41974,16 +41974,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 630,
+        "line": 631,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41997,16 +41997,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42020,16 +42020,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42043,16 +42043,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42066,16 +42066,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42089,16 +42089,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42112,16 +42112,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42135,16 +42135,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42158,16 +42158,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42181,16 +42181,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42204,16 +42204,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42227,16 +42227,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42250,16 +42250,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 645,
+        "line": 646,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42273,16 +42273,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42296,16 +42296,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42319,16 +42319,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42342,16 +42342,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42365,16 +42365,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42388,16 +42388,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42411,16 +42411,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42434,16 +42434,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42457,16 +42457,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42480,16 +42480,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 659,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42503,16 +42503,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42526,16 +42526,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42549,16 +42549,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42572,16 +42572,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42595,16 +42595,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42618,16 +42618,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42641,16 +42641,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42664,16 +42664,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42687,16 +42687,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42710,16 +42710,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 671,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42733,16 +42733,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42756,16 +42756,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42779,16 +42779,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42802,16 +42802,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42825,16 +42825,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42848,16 +42848,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42871,16 +42871,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42894,16 +42894,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42917,16 +42917,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42940,16 +42940,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42963,16 +42963,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42986,16 +42986,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43009,16 +43009,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43032,16 +43032,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43055,16 +43055,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43078,16 +43078,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43101,16 +43101,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 701,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43124,16 +43124,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 701,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43147,16 +43147,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43170,16 +43170,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43193,16 +43193,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43216,16 +43216,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43239,16 +43239,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43262,16 +43262,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 706,
+        "line": 707,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43285,16 +43285,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 713,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43308,16 +43308,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43331,16 +43331,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43354,16 +43354,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43377,16 +43377,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43400,16 +43400,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43423,16 +43423,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43446,16 +43446,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43469,16 +43469,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43492,16 +43492,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43515,16 +43515,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43538,16 +43538,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43561,16 +43561,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43584,16 +43584,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43607,16 +43607,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 721,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43630,16 +43630,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43653,16 +43653,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43676,16 +43676,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43699,16 +43699,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43722,16 +43722,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43745,16 +43745,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43768,16 +43768,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 734,
+        "line": 735,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43791,16 +43791,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43814,16 +43814,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43837,16 +43837,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43860,16 +43860,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43883,16 +43883,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43906,16 +43906,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43929,16 +43929,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43952,16 +43952,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43975,16 +43975,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43998,16 +43998,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44021,16 +44021,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44044,16 +44044,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44067,16 +44067,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44090,16 +44090,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44113,16 +44113,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44136,16 +44136,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44159,16 +44159,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44182,16 +44182,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44205,16 +44205,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44228,16 +44228,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44251,16 +44251,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44274,16 +44274,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 753,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44297,16 +44297,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44320,16 +44320,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44343,16 +44343,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44366,16 +44366,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44389,16 +44389,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44412,16 +44412,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44435,16 +44435,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44458,16 +44458,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44481,16 +44481,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44504,16 +44504,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44527,16 +44527,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44550,16 +44550,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44573,16 +44573,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44596,16 +44596,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 789,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44619,16 +44619,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44642,16 +44642,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44665,16 +44665,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44688,16 +44688,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44711,16 +44711,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44734,16 +44734,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44757,16 +44757,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44780,16 +44780,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44803,16 +44803,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 816,
+        "line": 817,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44826,16 +44826,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44849,16 +44849,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44872,16 +44872,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44895,16 +44895,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44918,16 +44918,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44941,16 +44941,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44964,16 +44964,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44987,16 +44987,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45010,16 +45010,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45033,16 +45033,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45056,16 +45056,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45079,16 +45079,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45102,16 +45102,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45125,16 +45125,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45148,16 +45148,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45171,16 +45171,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45194,16 +45194,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45217,16 +45217,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45240,16 +45240,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45263,16 +45263,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45286,16 +45286,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45309,16 +45309,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45332,16 +45332,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45355,16 +45355,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45378,16 +45378,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 832,
+        "line": 833,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45401,16 +45401,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45424,16 +45424,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45447,16 +45447,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45470,16 +45470,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 913,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45493,16 +45493,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 918,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45516,16 +45516,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 918,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45539,16 +45539,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 918,
+        "line": 919,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45562,16 +45562,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 923,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45585,16 +45585,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 923,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45608,16 +45608,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 924,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45631,16 +45631,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45654,16 +45654,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45677,16 +45677,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45700,16 +45700,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45723,16 +45723,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45746,16 +45746,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45769,16 +45769,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 929,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45792,16 +45792,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 938,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45815,16 +45815,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 938,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45838,16 +45838,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 938,
+        "line": 939,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45861,16 +45861,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45884,16 +45884,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45907,16 +45907,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45930,16 +45930,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 949,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45953,16 +45953,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 962,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45976,16 +45976,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 962,
+        "line": 963,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45999,16 +45999,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46022,16 +46022,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46045,16 +46045,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46068,16 +46068,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46091,16 +46091,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46114,16 +46114,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46137,16 +46137,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46160,16 +46160,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 971,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46183,16 +46183,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46206,16 +46206,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46229,16 +46229,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46252,16 +46252,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 981,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46275,16 +46275,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46298,16 +46298,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46321,16 +46321,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46344,16 +46344,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46367,16 +46367,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46390,16 +46390,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46413,16 +46413,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46436,16 +46436,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46459,16 +46459,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46482,16 +46482,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46505,16 +46505,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46528,16 +46528,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46551,16 +46551,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46574,16 +46574,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46597,16 +46597,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46620,16 +46620,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1009,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46643,16 +46643,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46666,16 +46666,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46689,16 +46689,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1016,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46712,16 +46712,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46735,16 +46735,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46758,16 +46758,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46781,16 +46781,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46804,16 +46804,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46827,16 +46827,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46850,16 +46850,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46873,16 +46873,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1039,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46896,16 +46896,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46919,16 +46919,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46942,16 +46942,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46965,16 +46965,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46988,16 +46988,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47011,16 +47011,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47034,16 +47034,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47057,16 +47057,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47080,16 +47080,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47103,16 +47103,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47126,16 +47126,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47149,16 +47149,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47172,16 +47172,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47195,16 +47195,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47218,16 +47218,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47241,16 +47241,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47264,16 +47264,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47287,16 +47287,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47310,16 +47310,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1071,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47333,16 +47333,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47356,16 +47356,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47379,16 +47379,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47402,16 +47402,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47425,16 +47425,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47448,16 +47448,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47471,16 +47471,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47494,16 +47494,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1088,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47517,16 +47517,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47540,16 +47540,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47563,16 +47563,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47586,16 +47586,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47609,16 +47609,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47632,16 +47632,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47655,16 +47655,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47678,16 +47678,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47701,16 +47701,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47724,16 +47724,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47747,16 +47747,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47770,16 +47770,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47793,16 +47793,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47816,16 +47816,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47839,16 +47839,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47862,16 +47862,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47885,16 +47885,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47908,16 +47908,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47931,16 +47931,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47954,16 +47954,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47977,16 +47977,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48000,16 +48000,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48023,16 +48023,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48046,16 +48046,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48069,16 +48069,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48092,16 +48092,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48115,16 +48115,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48138,16 +48138,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48161,16 +48161,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 570,
             "kind": "try",
-            "line": 8
+            "line": 9
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51986,14 +51986,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1627
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1628,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52005,14 +52005,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1635
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1636,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52024,14 +52024,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1643
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1644,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53406,14 +53406,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1627
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1628,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53425,14 +53425,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1635
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1636,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53444,14 +53444,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1643
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1644,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54912,7 +54912,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1131,
+        "line": 1132,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54921,7 +54921,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1759,
+        "line": 1760,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54930,7 +54930,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1762,
+        "line": 1763,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54939,7 +54939,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1765,
+        "line": 1766,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54948,7 +54948,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1768,
+        "line": 1769,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54957,7 +54957,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1771,
+        "line": 1772,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54966,7 +54966,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1774,
+        "line": 1775,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54975,7 +54975,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1777,
+        "line": 1778,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54984,7 +54984,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1780,
+        "line": 1781,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54993,7 +54993,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1783,
+        "line": 1784,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55002,7 +55002,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1786,
+        "line": 1787,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55011,7 +55011,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1789,
+        "line": 1790,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55020,7 +55020,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1792,
+        "line": 1793,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55029,7 +55029,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1795,
+        "line": 1796,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55038,7 +55038,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1798,
+        "line": 1799,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55047,7 +55047,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1801,
+        "line": 1802,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55056,7 +55056,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1804,
+        "line": 1805,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55065,7 +55065,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1808,
+        "line": 1809,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55074,7 +55074,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1811,
+        "line": 1812,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55083,7 +55083,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1815,
+        "line": 1816,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55092,7 +55092,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1818,
+        "line": 1819,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55101,7 +55101,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1822,
+        "line": 1823,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55110,7 +55110,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1825,
+        "line": 1826,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55119,7 +55119,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1828,
+        "line": 1829,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55128,7 +55128,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1831,
+        "line": 1832,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55137,7 +55137,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1834,
+        "line": 1835,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55146,7 +55146,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1837,
+        "line": 1838,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55155,7 +55155,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1844,
+        "line": 1845,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55164,7 +55164,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1850,
+        "line": 1851,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55173,7 +55173,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1855,
+        "line": 1856,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55182,7 +55182,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1859,
+        "line": 1860,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55696,13 +55696,13 @@
       },
       {
         "kind": "dict",
-        "line": 1193,
+        "line": 1194,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1182,
+        "line": 1183,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -15570,6 +15570,37 @@
         "target": "easyuse_anima/aio/postprocess.py"
       },
       {
+        "alias": "_resize_image_to_size_if_needed",
+        "bound_name": "_resize_image_to_size_if_needed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resize_image_to_size_if_needed",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
+        "kind": "static_from",
+        "line": 58,
+        "name": "_resize_image_to_size_if_needed",
+        "optional": false,
+        "requested": ".easyuse_anima.aio.postprocess",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
         "alias": "_run_aio_postprocess_stage",
         "bound_name": "_run_aio_postprocess_stage",
         "branch_context": [
@@ -15622,7 +15653,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15653,7 +15684,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15684,7 +15715,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15715,7 +15746,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 64,
+        "line": 65,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15746,7 +15777,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15777,7 +15808,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15808,7 +15839,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15839,7 +15870,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15870,7 +15901,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15901,7 +15932,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15932,7 +15963,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15963,7 +15994,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15994,7 +16025,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16025,7 +16056,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16056,7 +16087,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16087,7 +16118,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16118,7 +16149,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 70,
+        "line": 71,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16149,7 +16180,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16180,7 +16211,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16211,7 +16242,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16242,7 +16273,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16273,7 +16304,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16304,7 +16335,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16335,7 +16366,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16366,7 +16397,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16397,7 +16428,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16428,7 +16459,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16459,7 +16490,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16490,7 +16521,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 85,
+        "line": 86,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16521,7 +16552,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16552,7 +16583,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16583,7 +16614,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16614,7 +16645,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16645,7 +16676,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16676,7 +16707,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16707,7 +16738,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16738,7 +16769,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16769,7 +16800,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16800,7 +16831,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 99,
+        "line": 100,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16831,7 +16862,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16862,7 +16893,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16893,7 +16924,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16924,7 +16955,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16955,7 +16986,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16986,7 +17017,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17017,7 +17048,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17048,7 +17079,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17079,7 +17110,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17110,7 +17141,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 111,
+        "line": 112,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17141,7 +17172,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17172,7 +17203,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17203,7 +17234,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17234,7 +17265,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17265,7 +17296,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17296,7 +17327,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17327,7 +17358,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17358,7 +17389,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17389,7 +17420,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17420,7 +17451,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17451,7 +17482,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17482,7 +17513,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17513,7 +17544,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17544,7 +17575,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17575,7 +17606,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17606,7 +17637,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 123,
+        "line": 124,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17637,7 +17668,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17668,7 +17699,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17699,7 +17730,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 141,
+        "line": 142,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17730,7 +17761,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17761,7 +17792,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17792,7 +17823,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17823,7 +17854,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17854,7 +17885,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 146,
+        "line": 147,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17885,7 +17916,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 153,
+        "line": 154,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17916,7 +17947,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17947,7 +17978,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17978,7 +18009,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -18009,7 +18040,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 154,
+        "line": 155,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -18040,7 +18071,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18071,7 +18102,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18102,7 +18133,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18133,7 +18164,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18164,7 +18195,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18195,7 +18226,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18226,7 +18257,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18257,7 +18288,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18288,7 +18319,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18319,7 +18350,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 160,
+        "line": 161,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18350,7 +18381,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 174,
+        "line": 175,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18381,7 +18412,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 174,
+        "line": 175,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18412,7 +18443,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 174,
+        "line": 175,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18443,7 +18474,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 174,
+        "line": 175,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18474,7 +18505,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 174,
+        "line": 175,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18505,7 +18536,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 174,
+        "line": 175,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18536,7 +18567,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 174,
+        "line": 175,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18567,7 +18598,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18598,7 +18629,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18629,7 +18660,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18660,7 +18691,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18691,7 +18722,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18722,7 +18753,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18753,7 +18784,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18784,7 +18815,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18815,7 +18846,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18846,7 +18877,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18877,7 +18908,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18908,7 +18939,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18939,7 +18970,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18970,7 +19001,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19001,7 +19032,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19032,7 +19063,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19063,7 +19094,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19094,7 +19125,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19125,7 +19156,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19156,7 +19187,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19187,7 +19218,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19218,7 +19249,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 193,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19249,7 +19280,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19280,7 +19311,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19311,7 +19342,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19342,7 +19373,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19373,7 +19404,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19404,7 +19435,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19435,7 +19466,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19466,7 +19497,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19497,7 +19528,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19528,7 +19559,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19559,7 +19590,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19590,7 +19621,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19621,7 +19652,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19652,7 +19683,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 228,
+        "line": 229,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19683,7 +19714,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19714,7 +19745,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19745,7 +19776,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19776,7 +19807,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19807,7 +19838,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19838,7 +19869,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19869,7 +19900,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19900,7 +19931,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19931,7 +19962,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 256,
+        "line": 257,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19962,7 +19993,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -19993,7 +20024,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20024,7 +20055,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20055,7 +20086,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20086,7 +20117,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20117,7 +20148,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20148,7 +20179,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20179,7 +20210,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20210,7 +20241,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20241,7 +20272,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20272,7 +20303,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20303,7 +20334,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20334,7 +20365,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20365,7 +20396,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20396,7 +20427,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20427,7 +20458,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20458,7 +20489,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20489,7 +20520,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20520,7 +20551,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20551,7 +20582,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20582,7 +20613,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20613,7 +20644,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20644,7 +20675,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20675,7 +20706,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20706,7 +20737,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 272,
+        "line": 273,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20737,7 +20768,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20768,7 +20799,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20799,7 +20830,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20830,7 +20861,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 352,
+        "line": 353,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20861,7 +20892,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20892,7 +20923,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20923,7 +20954,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 358,
+        "line": 359,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20954,7 +20985,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -20985,7 +21016,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21016,7 +21047,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 363,
+        "line": 364,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21047,7 +21078,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21078,7 +21109,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21109,7 +21140,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21140,7 +21171,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21171,7 +21202,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21202,7 +21233,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21233,7 +21264,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 369,
+        "line": 370,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21264,7 +21295,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21295,7 +21326,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21326,7 +21357,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 378,
+        "line": 379,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21357,7 +21388,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21388,7 +21419,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21419,7 +21450,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21450,7 +21481,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 389,
+        "line": 390,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21481,7 +21512,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21512,7 +21543,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 402,
+        "line": 403,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21543,7 +21574,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21574,7 +21605,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21605,7 +21636,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21636,7 +21667,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21667,7 +21698,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21698,7 +21729,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21729,7 +21760,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21760,7 +21791,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 410,
+        "line": 411,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21791,7 +21822,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21822,7 +21853,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21853,7 +21884,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21884,7 +21915,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 421,
+        "line": 422,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21915,7 +21946,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21946,7 +21977,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21977,7 +22008,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22008,7 +22039,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22039,7 +22070,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 428,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22070,7 +22101,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 435,
+        "line": 436,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22101,7 +22132,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 435,
+        "line": 436,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22132,7 +22163,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 439,
+        "line": 440,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22163,7 +22194,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22194,7 +22225,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22225,7 +22256,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 443,
+        "line": 444,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22256,7 +22287,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22287,7 +22318,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22318,7 +22349,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22349,7 +22380,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22380,7 +22411,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 448,
+        "line": 449,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22411,7 +22442,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 455,
+        "line": 456,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22442,7 +22473,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 455,
+        "line": 456,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22473,7 +22504,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 455,
+        "line": 456,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22504,7 +22535,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 460,
+        "line": 461,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22535,7 +22566,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 460,
+        "line": 461,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22566,7 +22597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 460,
+        "line": 461,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22597,7 +22628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 478,
+        "line": 479,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22628,7 +22659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 478,
+        "line": 479,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22659,7 +22690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 478,
+        "line": 479,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22690,7 +22721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 478,
+        "line": 479,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22721,7 +22752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 478,
+        "line": 479,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22752,7 +22783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22783,7 +22814,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 501,
+        "line": 502,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22814,7 +22845,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22845,7 +22876,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 505,
+        "line": 506,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22876,7 +22907,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22907,7 +22938,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22938,7 +22969,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22969,7 +23000,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23000,7 +23031,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23031,7 +23062,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23062,7 +23093,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23093,7 +23124,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23124,7 +23155,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23155,7 +23186,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23186,7 +23217,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23217,7 +23248,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23248,7 +23279,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23279,7 +23310,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23310,7 +23341,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 510,
+        "line": 511,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23341,7 +23372,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23372,7 +23403,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23403,7 +23434,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23434,7 +23465,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23465,7 +23496,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23496,7 +23527,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23527,7 +23558,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23558,7 +23589,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 527,
+        "line": 528,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23589,7 +23620,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23620,7 +23651,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 537,
+        "line": 538,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23651,7 +23682,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23682,7 +23713,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 541,
+        "line": 542,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23713,7 +23744,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 542,
+        "line": 543,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23744,7 +23775,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23775,7 +23806,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23806,7 +23837,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 543,
+        "line": 544,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23837,7 +23868,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23868,7 +23899,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 548,
+        "line": 549,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23899,7 +23930,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23930,7 +23961,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23961,7 +23992,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23992,7 +24023,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24023,7 +24054,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24054,7 +24085,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24085,7 +24116,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24116,7 +24147,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24147,7 +24178,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24178,7 +24209,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24209,7 +24240,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24240,7 +24271,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24271,7 +24302,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24302,7 +24333,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24333,7 +24364,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24364,7 +24395,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24395,7 +24426,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24426,7 +24457,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24457,7 +24488,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 549,
+        "line": 550,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24476,7 +24507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24491,7 +24522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24510,7 +24541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24525,7 +24556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24544,7 +24575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24559,7 +24590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24578,7 +24609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24593,7 +24624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24612,7 +24643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24627,7 +24658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24646,7 +24677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24661,7 +24692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24680,7 +24711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24695,7 +24726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24714,7 +24745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24729,7 +24760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24748,7 +24779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24763,7 +24794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24782,7 +24813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24797,7 +24828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24816,7 +24847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24831,7 +24862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24850,7 +24881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24865,7 +24896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24884,7 +24915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24899,7 +24930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24918,7 +24949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24933,7 +24964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24952,7 +24983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -24967,7 +24998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24986,7 +25017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25001,7 +25032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25020,7 +25051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25035,7 +25066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25054,7 +25085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25069,7 +25100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25088,7 +25119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25103,7 +25134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25122,7 +25153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25137,7 +25168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25156,7 +25187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25171,7 +25202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25190,7 +25221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25205,7 +25236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25224,7 +25255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25239,7 +25270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25258,7 +25289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25273,7 +25304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25292,7 +25323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25307,7 +25338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25326,7 +25357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25341,7 +25372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25360,7 +25391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25375,7 +25406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25394,7 +25425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25409,7 +25440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25428,7 +25459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25443,7 +25474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25462,7 +25493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25477,7 +25508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25496,7 +25527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25511,7 +25542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25530,7 +25561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25545,7 +25576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25564,7 +25595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25579,7 +25610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25598,7 +25629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25613,7 +25644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25632,7 +25663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25647,7 +25678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25666,7 +25697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25681,7 +25712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25700,7 +25731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25715,7 +25746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25734,7 +25765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25749,7 +25780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25768,7 +25799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25783,8 +25814,42 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "name": "_bind_aio_postprocess_runtime",
+        "optional": false,
+        "requested": "easyuse_anima.aio.postprocess",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "alias": "_resize_image_to_size_if_needed",
+        "bound_name": "_resize_image_to_size_if_needed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 571,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resize_image_to_size_if_needed",
+          "target": "easyuse_anima/aio/postprocess.py",
+          "try_line": 10
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
+        "kind": "static_from",
+        "line": 619,
+        "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
         "role": "compatibility_fallback",
@@ -25802,7 +25867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25817,7 +25882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25836,7 +25901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25851,7 +25916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25870,7 +25935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25885,7 +25950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25904,7 +25969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25919,7 +25984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25938,7 +26003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25953,7 +26018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25972,7 +26037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -25987,7 +26052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26006,7 +26071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26021,7 +26086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26040,7 +26105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26055,7 +26120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26074,7 +26139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26089,7 +26154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26108,7 +26173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26123,7 +26188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26142,7 +26207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26157,7 +26222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26176,7 +26241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26191,7 +26256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26210,7 +26275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26225,7 +26290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26244,7 +26309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26259,7 +26324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26278,7 +26343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26293,7 +26358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26312,7 +26377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26327,7 +26392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26346,7 +26411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26361,7 +26426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26380,7 +26445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26395,7 +26460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26414,7 +26479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26429,7 +26494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26448,7 +26513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26463,7 +26528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26482,7 +26547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26497,7 +26562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26516,7 +26581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26531,7 +26596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26550,7 +26615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26565,7 +26630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26584,7 +26649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26599,7 +26664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26618,7 +26683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26633,7 +26698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26652,7 +26717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26667,7 +26732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26686,7 +26751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26701,7 +26766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26720,7 +26785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26735,7 +26800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26754,7 +26819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26769,7 +26834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26788,7 +26853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26803,7 +26868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26822,7 +26887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26837,7 +26902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26856,7 +26921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26871,7 +26936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26890,7 +26955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26905,7 +26970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26924,7 +26989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26939,7 +27004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26958,7 +27023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -26973,7 +27038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26992,7 +27057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27007,7 +27072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27026,7 +27091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27041,7 +27106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27060,7 +27125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27075,7 +27140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27094,7 +27159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27109,7 +27174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27128,7 +27193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27143,7 +27208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27162,7 +27227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27177,7 +27242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27196,7 +27261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27211,7 +27276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27230,7 +27295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27245,7 +27310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27264,7 +27329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27279,7 +27344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27298,7 +27363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27313,7 +27378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27332,7 +27397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27347,7 +27412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27366,7 +27431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27381,7 +27446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27400,7 +27465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27415,7 +27480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27434,7 +27499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27449,7 +27514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27468,7 +27533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27483,7 +27548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27502,7 +27567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27517,7 +27582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27536,7 +27601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27551,7 +27616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27570,7 +27635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27585,7 +27650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27604,7 +27669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27619,7 +27684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27638,7 +27703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27653,7 +27718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27672,7 +27737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27687,7 +27752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27706,7 +27771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27721,7 +27786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27740,7 +27805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27755,7 +27820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27774,7 +27839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27789,7 +27854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27808,7 +27873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27823,7 +27888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27842,7 +27907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27857,7 +27922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27876,7 +27941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27891,7 +27956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27910,7 +27975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27925,7 +27990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27944,7 +28009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27959,7 +28024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27978,7 +28043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -27993,7 +28058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28012,7 +28077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28027,7 +28092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28046,7 +28111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28061,7 +28126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28080,7 +28145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28095,7 +28160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28114,7 +28179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28129,7 +28194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28148,7 +28213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28163,7 +28228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28182,7 +28247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28197,7 +28262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28216,7 +28281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28231,7 +28296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28250,7 +28315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28265,7 +28330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28284,7 +28349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28299,7 +28364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28318,7 +28383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28333,7 +28398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28352,7 +28417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28367,7 +28432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28386,7 +28451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28401,7 +28466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28420,7 +28485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28435,7 +28500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28454,7 +28519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28469,7 +28534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28488,7 +28553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28503,7 +28568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28522,7 +28587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28537,7 +28602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28556,7 +28621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28571,7 +28636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28590,7 +28655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28605,7 +28670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28624,7 +28689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28639,7 +28704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28658,7 +28723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28673,7 +28738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28692,7 +28757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28707,7 +28772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28726,7 +28791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28741,7 +28806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28760,7 +28825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28775,7 +28840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28794,7 +28859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28809,7 +28874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28828,7 +28893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28843,7 +28908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28862,7 +28927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28877,7 +28942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28896,7 +28961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28911,7 +28976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28930,7 +28995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28945,7 +29010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28964,7 +29029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -28979,7 +29044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28998,7 +29063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29013,7 +29078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29032,7 +29097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29047,7 +29112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29066,7 +29131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29081,7 +29146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29100,7 +29165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29115,7 +29180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29134,7 +29199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29149,7 +29214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29168,7 +29233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29183,7 +29248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29202,7 +29267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29217,7 +29282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29236,7 +29301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29251,7 +29316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29270,7 +29335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29285,7 +29350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29304,7 +29369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29319,7 +29384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29338,7 +29403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29353,7 +29418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29372,7 +29437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29387,7 +29452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29406,7 +29471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29421,7 +29486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29440,7 +29505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29455,7 +29520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29474,7 +29539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29489,7 +29554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29508,7 +29573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29523,7 +29588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29542,7 +29607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29557,7 +29622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29576,7 +29641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29591,7 +29656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29610,7 +29675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29625,7 +29690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29644,7 +29709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29659,7 +29724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29678,7 +29743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29693,7 +29758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29712,7 +29777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29727,7 +29792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29746,7 +29811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29761,7 +29826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29780,7 +29845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29795,7 +29860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29814,7 +29879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29829,7 +29894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29848,7 +29913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29863,7 +29928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29882,7 +29947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29897,7 +29962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29916,7 +29981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29931,7 +29996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29950,7 +30015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29965,7 +30030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29984,7 +30049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -29999,7 +30064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30018,7 +30083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30033,7 +30098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30052,7 +30117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30067,7 +30132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30086,7 +30151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30101,7 +30166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30120,7 +30185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30135,7 +30200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30154,7 +30219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30169,7 +30234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30188,7 +30253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30203,7 +30268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30222,7 +30287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30237,7 +30302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30256,7 +30321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30271,7 +30336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30290,7 +30355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30305,7 +30370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30324,7 +30389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30339,7 +30404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30358,7 +30423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30373,7 +30438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30392,7 +30457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30407,7 +30472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30426,7 +30491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30441,7 +30506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30460,7 +30525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30475,7 +30540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30494,7 +30559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30509,7 +30574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30528,7 +30593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30543,7 +30608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30562,7 +30627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30577,7 +30642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30596,7 +30661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30611,7 +30676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30630,7 +30695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30645,7 +30710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30664,7 +30729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30679,7 +30744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30698,7 +30763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30713,7 +30778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30732,7 +30797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30747,7 +30812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30766,7 +30831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30781,7 +30846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30800,7 +30865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30815,7 +30880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30834,7 +30899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30849,7 +30914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30868,7 +30933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30883,7 +30948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30902,7 +30967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30917,7 +30982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30936,7 +31001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30951,7 +31016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30970,7 +31035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -30985,7 +31050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31004,7 +31069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31019,7 +31084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31038,7 +31103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31053,7 +31118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31072,7 +31137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31087,7 +31152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31106,7 +31171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31121,7 +31186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31140,7 +31205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31155,7 +31220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31174,7 +31239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31189,7 +31254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31208,7 +31273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31223,7 +31288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31242,7 +31307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31257,7 +31322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31276,7 +31341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31291,7 +31356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31310,7 +31375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31325,7 +31390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31344,7 +31409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31359,7 +31424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31378,7 +31443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31393,7 +31458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31412,7 +31477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31427,7 +31492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31446,7 +31511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31461,7 +31526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31480,7 +31545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31495,7 +31560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31514,7 +31579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31529,7 +31594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31548,7 +31613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31563,7 +31628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31582,7 +31647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31597,7 +31662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31616,7 +31681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31631,7 +31696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31650,7 +31715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31665,7 +31730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31684,7 +31749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31699,7 +31764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31718,7 +31783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31733,7 +31798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31752,7 +31817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31767,7 +31832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31786,7 +31851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31801,7 +31866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31820,7 +31885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31835,7 +31900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31854,7 +31919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31869,7 +31934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31888,7 +31953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31903,7 +31968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31922,7 +31987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31937,7 +32002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31956,7 +32021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -31971,7 +32036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31990,7 +32055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32005,7 +32070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32024,7 +32089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32039,7 +32104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32058,7 +32123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32073,7 +32138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32092,7 +32157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32107,7 +32172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32126,7 +32191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32141,7 +32206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32160,7 +32225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32175,7 +32240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32194,7 +32259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32209,7 +32274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32228,7 +32293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32243,7 +32308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32262,7 +32327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32277,7 +32342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32296,7 +32361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32311,7 +32376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32330,7 +32395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32345,7 +32410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32364,7 +32429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32379,7 +32444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32398,7 +32463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32413,7 +32478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32432,7 +32497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32447,7 +32512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32466,7 +32531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32481,7 +32546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32500,7 +32565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32515,7 +32580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32534,7 +32599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32549,7 +32614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32568,7 +32633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32583,7 +32648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32602,7 +32667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32617,7 +32682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32636,7 +32701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32651,7 +32716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32670,7 +32735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32685,7 +32750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32704,7 +32769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32719,7 +32784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32738,7 +32803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32753,7 +32818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32772,7 +32837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32787,7 +32852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32806,7 +32871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32821,7 +32886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32840,7 +32905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32855,7 +32920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32874,7 +32939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32889,7 +32954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32908,7 +32973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32923,7 +32988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32942,7 +33007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32957,7 +33022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32976,7 +33041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -32991,7 +33056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33010,7 +33075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33025,7 +33090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33044,7 +33109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33059,7 +33124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33078,7 +33143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33093,7 +33158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33112,7 +33177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33127,7 +33192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33146,7 +33211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33161,7 +33226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33180,7 +33245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33195,7 +33260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33214,7 +33279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33229,7 +33294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33248,7 +33313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33263,7 +33328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33282,7 +33347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33297,7 +33362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33316,7 +33381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33331,7 +33396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33350,7 +33415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33365,7 +33430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33384,7 +33449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33399,7 +33464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33418,7 +33483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33433,7 +33498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33452,7 +33517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33467,7 +33532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33486,7 +33551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33501,7 +33566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33520,7 +33585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33535,7 +33600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33554,7 +33619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33569,7 +33634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33588,7 +33653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33603,7 +33668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33622,7 +33687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33637,7 +33702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33656,7 +33721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33671,7 +33736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33690,7 +33755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33705,7 +33770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33724,7 +33789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33739,7 +33804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33758,7 +33823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33773,7 +33838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33792,7 +33857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33807,7 +33872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33826,7 +33891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33841,7 +33906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33860,7 +33925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33875,7 +33940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33894,7 +33959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33909,7 +33974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33928,7 +33993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33943,7 +34008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33962,7 +34027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -33977,7 +34042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33996,7 +34061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34011,7 +34076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34030,7 +34095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34045,7 +34110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34064,7 +34129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34079,7 +34144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34098,7 +34163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34113,7 +34178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34132,7 +34197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34147,7 +34212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34166,7 +34231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34181,7 +34246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34200,7 +34265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34215,7 +34280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34234,7 +34299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34249,7 +34314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34268,7 +34333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34283,7 +34348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34302,7 +34367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34317,7 +34382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34336,7 +34401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34351,7 +34416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34370,7 +34435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34385,7 +34450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34404,7 +34469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34419,7 +34484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34438,7 +34503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34453,7 +34518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34472,7 +34537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34487,7 +34552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34506,7 +34571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34521,7 +34586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34540,7 +34605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34555,7 +34620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34574,7 +34639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34589,7 +34654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34608,7 +34673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34623,7 +34688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34642,7 +34707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34657,7 +34722,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34676,7 +34741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34691,7 +34756,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34710,7 +34775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34725,7 +34790,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1104,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34744,7 +34809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34759,7 +34824,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34778,7 +34843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34793,7 +34858,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34812,7 +34877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34827,7 +34892,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34846,7 +34911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34861,7 +34926,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1110,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34880,7 +34945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34895,7 +34960,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1110,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34914,7 +34979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34929,7 +34994,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34948,7 +35013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34963,7 +35028,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34982,7 +35047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -34997,7 +35062,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35016,7 +35081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35031,7 +35096,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35050,7 +35115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35065,7 +35130,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35084,7 +35149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35099,7 +35164,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35118,7 +35183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35133,7 +35198,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35152,7 +35217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35167,7 +35232,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35186,7 +35251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35201,7 +35266,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35220,7 +35285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35235,7 +35300,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35254,7 +35319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35269,7 +35334,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35288,7 +35353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35303,7 +35368,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35322,7 +35387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35337,7 +35402,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35356,7 +35421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35371,7 +35436,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35390,7 +35455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35405,7 +35470,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35424,7 +35489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35439,7 +35504,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35458,7 +35523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35473,7 +35538,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35492,7 +35557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35507,7 +35572,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35526,7 +35591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -35541,7 +35606,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35559,7 +35624,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1628
           }
         ],
         "classification": "external",
@@ -35567,7 +35632,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1629,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35584,7 +35649,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1636
           }
         ],
         "classification": "external",
@@ -35592,7 +35657,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1637,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35609,7 +35674,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1644
           }
         ],
         "classification": "external",
@@ -35617,7 +35682,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1645,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -38637,13 +38702,13 @@
       },
       {
         "is_package": false,
-        "loc": 174,
+        "loc": 199,
         "module": "easyuse_anima.aio.postprocess",
-        "normalized_git_blob_sha1": "85fa7f041636614cce3c1c17cb3c2d1087fed44a",
+        "normalized_git_blob_sha1": "3402745869e631bb5372b9cc0a2aafc42d9188f7",
         "path": "easyuse_anima/aio/postprocess.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 5,
+          "function_count": 6,
           "global_count": 3
         }
       },
@@ -39249,13 +39314,13 @@
       },
       {
         "is_package": false,
-        "loc": 1879,
+        "loc": 1865,
         "module": "nodes",
-        "normalized_git_blob_sha1": "6de84ba721ad593af4b2d34634976822eb7358d1",
+        "normalized_git_blob_sha1": "b27d8812d05c331d09c92ff66d75de8293720a94",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 9,
+          "function_count": 8,
           "global_count": 26
         }
       },
@@ -40615,7 +40680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40624,7 +40689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40638,7 +40703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40647,7 +40712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40661,7 +40726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40670,7 +40735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40684,7 +40749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40693,7 +40758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40707,7 +40772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40716,7 +40781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40730,7 +40795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40739,7 +40804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40753,7 +40818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40762,7 +40827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40776,7 +40841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40785,7 +40850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40799,7 +40864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40808,7 +40873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40822,7 +40887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40831,7 +40896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40845,7 +40910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40854,7 +40919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40868,7 +40933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40877,7 +40942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40891,7 +40956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40900,7 +40965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40914,7 +40979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40923,7 +40988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40937,7 +41002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40946,7 +41011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40960,7 +41025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40969,7 +41034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40983,7 +41048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -40992,7 +41057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41006,7 +41071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41015,7 +41080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41029,7 +41094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41038,7 +41103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41052,7 +41117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41061,7 +41126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41075,7 +41140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41084,7 +41149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41098,7 +41163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41107,7 +41172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41121,7 +41186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41130,7 +41195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41144,7 +41209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41153,7 +41218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41167,7 +41232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41176,7 +41241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41190,7 +41255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41199,7 +41264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41213,7 +41278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41222,7 +41287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41236,7 +41301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41245,7 +41310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41259,7 +41324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41268,7 +41333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41282,7 +41347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41291,7 +41356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41305,7 +41370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41314,7 +41379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41328,7 +41393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41337,7 +41402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41351,7 +41416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41360,7 +41425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 610,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41374,7 +41439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41383,7 +41448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41397,7 +41462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41406,7 +41471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41420,7 +41485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41429,7 +41494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41443,7 +41508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41452,7 +41517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41466,7 +41531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41475,7 +41540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41489,7 +41554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41498,7 +41563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41512,7 +41577,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
+            "kind": "try",
+            "line": 10
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
+        "kind": "static_from",
+        "line": 619,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/aio/postprocess.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41521,7 +41609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 618,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41535,7 +41623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41544,7 +41632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41558,7 +41646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41567,7 +41655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41581,7 +41669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41590,7 +41678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41604,7 +41692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41613,7 +41701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41627,7 +41715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41636,7 +41724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41650,7 +41738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41659,7 +41747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41673,7 +41761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41682,7 +41770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41696,7 +41784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41705,7 +41793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41719,7 +41807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41728,7 +41816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41742,7 +41830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41751,7 +41839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41765,7 +41853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41774,7 +41862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41788,7 +41876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41797,7 +41885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41811,7 +41899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41820,7 +41908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41834,7 +41922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41843,7 +41931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41857,7 +41945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41866,7 +41954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41880,7 +41968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41889,7 +41977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41903,7 +41991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41912,7 +42000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 630,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41926,7 +42014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41935,7 +42023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41949,7 +42037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41958,7 +42046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41972,7 +42060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -41981,7 +42069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41995,7 +42083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42004,7 +42092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42018,7 +42106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42027,7 +42115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42041,7 +42129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42050,7 +42138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42064,7 +42152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42073,7 +42161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42087,7 +42175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42096,7 +42184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42110,7 +42198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42119,7 +42207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42133,7 +42221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42142,7 +42230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42156,7 +42244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42165,7 +42253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42179,7 +42267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42188,7 +42276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 645,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42202,7 +42290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42211,7 +42299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42225,7 +42313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42234,7 +42322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42248,7 +42336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42257,7 +42345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42271,7 +42359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42280,7 +42368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42294,7 +42382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42303,7 +42391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42317,7 +42405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42326,7 +42414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42340,7 +42428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42349,7 +42437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42363,7 +42451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42372,7 +42460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42386,7 +42474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42395,7 +42483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42409,7 +42497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42418,7 +42506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 659,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42432,7 +42520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42441,7 +42529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42455,7 +42543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42464,7 +42552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42478,7 +42566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42487,7 +42575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42501,7 +42589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42510,7 +42598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42524,7 +42612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42533,7 +42621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42547,7 +42635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42556,7 +42644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42570,7 +42658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42579,7 +42667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42593,7 +42681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42602,7 +42690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42616,7 +42704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42625,7 +42713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42639,7 +42727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42648,7 +42736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 671,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42662,7 +42750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42671,7 +42759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42685,7 +42773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42694,7 +42782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42708,7 +42796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42717,7 +42805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42731,7 +42819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42740,7 +42828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42754,7 +42842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42763,7 +42851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42777,7 +42865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42786,7 +42874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42800,7 +42888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42809,7 +42897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42823,7 +42911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42832,7 +42920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42846,7 +42934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42855,7 +42943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42869,7 +42957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42878,7 +42966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42892,7 +42980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42901,7 +42989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42915,7 +43003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42924,7 +43012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42938,7 +43026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42947,7 +43035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42961,7 +43049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42970,7 +43058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42984,7 +43072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -42993,7 +43081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43007,7 +43095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43016,7 +43104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43030,7 +43118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43039,7 +43127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43053,7 +43141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43062,7 +43150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43076,7 +43164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43085,7 +43173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43099,7 +43187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43108,7 +43196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43122,7 +43210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43131,7 +43219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43145,7 +43233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43154,7 +43242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43168,7 +43256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43177,7 +43265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43191,7 +43279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43200,7 +43288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 706,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43214,7 +43302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43223,7 +43311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 713,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43237,7 +43325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43246,7 +43334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43260,7 +43348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43269,7 +43357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43283,7 +43371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43292,7 +43380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43306,7 +43394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43315,7 +43403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43329,7 +43417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43338,7 +43426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43352,7 +43440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43361,7 +43449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43375,7 +43463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43384,7 +43472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43398,7 +43486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43407,7 +43495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43421,7 +43509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43430,7 +43518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43444,7 +43532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43453,7 +43541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43467,7 +43555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43476,7 +43564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43490,7 +43578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43499,7 +43587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43513,7 +43601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43522,7 +43610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43536,7 +43624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43545,7 +43633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43559,7 +43647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43568,7 +43656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43582,7 +43670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43591,7 +43679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43605,7 +43693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43614,7 +43702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43628,7 +43716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43637,7 +43725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43651,7 +43739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43660,7 +43748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43674,7 +43762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43683,7 +43771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43697,7 +43785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43706,7 +43794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 734,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43720,7 +43808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43729,7 +43817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43743,7 +43831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43752,7 +43840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43766,7 +43854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43775,7 +43863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43789,7 +43877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43798,7 +43886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43812,7 +43900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43821,7 +43909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43835,7 +43923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43844,7 +43932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43858,7 +43946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43867,7 +43955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43881,7 +43969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43890,7 +43978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43904,7 +43992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43913,7 +44001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43927,7 +44015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43936,7 +44024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43950,7 +44038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43959,7 +44047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43973,7 +44061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -43982,7 +44070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43996,7 +44084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44005,7 +44093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44019,7 +44107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44028,7 +44116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44042,7 +44130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44051,7 +44139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44065,7 +44153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44074,7 +44162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44088,7 +44176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44097,7 +44185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44111,7 +44199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44120,7 +44208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44134,7 +44222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44143,7 +44231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44157,7 +44245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44166,7 +44254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44180,7 +44268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44189,7 +44277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44203,7 +44291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44212,7 +44300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44226,7 +44314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44235,7 +44323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44249,7 +44337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44258,7 +44346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44272,7 +44360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44281,7 +44369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44295,7 +44383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44304,7 +44392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44318,7 +44406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44327,7 +44415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44341,7 +44429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44350,7 +44438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44364,7 +44452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44373,7 +44461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44387,7 +44475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44396,7 +44484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44410,7 +44498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44419,7 +44507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44433,7 +44521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44442,7 +44530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44456,7 +44544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44465,7 +44553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44479,7 +44567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44488,7 +44576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44502,7 +44590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44511,7 +44599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44525,7 +44613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44534,7 +44622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44548,7 +44636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44557,7 +44645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44571,7 +44659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44580,7 +44668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44594,7 +44682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44603,7 +44691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44617,7 +44705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44626,7 +44714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44640,7 +44728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44649,7 +44737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44663,7 +44751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44672,7 +44760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44686,7 +44774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44695,7 +44783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44709,7 +44797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44718,7 +44806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44732,7 +44820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44741,7 +44829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 816,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44755,7 +44843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44764,7 +44852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44778,7 +44866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44787,7 +44875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44801,7 +44889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44810,7 +44898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44824,7 +44912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44833,7 +44921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44847,7 +44935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44856,7 +44944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44870,7 +44958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44879,7 +44967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44893,7 +44981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44902,7 +44990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44916,7 +45004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44925,7 +45013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44939,7 +45027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44948,7 +45036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44962,7 +45050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44971,7 +45059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44985,7 +45073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -44994,7 +45082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45008,7 +45096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45017,7 +45105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45031,7 +45119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45040,7 +45128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45054,7 +45142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45063,7 +45151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45077,7 +45165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45086,7 +45174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45100,7 +45188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45109,7 +45197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45123,7 +45211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45132,7 +45220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45146,7 +45234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45155,7 +45243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45169,7 +45257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45178,7 +45266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45192,7 +45280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45201,7 +45289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45215,7 +45303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45224,7 +45312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45238,7 +45326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45247,7 +45335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45261,7 +45349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45270,7 +45358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45284,7 +45372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45293,7 +45381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45307,7 +45395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45316,7 +45404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 832,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45330,7 +45418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45339,7 +45427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45353,7 +45441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45362,7 +45450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45376,7 +45464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45385,7 +45473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45399,7 +45487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45408,7 +45496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45422,7 +45510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45431,7 +45519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45445,7 +45533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45454,7 +45542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45468,7 +45556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45477,7 +45565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 918,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45491,7 +45579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45500,7 +45588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45514,7 +45602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45523,7 +45611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45537,7 +45625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45546,7 +45634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45560,7 +45648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45569,7 +45657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45583,7 +45671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45592,7 +45680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45606,7 +45694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45615,7 +45703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45629,7 +45717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45638,7 +45726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45652,7 +45740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45661,7 +45749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45675,7 +45763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45684,7 +45772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45698,7 +45786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45707,7 +45795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 929,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45721,7 +45809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45730,7 +45818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45744,7 +45832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45753,7 +45841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45767,7 +45855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45776,7 +45864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 938,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45790,7 +45878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45799,7 +45887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45813,7 +45901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45822,7 +45910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45836,7 +45924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45845,7 +45933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45859,7 +45947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45868,7 +45956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 949,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45882,7 +45970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45891,7 +45979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45905,7 +45993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45914,7 +46002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 962,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45928,7 +46016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45937,7 +46025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45951,7 +46039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45960,7 +46048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45974,7 +46062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -45983,7 +46071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45997,7 +46085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46006,7 +46094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46020,7 +46108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46029,7 +46117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46043,7 +46131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46052,7 +46140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46066,7 +46154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46075,7 +46163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46089,7 +46177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46098,7 +46186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46112,7 +46200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46121,7 +46209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46135,7 +46223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46144,7 +46232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46158,7 +46246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46167,7 +46255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46181,7 +46269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46190,7 +46278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 981,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46204,7 +46292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46213,7 +46301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46227,7 +46315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46236,7 +46324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46250,7 +46338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46259,7 +46347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46273,7 +46361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46282,7 +46370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46296,7 +46384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46305,7 +46393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 987,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46319,7 +46407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46328,7 +46416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46342,7 +46430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46351,7 +46439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 995,
+        "line": 997,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46365,7 +46453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46374,7 +46462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 999,
+        "line": 1001,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46388,7 +46476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46397,7 +46485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46411,7 +46499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46420,7 +46508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46434,7 +46522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46443,7 +46531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46457,7 +46545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46466,7 +46554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46480,7 +46568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46489,7 +46577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46503,7 +46591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46512,7 +46600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46526,7 +46614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46535,7 +46623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46549,7 +46637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46558,7 +46646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46572,7 +46660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46581,7 +46669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46595,7 +46683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46604,7 +46692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46618,7 +46706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46627,7 +46715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46641,7 +46729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46650,7 +46738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46664,7 +46752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46673,7 +46761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46687,7 +46775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46696,7 +46784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46710,7 +46798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46719,7 +46807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46733,7 +46821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46742,7 +46830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46756,7 +46844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46765,7 +46853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46779,7 +46867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46788,7 +46876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46802,7 +46890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46811,7 +46899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1040,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46825,7 +46913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46834,7 +46922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46848,7 +46936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46857,7 +46945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1061,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46871,7 +46959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46880,7 +46968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46894,7 +46982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46903,7 +46991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46917,7 +47005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46926,7 +47014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46940,7 +47028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46949,7 +47037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46963,7 +47051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46972,7 +47060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46986,7 +47074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -46995,7 +47083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47009,7 +47097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47018,7 +47106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47032,7 +47120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47041,7 +47129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47055,7 +47143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47064,7 +47152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47078,7 +47166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47087,7 +47175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47101,7 +47189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47110,7 +47198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47124,7 +47212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47133,7 +47221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47147,7 +47235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47156,7 +47244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47170,7 +47258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47179,7 +47267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47193,7 +47281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47202,7 +47290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47216,7 +47304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47225,7 +47313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47239,7 +47327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47248,7 +47336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47262,7 +47350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47271,7 +47359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47285,7 +47373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47294,7 +47382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47308,7 +47396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47317,7 +47405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47331,7 +47419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47340,7 +47428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47354,7 +47442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47363,7 +47451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47377,7 +47465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47386,7 +47474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47400,7 +47488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47409,7 +47497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47423,7 +47511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47432,7 +47520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1087,
+        "line": 1089,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47446,7 +47534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47455,7 +47543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47469,7 +47557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47478,7 +47566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47492,7 +47580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47501,7 +47589,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47515,7 +47603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47524,7 +47612,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47538,7 +47626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47547,7 +47635,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47561,7 +47649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47570,7 +47658,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47584,7 +47672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47593,7 +47681,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47607,7 +47695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47616,7 +47704,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47630,7 +47718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47639,7 +47727,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47653,7 +47741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47662,7 +47750,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47676,7 +47764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47685,7 +47773,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47699,7 +47787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47708,7 +47796,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47722,7 +47810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47731,7 +47819,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47745,7 +47833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47754,7 +47842,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47768,7 +47856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47777,7 +47865,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47791,7 +47879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47800,7 +47888,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47814,7 +47902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47823,7 +47911,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47837,7 +47925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47846,7 +47934,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47860,7 +47948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47869,7 +47957,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47883,7 +47971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47892,7 +47980,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47906,7 +47994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47915,7 +48003,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47929,7 +48017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47938,7 +48026,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47952,7 +48040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47961,7 +48049,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47975,7 +48063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -47984,7 +48072,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47998,7 +48086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -48007,7 +48095,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48021,7 +48109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -48030,7 +48118,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48044,7 +48132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -48053,7 +48141,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48067,7 +48155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -48076,7 +48164,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48090,7 +48178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 571,
             "kind": "try",
             "line": 10
           }
@@ -48099,7 +48187,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51926,14 +52014,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1628
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1629,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51945,14 +52033,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1636
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1637,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -51964,14 +52052,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1644
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1645,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53346,14 +53434,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1626
+            "line": 1628
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1627,
+        "line": 1629,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53365,14 +53453,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1634
+            "line": 1636
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1635,
+        "line": 1637,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53384,14 +53472,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1642
+            "line": 1644
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1643,
+        "line": 1645,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54852,7 +54940,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1131,
+        "line": 1133,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54861,7 +54949,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1775,
+        "line": 1761,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54870,7 +54958,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1778,
+        "line": 1764,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54879,7 +54967,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1781,
+        "line": 1767,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54888,7 +54976,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1784,
+        "line": 1770,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54897,7 +54985,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1787,
+        "line": 1773,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54906,7 +54994,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1790,
+        "line": 1776,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54915,7 +55003,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1793,
+        "line": 1779,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54924,7 +55012,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1796,
+        "line": 1782,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54933,7 +55021,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1799,
+        "line": 1785,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54942,7 +55030,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1802,
+        "line": 1788,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54951,7 +55039,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1805,
+        "line": 1791,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54960,7 +55048,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1808,
+        "line": 1794,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54969,7 +55057,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1811,
+        "line": 1797,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54978,7 +55066,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1814,
+        "line": 1800,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54987,7 +55075,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1817,
+        "line": 1803,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54996,7 +55084,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1820,
+        "line": 1806,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55005,7 +55093,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1824,
+        "line": 1810,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55014,7 +55102,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1827,
+        "line": 1813,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55023,7 +55111,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1831,
+        "line": 1817,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55032,7 +55120,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1834,
+        "line": 1820,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55041,7 +55129,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1838,
+        "line": 1824,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55050,7 +55138,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1841,
+        "line": 1827,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55059,7 +55147,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1844,
+        "line": 1830,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55068,7 +55156,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1847,
+        "line": 1833,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55077,7 +55165,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1850,
+        "line": 1836,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55086,7 +55174,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1853,
+        "line": 1839,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55095,7 +55183,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1860,
+        "line": 1846,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55104,7 +55192,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1866,
+        "line": 1852,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55113,7 +55201,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1871,
+        "line": 1857,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55122,7 +55210,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1875,
+        "line": 1861,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55636,13 +55724,13 @@
       },
       {
         "kind": "dict",
-        "line": 1193,
+        "line": 1195,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1182,
+        "line": 1184,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -14344,23 +14344,6 @@
         "source": "nodes.py"
       },
       {
-        "alias": null,
-        "bound_name": "Any",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 8,
-        "name": "Any",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "nodes.py"
-      },
-      {
         "alias": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "branch_context": [
@@ -14369,7 +14352,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14377,12 +14360,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14400,7 +14383,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14408,12 +14391,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14431,7 +14414,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14439,12 +14422,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14462,7 +14445,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14470,12 +14453,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14493,7 +14476,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14501,12 +14484,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_first_pass_cache_runtime",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14524,7 +14507,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14532,12 +14515,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14555,7 +14538,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14563,12 +14546,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14586,7 +14569,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14594,12 +14577,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 11,
+        "line": 9,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": ".easyuse_anima.aio.first_pass_cache",
@@ -14617,7 +14600,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14625,12 +14608,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_legacy_generation_runtime",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14648,7 +14631,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14656,12 +14639,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14679,7 +14662,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14687,12 +14670,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14710,7 +14693,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14718,12 +14701,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14741,7 +14724,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14749,12 +14732,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14772,7 +14755,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14780,12 +14763,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14803,7 +14786,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14811,12 +14794,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14834,7 +14817,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14842,12 +14825,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 22,
+        "line": 20,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.legacy_generation",
@@ -14865,7 +14848,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14873,12 +14856,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14896,7 +14879,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14904,12 +14887,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14927,7 +14910,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14935,12 +14918,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14958,7 +14941,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14966,12 +14949,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -14989,7 +14972,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -14997,12 +14980,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15020,7 +15003,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15028,12 +15011,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15051,7 +15034,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15059,12 +15042,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15082,7 +15065,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15090,12 +15073,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15113,7 +15096,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15121,12 +15104,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15144,7 +15127,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15152,12 +15135,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_generation_normalization_runtime",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15175,7 +15158,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15183,12 +15166,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15206,7 +15189,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15214,12 +15197,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15237,7 +15220,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15245,12 +15228,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15268,7 +15251,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15276,12 +15259,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15299,7 +15282,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15307,12 +15290,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15330,7 +15313,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15338,12 +15321,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 32,
+        "line": 30,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_normalization",
@@ -15361,7 +15344,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15369,12 +15352,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 50,
+        "line": 48,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.generation_settings",
@@ -15392,7 +15375,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15400,12 +15383,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 53,
+        "line": 51,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15423,7 +15406,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15431,12 +15414,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 53,
+        "line": 51,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15454,7 +15437,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15462,12 +15445,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_usdu_planning_runtime",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 53,
+        "line": 51,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.usdu",
@@ -15485,7 +15468,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15493,12 +15476,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 58,
+        "line": 56,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15516,7 +15499,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15524,12 +15507,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 58,
+        "line": 56,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15547,7 +15530,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15555,12 +15538,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_postprocess_runtime",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 58,
+        "line": 56,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15578,7 +15561,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15586,12 +15569,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 58,
+        "line": 56,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15609,7 +15592,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15617,12 +15600,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 58,
+        "line": 56,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": ".easyuse_anima.aio.postprocess",
@@ -15640,7 +15623,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15648,12 +15631,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 65,
+        "line": 63,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15671,7 +15654,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15679,12 +15662,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 65,
+        "line": 63,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15702,7 +15685,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15710,12 +15693,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 65,
+        "line": 63,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15733,7 +15716,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15741,12 +15724,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_conditioning_runtime",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 65,
+        "line": 63,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.conditioning",
@@ -15764,7 +15747,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15772,12 +15755,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15795,7 +15778,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15803,12 +15786,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15826,7 +15809,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15834,12 +15817,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15857,7 +15840,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15865,12 +15848,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15888,7 +15871,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15896,12 +15879,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15919,7 +15902,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15927,12 +15910,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15950,7 +15933,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15958,12 +15941,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -15981,7 +15964,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -15989,12 +15972,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16012,7 +15995,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16020,12 +16003,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16043,7 +16026,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16051,12 +16034,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_model_preparation_runtime",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16074,7 +16057,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16082,12 +16065,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16105,7 +16088,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16113,12 +16096,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16136,7 +16119,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16144,12 +16127,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 71,
+        "line": 69,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": ".easyuse_anima.aio.model_preparation",
@@ -16167,7 +16150,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16175,12 +16158,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16198,7 +16181,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16206,12 +16189,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16229,7 +16212,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16237,12 +16220,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_sampling_runtime",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16260,7 +16243,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16268,12 +16251,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16291,7 +16274,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16299,12 +16282,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16322,7 +16305,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16330,12 +16313,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16353,7 +16336,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16361,12 +16344,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16384,7 +16367,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16392,12 +16375,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16415,7 +16398,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16423,12 +16406,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16446,7 +16429,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16454,12 +16437,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16477,7 +16460,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16485,12 +16468,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16508,7 +16491,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16516,12 +16499,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 86,
+        "line": 84,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": ".easyuse_anima.aio.sampling",
@@ -16539,7 +16522,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16547,12 +16530,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16570,7 +16553,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16578,12 +16561,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16601,7 +16584,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16609,12 +16592,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16632,7 +16615,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16640,12 +16623,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16663,7 +16646,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16671,12 +16654,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16694,7 +16677,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16702,12 +16685,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16725,7 +16708,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16733,12 +16716,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_preview_runtime",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16756,7 +16739,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16764,12 +16747,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16787,7 +16770,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16795,12 +16778,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16818,7 +16801,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16826,12 +16809,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 100,
+        "line": 98,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": ".easyuse_anima.aio.preview",
@@ -16849,7 +16832,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16857,12 +16840,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16880,7 +16863,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16888,12 +16871,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16911,7 +16894,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16919,12 +16902,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16942,7 +16925,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16950,12 +16933,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -16973,7 +16956,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -16981,12 +16964,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17004,7 +16987,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17012,12 +16995,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_output_runtime",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17035,7 +17018,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17043,12 +17026,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17066,7 +17049,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17074,12 +17057,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17097,7 +17080,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17105,12 +17088,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17128,7 +17111,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17136,12 +17119,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 112,
+        "line": 110,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": ".easyuse_anima.aio.output",
@@ -17159,7 +17142,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17167,12 +17150,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_resource_runtime",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17190,7 +17173,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17198,12 +17181,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17221,7 +17204,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17229,12 +17212,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17252,7 +17235,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17260,12 +17243,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17283,7 +17266,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17291,12 +17274,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17314,7 +17297,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17322,12 +17305,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17345,7 +17328,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17353,12 +17336,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17376,7 +17359,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17384,12 +17367,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17407,7 +17390,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17415,12 +17398,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17438,7 +17421,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17446,12 +17429,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17469,7 +17452,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17477,12 +17460,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17500,7 +17483,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17508,12 +17491,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17531,7 +17514,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17539,12 +17522,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17562,7 +17545,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17570,12 +17553,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17593,7 +17576,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17601,12 +17584,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17624,7 +17607,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17632,12 +17615,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 124,
+        "line": 122,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": ".easyuse_anima.aio.resources",
@@ -17655,7 +17638,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17663,12 +17646,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 142,
+        "line": 140,
         "name": "_json_clone",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17686,7 +17669,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17694,12 +17677,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 142,
+        "line": 140,
         "name": "_json_object",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17717,7 +17700,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17725,12 +17708,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 142,
+        "line": 140,
         "name": "_stable_change_key",
         "optional": false,
         "requested": ".easyuse_anima.common.serialization",
@@ -17748,7 +17731,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17756,12 +17739,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 147,
+        "line": 145,
         "name": "_as_bool",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17779,7 +17762,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17787,12 +17770,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 147,
+        "line": 145,
         "name": "_as_float",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17810,7 +17793,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17818,12 +17801,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 147,
+        "line": 145,
         "name": "_as_int",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17841,7 +17824,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17849,12 +17832,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 147,
+        "line": 145,
         "name": "_choice",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17872,7 +17855,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17880,12 +17863,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 147,
+        "line": 145,
         "name": "_single_value",
         "optional": false,
         "requested": ".easyuse_anima.common.values",
@@ -17903,7 +17886,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17911,12 +17894,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 154,
+        "line": 152,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": ".easyuse_anima.workflow",
@@ -17934,7 +17917,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17942,12 +17925,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_correction_runtime",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 155,
+        "line": 153,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17965,7 +17948,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -17973,12 +17956,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 155,
+        "line": 153,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -17996,7 +17979,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18004,12 +17987,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 155,
+        "line": 153,
         "name": "_split_tag_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -18027,7 +18010,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18035,12 +18018,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 155,
+        "line": 153,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.correction",
@@ -18058,7 +18041,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18066,12 +18049,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18089,7 +18072,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18097,12 +18080,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18120,7 +18103,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18128,12 +18111,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18151,7 +18134,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18159,12 +18142,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_fields_runtime",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18182,7 +18165,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18190,12 +18173,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18213,7 +18196,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18221,12 +18204,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18244,7 +18227,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18252,12 +18235,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18275,7 +18258,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18283,12 +18266,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18306,7 +18289,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18314,12 +18297,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18337,7 +18320,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18345,12 +18328,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 161,
+        "line": 159,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18368,7 +18351,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18376,12 +18359,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18399,7 +18382,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18407,12 +18390,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18430,7 +18413,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18438,12 +18421,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18461,7 +18444,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18469,12 +18452,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18492,7 +18475,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18500,12 +18483,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18523,7 +18506,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18531,12 +18514,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18554,7 +18537,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18562,12 +18545,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 175,
+        "line": 173,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18585,7 +18568,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18593,12 +18576,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18616,7 +18599,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18624,12 +18607,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18647,7 +18630,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18655,12 +18638,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18678,7 +18661,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18686,12 +18669,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18709,7 +18692,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18717,12 +18700,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18740,7 +18723,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18748,12 +18731,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18771,7 +18754,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18779,12 +18762,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18802,7 +18785,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18810,12 +18793,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18833,7 +18816,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18841,12 +18824,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18864,7 +18847,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18872,12 +18855,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18895,7 +18878,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18903,12 +18886,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18926,7 +18909,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18934,12 +18917,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18957,7 +18940,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18965,12 +18948,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_advanced_runtime",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -18988,7 +18971,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -18996,12 +18979,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19019,7 +19002,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19027,12 +19010,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19050,7 +19033,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19058,12 +19041,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19081,7 +19064,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19089,12 +19072,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19112,7 +19095,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19120,12 +19103,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19143,7 +19126,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19151,12 +19134,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19174,7 +19157,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19182,12 +19165,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19205,7 +19188,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19213,12 +19196,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19236,7 +19219,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19244,12 +19227,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 193,
+        "line": 191,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19267,7 +19250,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19275,12 +19258,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19298,7 +19281,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19306,12 +19289,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_runtime",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19329,7 +19312,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19337,12 +19320,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19360,7 +19343,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19368,12 +19351,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19391,7 +19374,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19399,12 +19382,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19422,7 +19405,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19430,12 +19413,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19453,7 +19436,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19461,12 +19444,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19484,7 +19467,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19492,12 +19475,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19515,7 +19498,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19523,12 +19506,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19546,7 +19529,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19554,12 +19537,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19577,7 +19560,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19585,12 +19568,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19608,7 +19591,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19616,12 +19599,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19639,7 +19622,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19647,12 +19630,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19670,7 +19653,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19678,12 +19661,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 229,
+        "line": 227,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19701,7 +19684,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19709,12 +19692,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19732,7 +19715,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19740,12 +19723,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19763,7 +19746,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19771,12 +19754,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19794,7 +19777,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19802,12 +19785,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19825,7 +19808,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19833,12 +19816,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19856,7 +19839,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19864,12 +19847,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_conditioning_runtime",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19887,7 +19870,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19895,12 +19878,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19918,7 +19901,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19926,12 +19909,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19949,7 +19932,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19957,12 +19940,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 257,
+        "line": 255,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -19980,7 +19963,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -19988,12 +19971,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20011,7 +19994,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20019,12 +20002,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20042,7 +20025,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20050,12 +20033,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20073,7 +20056,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20081,12 +20064,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20104,7 +20087,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20112,12 +20095,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20135,7 +20118,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20143,12 +20126,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20166,7 +20149,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20174,12 +20157,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20197,7 +20180,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20205,12 +20188,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20228,7 +20211,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20236,12 +20219,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20259,7 +20242,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20267,12 +20250,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20290,7 +20273,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20298,12 +20281,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20321,7 +20304,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20329,12 +20312,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20352,7 +20335,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20360,12 +20343,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20383,7 +20366,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20391,12 +20374,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20414,7 +20397,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20422,12 +20405,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_artist_mix_runtime",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20445,7 +20428,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20453,12 +20436,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20476,7 +20459,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20484,12 +20467,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20507,7 +20490,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20515,12 +20498,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20538,7 +20521,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20546,12 +20529,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20569,7 +20552,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20577,12 +20560,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20600,7 +20583,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20608,12 +20591,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20631,7 +20614,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20639,12 +20622,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20662,7 +20645,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20670,12 +20653,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20693,7 +20676,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20701,12 +20684,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20724,7 +20707,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20732,12 +20715,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 273,
+        "line": 271,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20755,7 +20738,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20763,12 +20746,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 353,
+        "line": 351,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20786,7 +20769,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20794,12 +20777,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 353,
+        "line": 351,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20817,7 +20800,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20825,12 +20808,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 353,
+        "line": 351,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20848,7 +20831,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20856,12 +20839,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_data_node_runtime",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 353,
+        "line": 351,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -20879,7 +20862,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20887,12 +20870,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 359,
+        "line": 357,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20910,7 +20893,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20918,12 +20901,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 359,
+        "line": 357,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20941,7 +20924,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20949,12 +20932,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 359,
+        "line": 357,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -20972,7 +20955,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -20980,12 +20963,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 364,
+        "line": 362,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21003,7 +20986,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21011,12 +20994,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 364,
+        "line": 362,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21034,7 +21017,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21042,12 +21025,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_advanced_node_runtime",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 364,
+        "line": 362,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21065,7 +21048,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21073,12 +21056,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 370,
+        "line": 368,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21096,7 +21079,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21104,12 +21087,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 370,
+        "line": 368,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21127,7 +21110,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21135,12 +21118,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 370,
+        "line": 368,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21158,7 +21141,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21166,12 +21149,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 370,
+        "line": 368,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21189,7 +21172,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21197,12 +21180,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_node_runtime",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 370,
+        "line": 368,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21220,7 +21203,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21228,12 +21211,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 370,
+        "line": 368,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21251,7 +21234,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21259,12 +21242,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 370,
+        "line": 368,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21282,7 +21265,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21290,12 +21273,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 379,
+        "line": 377,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21313,7 +21296,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21321,12 +21304,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 379,
+        "line": 377,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21344,7 +21327,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21352,12 +21335,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 379,
+        "line": 377,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21375,7 +21358,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21383,12 +21366,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_runtime",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 390,
+        "line": 388,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21406,7 +21389,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21414,12 +21397,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 390,
+        "line": 388,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21437,7 +21420,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21445,12 +21428,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 390,
+        "line": 388,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21468,7 +21451,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21476,12 +21459,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 390,
+        "line": 388,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21499,7 +21482,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21507,12 +21490,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 403,
+        "line": 401,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21530,7 +21513,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21538,12 +21521,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 403,
+        "line": 401,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21561,7 +21544,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21569,12 +21552,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_max_resolution",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21592,7 +21575,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21600,12 +21583,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21623,7 +21606,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21631,12 +21614,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21654,7 +21637,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21662,12 +21645,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_comfy_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21685,7 +21668,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21693,12 +21676,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_loaded_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21716,7 +21699,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21724,12 +21707,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21747,7 +21730,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21755,12 +21738,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_any_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21778,7 +21761,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21786,12 +21769,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 411,
+        "line": 409,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21809,7 +21792,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21817,12 +21800,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 422,
+        "line": 420,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21840,7 +21823,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21848,12 +21831,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 422,
+        "line": 420,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21871,7 +21854,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21879,12 +21862,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_encode_with_comfy_clip",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 422,
+        "line": 420,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21902,7 +21885,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21910,12 +21893,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 422,
+        "line": 420,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -21933,7 +21916,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21941,12 +21924,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21964,7 +21947,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -21972,12 +21955,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -21995,7 +21978,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22003,12 +21986,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22026,7 +22009,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22034,12 +22017,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22057,7 +22040,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22065,12 +22048,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22088,7 +22071,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22096,12 +22079,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 436,
+        "line": 434,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22119,7 +22102,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22127,12 +22110,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 436,
+        "line": 434,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22150,7 +22133,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22158,12 +22141,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_impact_detailer_node_runtime",
           "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 440,
+        "line": 438,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22181,7 +22164,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22189,12 +22172,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22212,7 +22195,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22220,12 +22203,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22243,7 +22226,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22251,12 +22234,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_node_runtime",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22274,7 +22257,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22282,12 +22265,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22305,7 +22288,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22313,12 +22296,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22336,7 +22319,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22344,12 +22327,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22367,7 +22350,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22375,12 +22358,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22398,7 +22381,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22406,12 +22389,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_node_runtime",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22429,7 +22412,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22437,12 +22420,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 456,
+        "line": 454,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22460,7 +22443,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22468,12 +22451,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 456,
+        "line": 454,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22491,7 +22474,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22499,12 +22482,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_node_runtime",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 456,
+        "line": 454,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22522,7 +22505,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22530,12 +22513,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 461,
+        "line": 459,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22553,7 +22536,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22561,12 +22544,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 461,
+        "line": 459,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22584,7 +22567,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22592,12 +22575,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 461,
+        "line": 459,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22615,7 +22598,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22623,12 +22606,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22646,7 +22629,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22654,12 +22637,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22677,7 +22660,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22685,12 +22668,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22708,7 +22691,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22716,12 +22699,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22739,7 +22722,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22747,12 +22730,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22770,7 +22753,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22778,12 +22761,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 502,
+        "line": 500,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22801,7 +22784,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22809,12 +22792,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 502,
+        "line": 500,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -22832,7 +22815,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22840,12 +22823,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22863,7 +22846,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22871,12 +22854,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -22894,7 +22877,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22902,12 +22885,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22925,7 +22908,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22933,12 +22916,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_metadata_runtime",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22956,7 +22939,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22964,12 +22947,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -22987,7 +22970,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -22995,12 +22978,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23018,7 +23001,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23026,12 +23009,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23049,7 +23032,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23057,12 +23040,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23080,7 +23063,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23088,12 +23071,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23111,7 +23094,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23119,12 +23102,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23142,7 +23125,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23150,12 +23133,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23173,7 +23156,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23181,12 +23164,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23204,7 +23187,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23212,12 +23195,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23235,7 +23218,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23243,12 +23226,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23266,7 +23249,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23274,12 +23257,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23297,7 +23280,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23305,12 +23288,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23328,7 +23311,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23336,12 +23319,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23359,7 +23342,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23367,12 +23350,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_preset_runtime",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23390,7 +23373,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23398,12 +23381,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23421,7 +23404,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23429,12 +23412,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23452,7 +23435,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23460,12 +23443,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23483,7 +23466,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23491,12 +23474,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23514,7 +23497,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23522,12 +23505,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23545,7 +23528,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23553,12 +23536,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23576,7 +23559,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23584,12 +23567,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23607,7 +23590,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23615,12 +23598,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 538,
+        "line": 536,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23638,7 +23621,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23646,12 +23629,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_node_runtime",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 538,
+        "line": 536,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23669,7 +23652,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23677,12 +23660,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23700,7 +23683,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23708,12 +23691,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23731,7 +23714,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23739,12 +23722,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 543,
+        "line": 541,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23762,7 +23745,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23770,12 +23753,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23793,7 +23776,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23801,12 +23784,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -23824,7 +23807,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23832,12 +23815,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -23855,7 +23838,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23863,12 +23846,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 549,
+        "line": 547,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23886,7 +23869,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23894,12 +23877,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 549,
+        "line": 547,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -23917,7 +23900,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23925,12 +23908,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23948,7 +23931,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23956,12 +23939,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -23979,7 +23962,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -23987,12 +23970,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24010,7 +23993,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24018,12 +24001,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24041,7 +24024,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24049,12 +24032,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24072,7 +24055,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24080,12 +24063,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24103,7 +24086,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24111,12 +24094,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24134,7 +24117,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24142,12 +24125,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24165,7 +24148,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24173,12 +24156,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24196,7 +24179,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24204,12 +24187,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24227,7 +24210,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24235,12 +24218,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24258,7 +24241,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24266,12 +24249,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24289,7 +24272,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24297,12 +24280,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24320,7 +24303,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24328,12 +24311,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24351,7 +24334,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24359,12 +24342,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24382,7 +24365,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24390,12 +24373,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24413,7 +24396,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24421,12 +24404,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24444,7 +24427,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24452,12 +24435,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24475,7 +24458,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "internal",
@@ -24483,12 +24466,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24507,9 +24490,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24517,12 +24500,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24541,9 +24524,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24551,12 +24534,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24575,9 +24558,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24585,12 +24568,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_FIRST_PASS_CACHE_ORDER",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24609,9 +24592,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24619,12 +24602,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_first_pass_cache_key",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24643,9 +24626,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24653,12 +24636,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_first_pass_cache_runtime",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24677,9 +24660,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24687,12 +24670,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_aio_cache_value",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24711,9 +24694,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24721,12 +24704,12 @@
         "compatibility_pair": {
           "bound_name": "_get_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24745,9 +24728,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24755,12 +24738,12 @@
         "compatibility_pair": {
           "bound_name": "_put_aio_first_pass_cache",
           "target": "easyuse_anima/aio/first_pass_cache.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24779,9 +24762,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24789,12 +24772,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_legacy_generation_runtime",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24813,9 +24796,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24823,12 +24806,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24847,9 +24830,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24857,12 +24840,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_detailer_target",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24881,9 +24864,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24891,12 +24874,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_highres_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24915,9 +24898,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24925,12 +24908,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_legacy_generation",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24949,9 +24932,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24959,12 +24942,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_resshift_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24983,9 +24966,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -24993,12 +24976,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25017,9 +25000,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25027,12 +25010,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_usdu_upscale_stage",
           "target": "easyuse_anima/aio/legacy_generation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25051,9 +25034,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25061,12 +25044,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEEDS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25085,9 +25068,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25095,12 +25078,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_DECREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25119,9 +25102,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25129,12 +25112,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_INCREMENT",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25153,9 +25136,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25163,12 +25146,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_SPECIAL_SEED_RANDOM",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25187,9 +25170,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25197,12 +25180,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_CUSTOM_RE",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25221,9 +25204,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25231,12 +25214,12 @@
         "compatibility_pair": {
           "bound_name": "_AIO_DETAILER_RESERVED_KEYS",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25255,9 +25238,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25265,12 +25248,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_has_enabled_targets",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25289,9 +25272,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25299,12 +25282,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_defaults",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25323,9 +25306,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25333,12 +25316,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_detailer_target_order",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25357,9 +25340,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25367,12 +25350,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_generation_normalization_runtime",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25391,9 +25374,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25401,12 +25384,12 @@
         "compatibility_pair": {
           "bound_name": "_is_aio_detailer_target_name",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25425,9 +25408,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25435,12 +25418,12 @@
         "compatibility_pair": {
           "bound_name": "_merge_versioned_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25459,9 +25442,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25469,12 +25452,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_dit_corrections_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25493,9 +25476,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25503,12 +25486,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25527,9 +25510,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25537,12 +25520,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_seed",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25561,9 +25544,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25571,12 +25554,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_spectrum_settings",
           "target": "easyuse_anima/aio/generation_normalization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25595,9 +25578,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25605,12 +25588,12 @@
         "compatibility_pair": {
           "bound_name": "_round_trip_aio_generation_settings",
           "target": "easyuse_anima/aio/generation_settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 611,
+        "line": 609,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25629,9 +25612,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25639,12 +25622,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_auto_tile_dimension",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25663,9 +25646,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25673,12 +25656,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_tile_plan",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25697,9 +25680,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25707,12 +25690,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_usdu_planning_runtime",
           "target": "easyuse_anima/aio/usdu.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25731,9 +25714,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25741,12 +25724,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_final_fit_size",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25765,9 +25748,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25775,12 +25758,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_final_fit",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25799,9 +25782,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25809,12 +25792,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_postprocess_runtime",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25833,9 +25816,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25843,12 +25826,12 @@
         "compatibility_pair": {
           "bound_name": "_resize_image_to_size_if_needed",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25867,9 +25850,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25877,12 +25860,12 @@
         "compatibility_pair": {
           "bound_name": "_run_aio_postprocess_stage",
           "target": "easyuse_anima/aio/postprocess.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25901,9 +25884,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25911,12 +25894,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_data_fields_for_usdu",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25935,9 +25918,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25945,12 +25928,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_conditioning",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -25969,9 +25952,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -25979,12 +25962,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_usdu_prompt_without_general",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26003,9 +25986,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26013,12 +25996,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_conditioning_runtime",
           "target": "easyuse_anima/aio/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26037,9 +26020,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26047,12 +26030,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_stack_signature",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26071,9 +26054,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26081,12 +26064,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_anima_dave_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26105,9 +26088,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26115,12 +26098,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_kj_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26139,9 +26122,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26149,12 +26132,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26173,9 +26156,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26183,12 +26166,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_model_patches",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26207,9 +26190,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26217,12 +26200,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_safe_pag_patch",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26241,9 +26224,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26251,12 +26234,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26275,9 +26258,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26285,12 +26268,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26309,9 +26292,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26319,12 +26302,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26343,9 +26326,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26353,12 +26336,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_model_preparation_runtime",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26377,9 +26360,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26387,12 +26370,12 @@
         "compatibility_pair": {
           "bound_name": "_cleanup_aio_ephemeral_model",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26411,9 +26394,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26421,12 +26404,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_lora_stack",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26445,9 +26428,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26455,12 +26438,12 @@
         "compatibility_pair": {
           "bound_name": "_patch_model_sampling_aura_flow",
           "target": "easyuse_anima/aio/model_preparation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26479,9 +26462,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26489,12 +26472,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_highres_effective_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26513,9 +26496,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26523,12 +26506,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_stage_sampler_settings",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26547,9 +26530,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26557,12 +26540,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_sampling_runtime",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26581,9 +26564,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26591,12 +26574,12 @@
         "compatibility_pair": {
           "bound_name": "_decode_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26615,9 +26598,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26625,12 +26608,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_image_with_comfy_vae",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26649,9 +26632,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26659,12 +26642,12 @@
         "compatibility_pair": {
           "bound_name": "_generate_empty_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26683,9 +26666,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26693,12 +26676,12 @@
         "compatibility_pair": {
           "bound_name": "_new_aio_random_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26717,9 +26700,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26727,12 +26710,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_aio_runtime_seed",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26751,9 +26734,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26761,12 +26744,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_aio_backend",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26785,9 +26768,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26795,12 +26778,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_comfy",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26819,9 +26802,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26829,12 +26812,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_mod_guidance_advanced",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26853,9 +26836,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26863,12 +26846,12 @@
         "compatibility_pair": {
           "bound_name": "_sample_latent_with_spectrum_spd",
           "target": "easyuse_anima/aio/sampling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26887,9 +26870,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26897,12 +26880,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_FORMAT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26921,9 +26904,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26931,12 +26914,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_CACHE_QUALITY",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26955,9 +26938,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26965,12 +26948,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_EVENT",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -26989,9 +26972,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -26999,12 +26982,12 @@
         "compatibility_pair": {
           "bound_name": "AIO_PREVIEW_STAGE_LABELS",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27023,9 +27006,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27033,12 +27016,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_base_directory",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27057,9 +27040,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27067,12 +27050,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_preview_file_size_bytes",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27091,9 +27074,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27101,12 +27084,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_preview_runtime",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27125,9 +27108,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27135,12 +27118,12 @@
         "compatibility_pair": {
           "bound_name": "_save_aio_temp_preview_image",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27159,9 +27142,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27169,12 +27152,12 @@
         "compatibility_pair": {
           "bound_name": "_send_aio_preview_event",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27193,9 +27176,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27203,12 +27186,12 @@
         "compatibility_pair": {
           "bound_name": "_tag_aio_preview_images",
           "target": "easyuse_anima/aio/preview.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27227,9 +27210,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27237,12 +27220,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_additional_hashes",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27261,9 +27244,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27271,12 +27254,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_image_saver_civitai_hash_fetcher_entries",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27295,9 +27278,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27305,12 +27288,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_lora_metadata_name",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27329,9 +27312,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27339,12 +27322,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_prompt_with_lora_metadata",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27363,9 +27346,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27373,12 +27356,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_save_filename_prefix",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27397,9 +27380,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27407,12 +27390,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_output_runtime",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27431,9 +27414,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27441,12 +27424,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_civitai_hash_fetchers",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27465,9 +27448,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27475,12 +27458,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_hash_bundles",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27499,9 +27482,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27509,12 +27492,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_comfy",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27533,9 +27516,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27543,12 +27526,12 @@
         "compatibility_pair": {
           "bound_name": "_save_image_with_image_saver",
           "target": "easyuse_anima/aio/output.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27567,9 +27550,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27577,12 +27560,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_resource_runtime",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27601,9 +27584,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27611,12 +27594,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_clip_loader_types",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27635,9 +27618,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27645,12 +27628,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_diffusion_model_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27669,9 +27652,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27679,12 +27662,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_text_encoder_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27703,9 +27686,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27713,12 +27696,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_vae_names",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27737,9 +27720,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27747,12 +27730,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_resources_from_input_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27771,9 +27754,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27781,12 +27764,12 @@
         "compatibility_pair": {
           "bound_name": "_load_aio_sam3_context",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27805,9 +27788,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27815,12 +27798,12 @@
         "compatibility_pair": {
           "bound_name": "_load_checkpoint_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27839,9 +27822,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27849,12 +27832,12 @@
         "compatibility_pair": {
           "bound_name": "_load_clip_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27873,9 +27856,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27883,12 +27866,12 @@
         "compatibility_pair": {
           "bound_name": "_load_diffusion_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27907,9 +27890,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27917,12 +27900,12 @@
         "compatibility_pair": {
           "bound_name": "_load_upscale_model_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27941,9 +27924,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27951,12 +27934,12 @@
         "compatibility_pair": {
           "bound_name": "_load_vae_with_comfy",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27975,9 +27958,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -27985,12 +27968,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_aio_input_settings",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28009,9 +27992,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28019,12 +28002,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_checkpoint_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28043,9 +28026,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28053,12 +28036,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_clip_type_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28077,9 +28060,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28087,12 +28070,12 @@
         "compatibility_pair": {
           "bound_name": "_preferred_name_default",
           "target": "easyuse_anima/aio/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28111,9 +28094,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28121,12 +28104,12 @@
         "compatibility_pair": {
           "bound_name": "_json_clone",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28145,9 +28128,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28155,12 +28138,12 @@
         "compatibility_pair": {
           "bound_name": "_json_object",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28179,9 +28162,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28189,12 +28172,12 @@
         "compatibility_pair": {
           "bound_name": "_stable_change_key",
           "target": "easyuse_anima/common/serialization.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28213,9 +28196,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28223,12 +28206,12 @@
         "compatibility_pair": {
           "bound_name": "_as_bool",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28247,9 +28230,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28257,12 +28240,12 @@
         "compatibility_pair": {
           "bound_name": "_as_float",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28281,9 +28264,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28291,12 +28274,12 @@
         "compatibility_pair": {
           "bound_name": "_as_int",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28315,9 +28298,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28325,12 +28308,12 @@
         "compatibility_pair": {
           "bound_name": "_choice",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28349,9 +28332,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28359,12 +28342,12 @@
         "compatibility_pair": {
           "bound_name": "_single_value",
           "target": "easyuse_anima/common/values.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28383,9 +28366,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28393,12 +28376,12 @@
         "compatibility_pair": {
           "bound_name": "_get_workflow_node",
           "target": "easyuse_anima/workflow.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28417,9 +28400,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28427,12 +28410,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_correction_runtime",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28451,9 +28434,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28461,12 +28444,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_translation_change_key",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28485,9 +28468,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28495,12 +28478,12 @@
         "compatibility_pair": {
           "bound_name": "_split_tag_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28519,9 +28502,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28529,12 +28512,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_text",
           "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28553,9 +28536,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28563,12 +28546,12 @@
         "compatibility_pair": {
           "bound_name": "_HASH_COMMENT_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28587,9 +28570,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28597,12 +28580,12 @@
         "compatibility_pair": {
           "bound_name": "_INLINE_SPACE_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28621,9 +28604,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28631,12 +28614,12 @@
         "compatibility_pair": {
           "bound_name": "_WEIGHTED_TOKEN_RE",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28655,9 +28638,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28665,12 +28648,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_fields_runtime",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28689,9 +28672,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28699,12 +28682,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_builder_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28723,9 +28706,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28733,12 +28716,12 @@
         "compatibility_pair": {
           "bound_name": "_filter_metadata_prompt",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28757,9 +28740,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28767,12 +28750,12 @@
         "compatibility_pair": {
           "bound_name": "_join_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28791,9 +28774,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28801,12 +28784,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_key",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28825,9 +28808,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28835,12 +28818,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_filter_keys",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28859,9 +28842,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28869,12 +28852,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_tokens",
           "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28893,9 +28876,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28903,12 +28886,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_DATA_TYPE",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28927,9 +28910,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28937,12 +28920,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_outputs_from_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28961,9 +28944,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -28971,12 +28954,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_prompt_data_overrides",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -28995,9 +28978,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29005,12 +28988,12 @@
         "compatibility_pair": {
           "bound_name": "_copy_prompt_data_for_update",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29029,9 +29012,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29039,12 +29022,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_data",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29063,9 +29046,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29073,12 +29056,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_json_safe",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29097,9 +29080,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29107,12 +29090,12 @@
         "compatibility_pair": {
           "bound_name": "_prompt_data_parameter_snapshot",
           "target": "easyuse_anima/prompt/data.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29131,9 +29114,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29141,12 +29124,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_artist_field_prompt",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29165,9 +29148,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29175,12 +29158,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_default_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29199,9 +29182,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29209,12 +29192,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_naia_panes",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29233,9 +29216,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29243,12 +29226,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_enabled_pane_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29267,9 +29250,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29277,12 +29260,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_input_values",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29301,9 +29284,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29311,12 +29294,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_field_socket_name",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29335,9 +29318,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29345,12 +29328,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_fields_json",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29369,9 +29352,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29379,12 +29362,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_has_enabled_naia",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29403,9 +29386,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29413,12 +29396,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_prompt_with_artist_override",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29437,9 +29420,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29447,12 +29430,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_uses_naia_resolution",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29471,9 +29454,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29481,12 +29464,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_advanced_field_inputs",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29505,9 +29488,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29515,12 +29498,12 @@
         "compatibility_pair": {
           "bound_name": "_as_advanced_height",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29539,9 +29522,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29549,12 +29532,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_advanced_runtime",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29573,9 +29556,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29583,12 +29566,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompt_data",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29607,9 +29590,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29617,12 +29600,12 @@
         "compatibility_pair": {
           "bound_name": "_build_advanced_prompts",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29641,9 +29624,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29651,12 +29634,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29675,9 +29658,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29685,12 +29668,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_advanced_field_sequence",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29709,9 +29692,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29719,12 +29702,12 @@
         "compatibility_pair": {
           "bound_name": "_expand_advanced_wildcard_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29743,9 +29726,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29753,12 +29736,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_advanced_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29777,9 +29760,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29787,12 +29770,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_prompt_studio_wildcard_seed_control",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29811,9 +29794,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29821,12 +29804,12 @@
         "compatibility_pair": {
           "bound_name": "_set_naia_field_text",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29845,9 +29828,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29855,12 +29838,12 @@
         "compatibility_pair": {
           "bound_name": "_translate_prompt_fields",
           "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29879,9 +29862,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29889,12 +29872,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_regional_field_inputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29913,9 +29896,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29923,12 +29906,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_runtime",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29947,9 +29930,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29957,12 +29940,12 @@
         "compatibility_pair": {
           "bound_name": "_build_regional_outputs",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -29981,9 +29964,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -29991,12 +29974,12 @@
         "compatibility_pair": {
           "bound_name": "_clone_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30015,9 +29998,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30025,12 +30008,12 @@
         "compatibility_pair": {
           "bound_name": "_conditioning_set_values",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30049,9 +30032,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30059,12 +30042,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_mask_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30083,9 +30066,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30093,12 +30076,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_config",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30117,9 +30100,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30127,12 +30110,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_regional_fields",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30151,9 +30134,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30161,12 +30144,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_json_object",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30185,9 +30168,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30195,12 +30178,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_config_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30219,9 +30202,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30229,12 +30212,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_fields_json",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30253,9 +30236,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30263,12 +30246,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_mask_bounds_area",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30287,9 +30270,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30297,12 +30280,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_payload_canvas",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30321,9 +30304,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30331,12 +30314,12 @@
         "compatibility_pair": {
           "bound_name": "_regional_union_mask_for_ids",
           "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30355,9 +30338,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30365,12 +30348,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30389,9 +30372,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30399,12 +30382,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODES",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30423,9 +30406,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30433,12 +30416,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30457,9 +30440,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30467,12 +30450,12 @@
         "compatibility_pair": {
           "bound_name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30491,9 +30474,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30501,12 +30484,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_spectrum_anima_mod_guidance",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30525,9 +30508,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30535,12 +30518,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_conditioning_runtime",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30559,9 +30542,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30569,12 +30552,12 @@
         "compatibility_pair": {
           "bound_name": "_find_spectrum_anima_mod_guidance_class",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30593,9 +30576,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30603,12 +30586,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_anima_mod_guidance_profile",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30627,9 +30610,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30637,12 +30620,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_anima_mod_guidance_enabled",
           "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30661,9 +30644,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30671,12 +30654,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30695,9 +30678,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30705,12 +30688,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30729,9 +30712,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30739,12 +30722,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30763,9 +30746,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30773,12 +30756,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30797,9 +30780,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30807,12 +30790,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30831,9 +30814,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30841,12 +30824,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_START_PERCENT",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30865,9 +30848,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30875,12 +30858,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30899,9 +30882,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30909,12 +30892,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30933,9 +30916,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30943,12 +30926,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_INPUT_MODES",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30967,9 +30950,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -30977,12 +30960,12 @@
         "compatibility_pair": {
           "bound_name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31001,9 +30984,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31011,12 +30994,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_inline_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31035,9 +31018,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31045,12 +31028,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_mix_mode_tooltip",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31069,9 +31052,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31079,12 +31062,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_prompt_with_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31103,9 +31086,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31113,12 +31096,12 @@
         "compatibility_pair": {
           "bound_name": "_artist_tags_from_prompt",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31137,9 +31120,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31147,12 +31130,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_artist_mix_runtime",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31171,9 +31154,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31181,12 +31164,12 @@
         "compatibility_pair": {
           "bound_name": "_blend_conditionings",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31205,9 +31188,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31215,12 +31198,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_float",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31239,9 +31222,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31249,12 +31232,12 @@
         "compatibility_pair": {
           "bound_name": "_bounded_artist_mix_int",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31273,9 +31256,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31283,12 +31266,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_clustered",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31307,9 +31290,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31317,12 +31300,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_artist_delta_rms",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31341,9 +31324,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31351,12 +31334,12 @@
         "compatibility_pair": {
           "bound_name": "_encode_prompt_data_positive_conditioning",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31375,9 +31358,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31385,12 +31368,12 @@
         "compatibility_pair": {
           "bound_name": "_join_artist_mix_source_prompts",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31409,9 +31392,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31419,12 +31402,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_mix_mode",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31443,9 +31426,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31453,12 +31436,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_artist_tag_position",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31477,9 +31460,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31487,12 +31470,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_artist_mix_items",
           "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31511,9 +31494,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31521,12 +31504,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaArtistMixConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31545,9 +31528,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31555,12 +31538,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataConditioning",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31579,9 +31562,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31589,12 +31572,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptDataUnpack",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31613,9 +31596,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31623,12 +31606,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_data_node_runtime",
           "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31647,9 +31630,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31657,12 +31640,12 @@
         "compatibility_pair": {
           "bound_name": "_ANY_TYPE",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31681,9 +31664,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31691,12 +31674,12 @@
         "compatibility_pair": {
           "bound_name": "_AnyType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31715,9 +31698,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31725,12 +31708,12 @@
         "compatibility_pair": {
           "bound_name": "_FlexibleOptionalInputType",
           "target": "easyuse_anima/nodes/input_types.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31749,9 +31732,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31759,12 +31742,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvanced",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31783,9 +31766,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31793,12 +31776,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioAdvancedV2",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31817,9 +31800,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31827,12 +31810,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_advanced_node_runtime",
           "target": "easyuse_anima/nodes/prompt_advanced_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31851,9 +31834,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31861,12 +31844,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaAIOGenerator",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31885,9 +31868,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31895,12 +31878,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaInput",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31919,9 +31902,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31929,12 +31912,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_generation_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31953,9 +31936,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31963,12 +31946,12 @@
         "compatibility_pair": {
           "bound_name": "_aio_input_settings_json",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -31987,9 +31970,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -31997,12 +31980,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_aio_node_runtime",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32021,9 +32004,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32031,12 +32014,12 @@
         "compatibility_pair": {
           "bound_name": "_easy_use_anima_input_signature",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32055,9 +32038,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32065,12 +32048,12 @@
         "compatibility_pair": {
           "bound_name": "_require_easy_use_anima_input",
           "target": "easyuse_anima/nodes/aio_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32089,9 +32072,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32099,12 +32082,12 @@
         "compatibility_pair": {
           "bound_name": "_align_down",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32123,9 +32106,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32133,12 +32116,12 @@
         "compatibility_pair": {
           "bound_name": "_align_nearest",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32157,9 +32140,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32167,12 +32150,12 @@
         "compatibility_pair": {
           "bound_name": "_image_tensor_size",
           "target": "easyuse_anima/image/geometry.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32191,9 +32174,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32201,12 +32184,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_runtime",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32225,9 +32208,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32235,12 +32218,12 @@
         "compatibility_pair": {
           "bound_name": "_context_value",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32259,9 +32242,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32269,12 +32252,12 @@
         "compatibility_pair": {
           "bound_name": "_sam3_context",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32293,9 +32276,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32303,12 +32286,12 @@
         "compatibility_pair": {
           "bound_name": "_segs_has_items",
           "target": "easyuse_anima/image/sam3.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32327,9 +32310,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32337,12 +32320,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_SCALE_MULTIPLES",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32361,9 +32344,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32371,12 +32354,12 @@
         "compatibility_pair": {
           "bound_name": "IMAGE_UPSCALE_METHODS",
           "target": "easyuse_anima/image/scaling.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32395,9 +32378,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32405,12 +32388,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_max_resolution",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32429,9 +32412,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32439,12 +32422,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_sampler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32463,9 +32446,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32473,12 +32456,12 @@
         "compatibility_pair": {
           "bound_name": "_comfy_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32497,9 +32480,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32507,12 +32490,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_comfy_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32531,9 +32514,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32541,12 +32524,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_find_loaded_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32565,9 +32548,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32575,12 +32558,12 @@
         "compatibility_pair": {
           "bound_name": "_impact_scheduler_names",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32599,9 +32582,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32609,12 +32592,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_any_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32633,9 +32616,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32643,12 +32626,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_require_custom_node_class",
           "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32667,9 +32650,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32677,12 +32660,12 @@
         "compatibility_pair": {
           "bound_name": "_call_with_supported_kwargs",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32701,9 +32684,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32711,12 +32694,12 @@
         "compatibility_pair": {
           "bound_name": "_common_upscale_image",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32735,9 +32718,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32745,12 +32728,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_encode_with_comfy_clip",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32769,9 +32752,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32779,12 +32762,12 @@
         "compatibility_pair": {
           "bound_name": "_node_output_tuple",
           "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32803,9 +32786,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32813,12 +32796,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_clip_loader_types",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32837,9 +32820,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32847,12 +32830,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_diffusion_model_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32871,9 +32854,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32881,12 +32864,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_text_encoder_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32905,9 +32888,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32915,12 +32898,12 @@
         "compatibility_pair": {
           "bound_name": "_adapter_comfy_vae_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32939,9 +32922,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32949,12 +32932,12 @@
         "compatibility_pair": {
           "bound_name": "_folder_path_names",
           "target": "easyuse_anima/infrastructure/comfy/resources.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32973,9 +32956,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -32983,12 +32966,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaDetailerAlignHook",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33007,9 +32990,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33017,12 +33000,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaImageScaleByMultiple",
           "target": "easyuse_anima/nodes/image_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33041,9 +33024,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33051,12 +33034,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_impact_detailer_node_runtime",
           "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1001,
+        "line": 999,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33075,9 +33058,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33085,12 +33068,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Context",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33109,9 +33092,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33119,12 +33102,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaSAM3Detailer",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33143,9 +33126,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33153,12 +33136,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_sam3_node_runtime",
           "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33177,9 +33160,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33187,12 +33170,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptBuilder",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33211,9 +33194,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33221,12 +33204,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrector",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33245,9 +33228,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33255,12 +33238,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptCorrectorSimple",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33279,9 +33262,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33289,12 +33272,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudio",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33313,9 +33296,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33323,12 +33306,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_prompt_node_runtime",
           "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33347,9 +33330,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33357,12 +33340,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaPromptStudioRegional",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33381,9 +33364,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33391,12 +33374,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaRegionalConditioning",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33415,9 +33398,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33425,12 +33408,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_regional_node_runtime",
           "target": "easyuse_anima/nodes/regional_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33449,9 +33432,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33459,12 +33442,12 @@
         "compatibility_pair": {
           "bound_name": "LATENT_ALIGN",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33483,9 +33466,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33493,12 +33476,12 @@
         "compatibility_pair": {
           "bound_name": "_parse_random_response",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33517,9 +33500,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33527,12 +33510,12 @@
         "compatibility_pair": {
           "bound_name": "_post_random",
           "target": "easyuse_anima/naia/client.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33551,9 +33534,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33561,12 +33544,12 @@
         "compatibility_pair": {
           "bound_name": "_advanced_resolution_from_selection",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33585,9 +33568,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33595,12 +33578,12 @@
         "compatibility_pair": {
           "bound_name": "_normalize_resolution_bucket",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33619,9 +33602,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33629,12 +33612,12 @@
         "compatibility_pair": {
           "bound_name": "_ratio_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33653,9 +33636,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33663,12 +33646,12 @@
         "compatibility_pair": {
           "bound_name": "_resolution_label",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33687,9 +33670,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33697,12 +33680,12 @@
         "compatibility_pair": {
           "bound_name": "_resolve_naia_resolution",
           "target": "easyuse_anima/naia/resolution.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33721,9 +33704,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33731,12 +33714,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaNAIARandomPrompt",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33755,9 +33738,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33765,12 +33748,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_naia_node_runtime",
           "target": "easyuse_anima/nodes/naia_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33789,9 +33772,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33799,12 +33782,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaWildcard",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33823,9 +33806,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33833,12 +33816,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_wildcard_node_runtime",
           "target": "easyuse_anima/nodes/wildcard_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33857,9 +33840,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33867,12 +33850,12 @@
         "compatibility_pair": {
           "bound_name": "_apply_lora_syntax_format",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33891,9 +33874,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33901,12 +33884,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_metadata_runtime",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33925,9 +33908,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33935,12 +33918,12 @@
         "compatibility_pair": {
           "bound_name": "_dedupe_text_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33959,9 +33942,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -33969,12 +33952,12 @@
         "compatibility_pair": {
           "bound_name": "_fallback_lora_path",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33993,9 +33976,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34003,12 +33986,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_info",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34027,9 +34010,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34037,12 +34020,12 @@
         "compatibility_pair": {
           "bound_name": "_get_lora_manager_trigger_words",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34061,9 +34044,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34071,12 +34054,12 @@
         "compatibility_pair": {
           "bound_name": "_load_lora_manager_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34095,9 +34078,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34105,12 +34088,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_combo_values",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34129,9 +34112,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34139,12 +34122,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_manager_trigger_words_from_metadata",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34163,9 +34146,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34173,12 +34156,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_model_exists",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34197,9 +34180,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34207,12 +34190,12 @@
         "compatibility_pair": {
           "bound_name": "_lora_stack_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34231,9 +34214,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34241,12 +34224,12 @@
         "compatibility_pair": {
           "bound_name": "_metadata_json_paths_for_lora",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34265,9 +34248,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34275,12 +34258,12 @@
         "compatibility_pair": {
           "bound_name": "_missing_lora_display_name",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34299,9 +34282,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34309,12 +34292,12 @@
         "compatibility_pair": {
           "bound_name": "_raise_missing_loras",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34333,9 +34316,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34343,12 +34326,12 @@
         "compatibility_pair": {
           "bound_name": "_trigger_words_from_value",
           "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34367,9 +34350,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34377,12 +34360,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_preset_runtime",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34401,9 +34384,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34411,12 +34394,12 @@
         "compatibility_pair": {
           "bound_name": "_correct_style_prompt",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34435,9 +34418,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34445,12 +34428,12 @@
         "compatibility_pair": {
           "bound_name": "_format_strength",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34469,9 +34452,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34479,12 +34462,12 @@
         "compatibility_pair": {
           "bound_name": "_get_loras_list",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34503,9 +34486,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34513,12 +34496,12 @@
         "compatibility_pair": {
           "bound_name": "_load_profile_data",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34537,9 +34520,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34547,12 +34530,12 @@
         "compatibility_pair": {
           "bound_name": "_profile_key",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34571,9 +34554,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34581,12 +34564,12 @@
         "compatibility_pair": {
           "bound_name": "_select_profile_values",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34605,9 +34588,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34615,12 +34598,12 @@
         "compatibility_pair": {
           "bound_name": "_wrap_profile_index",
           "target": "easyuse_anima/lora/preset.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34639,9 +34622,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34649,12 +34632,12 @@
         "compatibility_pair": {
           "bound_name": "EasyUseAnimaLoraPreset",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34673,9 +34656,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34683,12 +34666,12 @@
         "compatibility_pair": {
           "bound_name": "_bind_lora_node_runtime",
           "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34707,9 +34690,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34717,12 +34700,12 @@
         "compatibility_pair": {
           "bound_name": "correct_prompt",
           "target": "anima_prompt/__init__.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1101,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34741,9 +34724,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34751,12 +34734,12 @@
         "compatibility_pair": {
           "bound_name": "load_knowledge_base",
           "target": "anima_prompt/__init__.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1101,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34775,9 +34758,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34785,12 +34768,12 @@
         "compatibility_pair": {
           "bound_name": "parse_prompt",
           "target": "anima_prompt/parser.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1102,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34809,9 +34792,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34819,12 +34802,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_metadata_filter_words",
           "target": "settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34843,9 +34826,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34853,12 +34836,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_naia_settings",
           "target": "settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34877,9 +34860,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34887,12 +34870,12 @@
         "compatibility_pair": {
           "bound_name": "resolve_prompt_translation_settings",
           "target": "settings.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34911,9 +34894,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34921,12 +34904,12 @@
         "compatibility_pair": {
           "bound_name": "has_prompt_translation_markers",
           "target": "prompt_translation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34945,9 +34928,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34955,12 +34938,12 @@
         "compatibility_pair": {
           "bound_name": "translate_prompt_markers",
           "target": "prompt_translation.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34979,9 +34962,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -34989,12 +34972,12 @@
         "compatibility_pair": {
           "bound_name": "MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35013,9 +34996,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35023,12 +35006,12 @@
         "compatibility_pair": {
           "bound_name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35047,9 +35030,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35057,12 +35040,12 @@
         "compatibility_pair": {
           "bound_name": "PUBLIC_MAX_SEED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35081,9 +35064,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35091,12 +35074,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_DECREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35115,9 +35098,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35125,12 +35108,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35149,9 +35132,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35159,12 +35142,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_INCREMENT",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35183,9 +35166,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35193,12 +35176,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_MODES",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35217,9 +35200,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35227,12 +35210,12 @@
         "compatibility_pair": {
           "bound_name": "SEED_CONTROL_RANDOMIZE",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35251,9 +35234,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35261,12 +35244,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_FIXED",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35285,9 +35268,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35295,12 +35278,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_POPULATE",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35319,9 +35302,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35329,12 +35312,12 @@
         "compatibility_pair": {
           "bound_name": "WILDCARD_MODE_SEQUENTIAL",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35353,9 +35336,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35363,12 +35346,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcard_texts",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35387,9 +35370,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35397,12 +35380,12 @@
         "compatibility_pair": {
           "bound_name": "expand_wildcards",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35421,9 +35404,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35431,12 +35414,12 @@
         "compatibility_pair": {
           "bound_name": "has_wildcard_syntax",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35455,9 +35438,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35465,12 +35448,12 @@
         "compatibility_pair": {
           "bound_name": "next_seed",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35489,9 +35472,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35499,12 +35482,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_prompt_studio_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35523,9 +35506,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35533,12 +35516,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_seed",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35557,9 +35540,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35567,12 +35550,12 @@
         "compatibility_pair": {
           "bound_name": "normalize_wildcard_mode",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35591,9 +35574,9 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
@@ -35601,12 +35584,12 @@
         "compatibility_pair": {
           "bound_name": "wildcard_sources_signature",
           "target": "wildcard_engine.py",
-          "try_line": 10
+          "try_line": 8
         },
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35624,7 +35607,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1626
           }
         ],
         "classification": "external",
@@ -35632,7 +35615,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1627,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35649,7 +35632,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1634
           }
         ],
         "classification": "external",
@@ -35657,7 +35640,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1635,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35674,7 +35657,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1644
+            "line": 1642
           }
         ],
         "classification": "external",
@@ -35682,7 +35665,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1645,
+        "line": 1643,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -39314,9 +39297,9 @@
       },
       {
         "is_package": false,
-        "loc": 1865,
+        "loc": 1863,
         "module": "nodes",
-        "normalized_git_blob_sha1": "b27d8812d05c331d09c92ff66d75de8293720a94",
+        "normalized_git_blob_sha1": "10cb7e31fd9f8a4f85ecd65515881ae3ecafd3c3",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -40680,16 +40663,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40703,16 +40686,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40726,16 +40709,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40749,16 +40732,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40772,16 +40755,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40795,16 +40778,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40818,16 +40801,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40841,16 +40824,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40864,16 +40847,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40887,16 +40870,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40910,16 +40893,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40933,16 +40916,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40956,16 +40939,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40979,16 +40962,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41002,16 +40985,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41025,16 +41008,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41048,16 +41031,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41071,16 +41054,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41094,16 +41077,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41117,16 +41100,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41140,16 +41123,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41163,16 +41146,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41186,16 +41169,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41209,16 +41192,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41232,16 +41215,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41255,16 +41238,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41278,16 +41261,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41301,16 +41284,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41324,16 +41307,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41347,16 +41330,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41370,16 +41353,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41393,16 +41376,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41416,16 +41399,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 611,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41439,16 +41422,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41462,16 +41445,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41485,16 +41468,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41508,16 +41491,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41531,16 +41514,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41554,16 +41537,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41577,16 +41560,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41600,16 +41583,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41623,16 +41606,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41646,16 +41629,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41669,16 +41652,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41692,16 +41675,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41715,16 +41698,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41738,16 +41721,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41761,16 +41744,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41784,16 +41767,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41807,16 +41790,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41830,16 +41813,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41853,16 +41836,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41876,16 +41859,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41899,16 +41882,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41922,16 +41905,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41945,16 +41928,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41968,16 +41951,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41991,16 +41974,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42014,16 +41997,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42037,16 +42020,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42060,16 +42043,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42083,16 +42066,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42106,16 +42089,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42129,16 +42112,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42152,16 +42135,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42175,16 +42158,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42198,16 +42181,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42221,16 +42204,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42244,16 +42227,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42267,16 +42250,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42290,16 +42273,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42313,16 +42296,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42336,16 +42319,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42359,16 +42342,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42382,16 +42365,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42405,16 +42388,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42428,16 +42411,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42451,16 +42434,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42474,16 +42457,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42497,16 +42480,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42520,16 +42503,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42543,16 +42526,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42566,16 +42549,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42589,16 +42572,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42612,16 +42595,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42635,16 +42618,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42658,16 +42641,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42681,16 +42664,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42704,16 +42687,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42727,16 +42710,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42750,16 +42733,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42773,16 +42756,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42796,16 +42779,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42819,16 +42802,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42842,16 +42825,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42865,16 +42848,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42888,16 +42871,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42911,16 +42894,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42934,16 +42917,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42957,16 +42940,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42980,16 +42963,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43003,16 +42986,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43026,16 +43009,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43049,16 +43032,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43072,16 +43055,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43095,16 +43078,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43118,16 +43101,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43141,16 +43124,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43164,16 +43147,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43187,16 +43170,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43210,16 +43193,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43233,16 +43216,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43256,16 +43239,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43279,16 +43262,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43302,16 +43285,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43325,16 +43308,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43348,16 +43331,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43371,16 +43354,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43394,16 +43377,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43417,16 +43400,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43440,16 +43423,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43463,16 +43446,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43486,16 +43469,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43509,16 +43492,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43532,16 +43515,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43555,16 +43538,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43578,16 +43561,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43601,16 +43584,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43624,16 +43607,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43647,16 +43630,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43670,16 +43653,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43693,16 +43676,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43716,16 +43699,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43739,16 +43722,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43762,16 +43745,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43785,16 +43768,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43808,16 +43791,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43831,16 +43814,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43854,16 +43837,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43877,16 +43860,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43900,16 +43883,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43923,16 +43906,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43946,16 +43929,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43969,16 +43952,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43992,16 +43975,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44015,16 +43998,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44038,16 +44021,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44061,16 +44044,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44084,16 +44067,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44107,16 +44090,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44130,16 +44113,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44153,16 +44136,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44176,16 +44159,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44199,16 +44182,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44222,16 +44205,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44245,16 +44228,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44268,16 +44251,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44291,16 +44274,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44314,16 +44297,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44337,16 +44320,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44360,16 +44343,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44383,16 +44366,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44406,16 +44389,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44429,16 +44412,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44452,16 +44435,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44475,16 +44458,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44498,16 +44481,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44521,16 +44504,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44544,16 +44527,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44567,16 +44550,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44590,16 +44573,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44613,16 +44596,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44636,16 +44619,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44659,16 +44642,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44682,16 +44665,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44705,16 +44688,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44728,16 +44711,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44751,16 +44734,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44774,16 +44757,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44797,16 +44780,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44820,16 +44803,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44843,16 +44826,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44866,16 +44849,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44889,16 +44872,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44912,16 +44895,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44935,16 +44918,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44958,16 +44941,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44981,16 +44964,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45004,16 +44987,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45027,16 +45010,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45050,16 +45033,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45073,16 +45056,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45096,16 +45079,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45119,16 +45102,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45142,16 +45125,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45165,16 +45148,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45188,16 +45171,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45211,16 +45194,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45234,16 +45217,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45257,16 +45240,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45280,16 +45263,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45303,16 +45286,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45326,16 +45309,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45349,16 +45332,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45372,16 +45355,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45395,16 +45378,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45418,16 +45401,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45441,16 +45424,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45464,16 +45447,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45487,16 +45470,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45510,16 +45493,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45533,16 +45516,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45556,16 +45539,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45579,16 +45562,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45602,16 +45585,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45625,16 +45608,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45648,16 +45631,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45671,16 +45654,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45694,16 +45677,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45717,16 +45700,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45740,16 +45723,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45763,16 +45746,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45786,16 +45769,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45809,16 +45792,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45832,16 +45815,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45855,16 +45838,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45878,16 +45861,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45901,16 +45884,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45924,16 +45907,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45947,16 +45930,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45970,16 +45953,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45993,16 +45976,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46016,16 +45999,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46039,16 +46022,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46062,16 +46045,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46085,16 +46068,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46108,16 +46091,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46131,16 +46114,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46154,16 +46137,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46177,16 +46160,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46200,16 +46183,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46223,16 +46206,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46246,16 +46229,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46269,16 +46252,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46292,16 +46275,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46315,16 +46298,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46338,16 +46321,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46361,16 +46344,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46384,16 +46367,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46407,16 +46390,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46430,16 +46413,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 997,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46453,16 +46436,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1001,
+        "line": 999,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46476,16 +46459,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46499,16 +46482,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46522,16 +46505,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46545,16 +46528,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46568,16 +46551,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46591,16 +46574,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46614,16 +46597,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46637,16 +46620,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46660,16 +46643,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46683,16 +46666,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46706,16 +46689,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46729,16 +46712,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46752,16 +46735,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46775,16 +46758,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46798,16 +46781,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46821,16 +46804,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46844,16 +46827,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46867,16 +46850,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46890,16 +46873,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1040,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46913,16 +46896,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46936,16 +46919,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1061,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46959,16 +46942,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46982,16 +46965,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47005,16 +46988,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47028,16 +47011,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47051,16 +47034,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47074,16 +47057,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47097,16 +47080,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47120,16 +47103,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47143,16 +47126,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47166,16 +47149,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47189,16 +47172,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47212,16 +47195,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47235,16 +47218,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47258,16 +47241,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47281,16 +47264,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47304,16 +47287,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47327,16 +47310,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47350,16 +47333,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47373,16 +47356,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47396,16 +47379,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47419,16 +47402,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47442,16 +47425,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47465,16 +47448,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47488,16 +47471,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47511,16 +47494,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1089,
+        "line": 1087,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47534,16 +47517,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47557,16 +47540,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47580,16 +47563,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47603,16 +47586,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47626,16 +47609,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47649,16 +47632,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47672,16 +47655,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47695,16 +47678,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47718,16 +47701,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47741,16 +47724,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47764,16 +47747,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47787,16 +47770,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47810,16 +47793,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47833,16 +47816,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47856,16 +47839,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47879,16 +47862,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47902,16 +47885,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47925,16 +47908,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47948,16 +47931,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47971,16 +47954,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47994,16 +47977,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48017,16 +48000,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48040,16 +48023,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48063,16 +48046,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48086,16 +48069,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48109,16 +48092,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48132,16 +48115,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48155,16 +48138,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48178,16 +48161,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
-            "line": 10
+            "line": 8
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51997,31 +51980,20 @@
         "source": "nodes.py"
       },
       {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 8,
-        "optional": false,
-        "role": "ordinary",
-        "source": "nodes.py"
-      },
-      {
         "branch_context": [
           {
             "branch": "body",
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1626
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1627,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52033,14 +52005,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1634
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1635,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52052,14 +52024,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1644
+            "line": 1642
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1645,
+        "line": 1643,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53434,14 +53406,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1628
+            "line": 1626
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1629,
+        "line": 1627,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53453,14 +53425,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1636
+            "line": 1634
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1637,
+        "line": 1635,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53472,14 +53444,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1644
+            "line": 1642
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1645,
+        "line": 1643,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54940,7 +54912,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1133,
+        "line": 1131,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54949,7 +54921,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1761,
+        "line": 1759,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54958,7 +54930,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1764,
+        "line": 1762,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54967,7 +54939,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1767,
+        "line": 1765,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54976,7 +54948,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1770,
+        "line": 1768,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54985,7 +54957,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1773,
+        "line": 1771,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54994,7 +54966,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1776,
+        "line": 1774,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55003,7 +54975,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1779,
+        "line": 1777,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55012,7 +54984,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1782,
+        "line": 1780,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55021,7 +54993,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1785,
+        "line": 1783,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55030,7 +55002,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1788,
+        "line": 1786,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55039,7 +55011,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1791,
+        "line": 1789,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55048,7 +55020,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1794,
+        "line": 1792,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55057,7 +55029,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1797,
+        "line": 1795,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55066,7 +55038,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1800,
+        "line": 1798,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55075,7 +55047,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1803,
+        "line": 1801,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55084,7 +55056,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1806,
+        "line": 1804,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55093,7 +55065,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1810,
+        "line": 1808,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55102,7 +55074,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1813,
+        "line": 1811,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55111,7 +55083,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1817,
+        "line": 1815,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55120,7 +55092,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1820,
+        "line": 1818,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55129,7 +55101,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1824,
+        "line": 1822,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55138,7 +55110,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1827,
+        "line": 1825,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55147,7 +55119,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1830,
+        "line": 1828,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55156,7 +55128,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1833,
+        "line": 1831,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55165,7 +55137,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1836,
+        "line": 1834,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55174,7 +55146,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1839,
+        "line": 1837,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55183,7 +55155,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1846,
+        "line": 1844,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55192,7 +55164,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1852,
+        "line": 1850,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55201,7 +55173,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1857,
+        "line": 1855,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55210,7 +55182,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1861,
+        "line": 1859,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55724,13 +55696,13 @@
       },
       {
         "kind": "dict",
-        "line": 1195,
+        "line": 1193,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1184,
+        "line": 1182,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "snapshot": {
     "base_branch": "dev",
-    "base_commit": "4358ee3f5542a1d925846b726fdc84d102512bc6",
+    "base_commit": "eb0843d3e8c26c326e34e5c77dd1eb302b4a9933",
     "first_release": null,
     "owner_tasks": [
       "#184",
@@ -57,7 +57,8 @@
       "B-11c24",
       "B-11c25",
       "B-11c26",
-      "B-11c27"
+      "B-11c27",
+      "B-11c28"
     ]
   },
   "enums": {
@@ -92,11 +93,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 6,
-    "nodes_canonical_bindings": 299,
+    "nodes_canonical_bindings": 300,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 9,
+    "root_residual_functions": 8,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -659,6 +660,9 @@
     ],
     "_comfy_vae_names": [
       "easyuse_anima.nodes.aio_nodes"
+    ],
+    "_common_upscale_image": [
+      "easyuse_anima.aio.postprocess"
     ],
     "_conditioning_set_values": [
       "easyuse_anima.nodes.regional_nodes"
@@ -2272,6 +2276,7 @@
         "_aio_final_fit_size": "_aio_final_fit_size",
         "_apply_aio_final_fit": "_apply_aio_final_fit",
         "_bind_aio_postprocess_runtime": "_bind_aio_postprocess_runtime",
+        "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed",
         "_run_aio_postprocess_stage": "_run_aio_postprocess_stage"
       },
       "classification": "transitional_private_seam",
@@ -2607,14 +2612,12 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.postprocess",
         "canonical runtime resolver: easyuse_anima.aio.preview",
         "canonical runtime resolver: easyuse_anima.aio.usdu"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.postprocess string runtime lookup",
         "AST:easyuse_anima.aio.preview string runtime lookup",
@@ -2752,6 +2755,7 @@
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.model_preparation",
+        "canonical runtime resolver: easyuse_anima.aio.postprocess",
         "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling"
       ],
@@ -2759,6 +2763,7 @@
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.model_preparation string runtime lookup",
+        "AST:easyuse_anima.aio.postprocess string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup"
       ],
@@ -4228,8 +4233,7 @@
         "_find_comfy_node_mapping_class": "_find_comfy_node_mapping_class",
         "_find_loaded_node_class": "_find_loaded_node_class",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
-        "_require_custom_node_class": "_require_custom_node_class",
-        "_resize_image_to_size_if_needed": "_resize_image_to_size_if_needed"
+        "_require_custom_node_class": "_require_custom_node_class"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -92,7 +92,7 @@
   },
   "expected_counts": {
     "root_entrypoints": 3,
-    "excluded_preamble_implementation_bindings": 6,
+    "excluded_preamble_implementation_bindings": 5,
     "nodes_canonical_bindings": 300,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
@@ -128,7 +128,6 @@
     "EasyUseAnimaSAM3Detailer"
   ],
   "excluded_preamble_implementation_bindings": {
-    "Any": "typing:Any",
     "ceil": "math:ceil",
     "json": "json:json",
     "logging": "logging:logging",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -1071,8 +1071,96 @@ class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
         "_apply_aio_final_fit",
         "_aio_final_fit_size",
         "_bind_aio_postprocess_runtime",
+        "_resize_image_to_size_if_needed",
         "_run_aio_postprocess_stage",
     )
+
+    def _assert_resize_contract(self, root_module, canonical_module):
+        events = []
+
+        class Dimension:
+            def __init__(self, name, value):
+                self.name = name
+                self.value = value
+
+            def __int__(self):
+                events.append(("int", self.name))
+                return self.value
+
+        class Tensor:
+            def __init__(self, name):
+                self.name = name
+
+            def movedim(self, source, target):
+                events.append((f"{self.name}.movedim", (source, target)))
+                return samples if self is image else output
+
+        image = Tensor("image")
+        samples = Tensor("samples")
+        resized = Tensor("resized")
+        output = object()
+
+        def resolver(name):
+            events.append(("resolve", name))
+            return getattr(root_module, name)
+
+        def image_size(value, width, height):
+            events.append(("image_tensor_size", (value, width, height)))
+            return 320, 240
+
+        def upscale(value, width, height, method):
+            events.append(("common_upscale_image", (value, width, height, method)))
+            return resized
+
+        with (
+            patch.object(root_module, "_image_tensor_size", image_size),
+            patch.object(root_module, "_common_upscale_image", upscale),
+        ):
+            canonical_module._bind_aio_postprocess_runtime(resolve_helper=resolver)
+            try:
+                result = canonical_module._resize_image_to_size_if_needed(
+                    image,
+                    Dimension("width", 640),
+                    Dimension("height", 480),
+                    "",
+                )
+            finally:
+                canonical_module._bind_aio_postprocess_runtime(
+                    resolve_helper=lambda name: getattr(root_module, name)
+                )
+
+        self.assertEqual(result, (output, True))
+        self.assertEqual(
+            events,
+            [
+                ("int", "width"),
+                ("int", "height"),
+                ("resolve", "_image_tensor_size"),
+                ("image_tensor_size", (image, 640, 480)),
+                ("image.movedim", (-1, 1)),
+                ("resolve", "_common_upscale_image"),
+                ("common_upscale_image", (samples, 640, 480, "bicubic")),
+                ("resized.movedim", (1, -1)),
+            ],
+        )
+
+        with (
+            patch.object(root_module, "_image_tensor_size", return_value=(1, 1)),
+            patch.object(root_module, "_common_upscale_image") as common_upscale,
+        ):
+            result = canonical_module._resize_image_to_size_if_needed(image, 0, -5)
+        self.assertIs(result[0], image)
+        self.assertFalse(result[1])
+        common_upscale.assert_not_called()
+
+        failure = RuntimeError("resize failed")
+        with (
+            patch.object(root_module, "_image_tensor_size", return_value=(320, 240)),
+            patch.object(root_module, "_common_upscale_image", side_effect=failure),
+            self.assertRaises(RuntimeError) as raised,
+        ):
+            canonical_module._resize_image_to_size_if_needed(image, 640, 480)
+        self.assertIs(raised.exception, failure)
 
     def _assert_stage_contract(self, root_module, canonical_module):
         image = object()
@@ -1227,6 +1315,8 @@ class AioFinalFitPlanningMoveContractTests(unittest.TestCase):
         for name in self.MOVED_NAMES:
             with self.subTest(name=name):
                 self.assertIs(getattr(root_module, name), getattr(canonical_module, name))
+
+        self._assert_resize_contract(root_module, canonical_module)
 
         disabled = {"enabled": False, "mode": "megapixels"}
         with (

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "10cb7e31fd9f8a4f85ecd65515881ae3ecafd3c3")
+        self.assertEqual(report["git_blob_sha1"], "ddc55db1b1676a9aacd858dd36596ff2cd11f897")
         # Issue #184 B-11c28 moves only the shared AiO image resize helper to
         # its canonical postprocess owner.
         self.assertEqual(report["top_level"]["function_count"], 8)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_863)
+        self.assertEqual(report["line_count"], 1_864)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "b27d8812d05c331d09c92ff66d75de8293720a94")
+        self.assertEqual(report["git_blob_sha1"], "10cb7e31fd9f8a4f85ecd65515881ae3ecafd3c3")
         # Issue #184 B-11c28 moves only the shared AiO image resize helper to
         # its canonical postprocess owner.
         self.assertEqual(report["top_level"]["function_count"], 8)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_865)
+        self.assertEqual(report["line_count"], 1_863)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "6de84ba721ad593af4b2d34634976822eb7358d1")
-        # Issue #184 B-11c27 moves only the AiO USDU upscale leaf to its
-        # canonical legacy-generation owner.
-        self.assertEqual(report["top_level"]["function_count"], 9)
+        self.assertEqual(report["git_blob_sha1"], "b27d8812d05c331d09c92ff66d75de8293720a94")
+        # Issue #184 B-11c28 moves only the shared AiO image resize helper to
+        # its canonical postprocess owner.
+        self.assertEqual(report["top_level"]["function_count"], 8)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_879)
+        self.assertEqual(report["line_count"], 1_865)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -48,7 +48,6 @@ RUNTIME_LOOKUP_CALLS = {
     "runtime_proxy",
 }
 PREAMBLE_IMPLEMENTATION_BINDINGS = {
-    "Any": "typing:Any",
     "ceil": "math:ceil",
     "json": "json:json",
     "logging": "logging:logging",
@@ -1342,7 +1341,7 @@ def _build_document() -> dict[str, Any]:
         },
         "expected_counts": {
             "root_entrypoints": 3,
-            "excluded_preamble_implementation_bindings": 6,
+            "excluded_preamble_implementation_bindings": 5,
             "nodes_canonical_bindings": 300,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -16,7 +16,7 @@ NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
 
 SCHEMA_VERSION = 1
-BASE_COMMIT = "4358ee3f5542a1d925846b726fdc84d102512bc6"
+BASE_COMMIT = "eb0843d3e8c26c326e34e5c77dd1eb302b4a9933"
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -1330,6 +1330,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c25",
                 "B-11c26",
                 "B-11c27",
+                "B-11c28",
             ],
         },
         "enums": {
@@ -1342,11 +1343,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 6,
-            "nodes_canonical_bindings": 299,
+            "nodes_canonical_bindings": 300,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 9,
+            "root_residual_functions": 8,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,


### PR DESCRIPTION
## 변경 요약

- B-11c28 단일 Move로 root `_resize_image_to_size_if_needed` 구현만 기존 `easyuse_anima.aio.postprocess` 소유자로 이동합니다.
- resize 정책, Comfy upscale adapter, AiO stage, schema/default/workflow 동작은 변경하지 않고 root에는 relative/flat direct identity alias를 유지합니다.
- 이동 뒤 더 이상 쓰이지 않는 root `typing.Any` preamble import를 함께 제거해 G-01 Ruff 진단 수를 기존 113건으로 유지합니다.

## 작업 전 inventory

### Symbol / caller

- `_resize_image_to_size_if_needed`
  - 현재 surface: `nodes.py` private root definition
  - production caller: `easyuse_anima.aio.postprocess._apply_aio_final_fit`와 `easyuse_anima.aio.legacy_generation`의 highres/first-pass resize가 기존 runtime resolver로 root seam을 매 호출 조회
  - public mapping/`__all__` 없음
- canonical owner는 resize 결과와 final-fit 메타데이터를 이미 소유하는 `easyuse_anima.aio.postprocess`입니다. 새 module, binder, provider는 추가하지 않습니다.

### Alias / global-state seam

- 이동 후 relative/flat import 양쪽에서 root와 canonical helper identity를 유지합니다.
- 기존 `_bind_aio_postprocess_runtime`과 `_RUNTIME_RESOLVER`만 재사용합니다.
- helper는 mutable module state, cache, I/O, provider client를 소유하지 않습니다.
- 기존 legacy-generation caller는 계속 root name을 call-time resolve하므로 root monkeypatch 관찰성을 유지합니다.

### Call-time dependency inventory

- `_image_tensor_size`
- `_common_upscale_image`
- tensor의 `movedim`

### 보존할 평가·예외 순서

1. `target_width`를 `int` 변환하고 최소 1로 제한합니다.
2. `target_height`를 `int` 변환하고 최소 1로 제한합니다.
3. `_image_tensor_size(image, target_width, target_height)`를 call-time resolve·호출합니다.
4. 크기가 같으면 원본 image identity와 `False`를 반환하며 upscale helper를 조회하지 않습니다.
5. `image.movedim(-1, 1)`로 BHWC→BCHW 변환합니다.
6. `_common_upscale_image`를 call-time resolve하고 method는 `str(upscale_method or "bicubic")`로 평가합니다.
7. 결과를 `movedim(1, -1)`로 BCHW→BHWC 변환하고 `True`를 반환합니다.
8. 변환·tensor·upscale 예외는 wrapping/fallback 없이 그대로 전파합니다.

## Allowed-file boundary

- production: `easyuse_anima/aio/postprocess.py`, `nodes.py`
- contract/analyzer: `tests/test_node_contracts.py`, `tests/test_nodes_module_analyzer.py`, `tests/test_python_compatibility_surface.py`
- fixtures: `tests/fixtures/python_backend_baseline.json`, `tests/fixtures/python_compatibility_surface.v1.json`
- docs: `docs/architecture/python-backend-execution-roadmap.md`, `docs/architecture/python-compatibility-shims.md`
- `easyuse_anima/aio/legacy_generation.py`와 기존 AiO behavior tests는 실행만 하며 수정하지 않습니다.

## 예상 계약 delta

- base: `dev` / `eb0843d3e8c26c326e34e5c77dd1eb302b4a9933`
- canonical bindings: `299 → 300`
- root/top-level residual functions: `9 → 8`
- runtime binders: `30` 유지
- runtime resolver names: `290 → 291` (`_common_upscale_image` 추가)
- postprocess resolver consumers: `10 → 11`
- modules, globals, public mappings, legacy bindings: 변화 없음
- preamble implementation imports: `6 → 5` (`typing.Any` 제거)
- `nodes.py`: `1,879 → 1,864` lines

## 금지 경계

- resize math, clamp, method fallback, tensor layout, 반환 tuple/identity 변경 금지
- `_common_upscale_image`, `_image_tensor_size`, final-fit 또는 highres/stage 구현 동시 이동 금지
- helper cache, 예외 wrapping/fallback/retry, 새 provider/Protocol/RuntimeServices 도입 금지
- #167 seed reservation, #169 stage Contract/Behavior 변경 금지

## 검증

- exact head: `b1504950ab0059d62f399d84ea78aed148e23f95`
- focused alias/identity/no-op/movedim/dependency-order/error propagation, 기존 postprocess/highres, analyzer/import-boundary: 69 tests passed
- provenance 및 import-cleanup 후 targeted rerun: 12 tests, 36 tests passed
- canonical `easyuse_anima/aio/postprocess.py` Ruff: clean
- 독립 diff review: 오래된 compatibility base provenance 1건을 수정·재생성한 뒤 차단점 없음
- `tools/check_project.ps1 -Profile full` (exact worktree/head): Python unittest 932 passed, frontend 114 JavaScript files passed, TypeScript 6.0.3, Pyright baseline, import-boundary, `git diff --check` passed
- 전체 Ruff 113건은 기존 G-01 report-only 기준선이며 이번 Move로 증가하지 않음
- private stateless helper Move 범위이므로 live ComfyUI/browser smoke는 수행하지 않았습니다.

## 상태

- Ready
- Move-only boundary와 exact-head 검증을 충족했습니다.
