### PR TITLE
test: add E-01a Comfy host compatibility ledger

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -271,11 +271,39 @@ must explain how canonical code sees it without importing root `nodes.py`.
 Passing an explicit callable from the composition boundary is acceptable;
 canonical-to-root import is not.
 
+### 4.3 E-01a locked result
+
+The versioned decision ledger is
+`tests/fixtures/comfy_host_compatibility.v1.json`. The compatibility-surface
+test derives the current root signatures, adapter aliases, production
+resolver/binder consumers, root-observation timing, and repository monkeypatch
+consumers from the AST and rejects drift from the ledger.
+
+The reviewed decisions are:
+
+| Symbols | Durable classification | Root replacement decision |
+| --- | --- | --- |
+| `_comfy_max_resolution`, `_find_comfy_node_class`, `_find_comfy_node_mapping_class`, `_find_loaded_node_class` | `provider_owned` | private repository-test seam; migrate to fake provider/injection in E-07b |
+| `_require_custom_node_class`, `_require_any_custom_node_class`, `_encode_with_comfy_clip` | `pure_helper_with_provider_input` | private repository-test seam; migrate to fake provider/injection in E-07b |
+
+The GitHub public code-index search recorded in the ledger found no confirmed
+consumer outside this repository. That search is explicitly non-exhaustive;
+it does not convert absence of public hits into proof about private or
+unindexed source. Repository tests alone do not promote the seven underscore
+names to supported public API.
+
+All 22 production consumer slots currently observe `nodes.py` globals at call
+time. Some call the stored resolver directly and others bind a closure, but the
+closure still executes `resolve_helper(name)` for every invocation. This is
+inventory evidence, not a decision to preserve private root monkeypatching as
+public compatibility. E-07b must migrate the listed repository tests before
+#184 retires the corresponding root implementation.
+
 ## 5. Executable work units
 
 ### E-01a — Scoped host-wrapper inventory
 
-- **State:** READY
+- **State:** IN REVIEW in PR #325
 - **Owner:** #323 / parent #187
 - **Type:** Contract/docs/gate
 - **Base:** current `dev`
@@ -320,34 +348,29 @@ Exit:
 - **Owner:** #323 / parent #187
 - **Type:** Contract
 
-Candidate production files:
+Allowed production files:
 
 ```text
+easyuse_anima/infrastructure/comfy/provider.py
 easyuse_anima/runtime.py
-easyuse_anima/bootstrap.py
 ```
 
 Required contract:
 
+- declare only the four-method `ComfyHostProvider` Protocol needed to type the
+  runtime shell;
 - create a `RuntimeServices` value with only the ready `comfy` dependency;
 - define production install/access semantics;
 - reject or explicitly handle conflicting installation;
 - support isolated construction in tests;
 - keep `get_runtime()` out of feature/domain/service modules;
-- avoid changing route/Wildcard bootstrap behavior; and
+- do not wire bootstrap or implement host lookup; and
 - avoid adding shutdown responsibilities for resources that do not yet exist.
 
-Recommended tests:
+Allowed test file:
 
 ```text
-uninstalled access
-single install and identity
-same-runtime repeated install
-conflicting install
-adapter-boundary access
-isolated explicit runtime construction
-bootstrap repeat behavior
-package import without ComfyUI
+tests/test_runtime_services.py
 ```
 
 Stop if a viable implementation requires a full service graph, broad global
@@ -359,28 +382,22 @@ mutation, or feature code importing runtime.
 - **Owner:** #323 / parent #187
 - **Type:** Contract
 
-Candidate production files:
+Allowed production files:
 
 ```text
+easyuse_anima/bootstrap.py
 easyuse_anima/infrastructure/comfy/provider.py
-easyuse_anima/infrastructure/comfy/capabilities.py
-easyuse_anima/infrastructure/comfy/invocation.py
 ```
 
-Required tests:
+Allowed test files:
 
 ```text
-provider module import with host absent
-delayed host availability
-direct NODE_CLASS_MAPPINGS hit
-host attribute fallback
-loaded-module mapping fallback
-missing node
-valid, invalid, and missing MAX_RESOLUTION
-single/any required-node error text parity
-CLIPTextEncode success, missing class, missing encode, empty result
-no cache or import-time side effect
+tests/test_comfy_host_provider.py
+tests/test_runtime_services.py
 ```
+
+E-07a implements the default lazy provider and composes it at bootstrap.
+Requirement-helper and CLIP-invocation wiring remain E-07b work.
 
 Stop if the provider starts owning feature schemas, node instances, stage
 policy, or cache behavior.

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -1,0 +1,617 @@
+{
+  "schema_version": 1,
+  "owner": "#323",
+  "parent": "#187",
+  "blocked_move_owner": "#184",
+  "snapshot_base": "4f80cc06cd3bb58f5273bff87d1d9c5978a017fa",
+  "enums": {
+    "compatibility_classifications": [
+      "provider_owned",
+      "pure_helper_with_provider_input",
+      "transitional_root_override",
+      "unsupported_test_only",
+      "supported_public"
+    ]
+  },
+  "expected_counts": {
+    "production_consumer_slots": 22,
+    "unique_production_modules": 15,
+    "root_monkeypatch_test_files": 13,
+    "canonical_monkeypatch_test_files": 2
+  },
+  "external_evidence": {
+    "github_public_code_search_2026_07_23": {
+      "query_symbols": [
+        "_comfy_max_resolution",
+        "_encode_with_comfy_clip",
+        "_find_comfy_node_class",
+        "_find_comfy_node_mapping_class",
+        "_find_loaded_node_class",
+        "_require_any_custom_node_class",
+        "_require_custom_node_class"
+      ],
+      "max_results_per_symbol": 100,
+      "confirmed_external_repositories": [],
+      "exhaustive": false,
+      "limitations": "GitHub public code search does not cover private or unindexed source; repository-only hits are not external support evidence."
+    }
+  },
+  "symbols": [
+    {
+      "symbol": "_comfy_max_resolution",
+      "root_signature": {
+        "parameters": [],
+        "return": "int"
+      },
+      "adapter_binding": {
+        "alias": "_adapter_comfy_max_resolution",
+        "target": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution"
+      },
+      "root_dependencies": [
+        "_adapter_comfy_max_resolution"
+      ],
+      "canonical_target": "ComfyHostProvider.max_resolution",
+      "production_consumers": [
+        {
+          "module": "easyuse_anima.aio.generation_normalization",
+          "binder": "_bind_aio_generation_normalization_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.nodes.impact_detailer_nodes",
+          "binder": "_bind_impact_detailer_node_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.nodes.sam3_nodes",
+          "binder": "_bind_sam3_node_runtime",
+          "root_observation": "call_time"
+        }
+      ],
+      "repository_monkeypatch_consumers": {
+        "root": [
+          "tests/test_aio_schema_contract.py"
+        ],
+        "canonical": [
+          "tests/test_node_contracts.py",
+          "tests/test_sam3_nodes.py"
+        ]
+      },
+      "confirmed_external_consumers": [],
+      "external_evidence_ref": "github_public_code_search_2026_07_23",
+      "host_lookup_order": [
+        "import host nodes at call time",
+        "read MAX_RESOLUTION or use 16384",
+        "convert to int",
+        "return 16384 after any import, attribute, or conversion failure"
+      ],
+      "error_result_contract": [
+        "returns an int",
+        "missing or invalid host value returns 16384",
+        "host discovery failures do not escape"
+      ],
+      "optional_dependency_behavior": [
+        "ComfyUI nodes is optional until invocation",
+        "module import does not require a host module"
+      ],
+      "compatibility_classification": "provider_owned",
+      "root_seam_classification": "unsupported_test_only",
+      "call_time_replacement_required": false,
+      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "root_removal_gate": "E-07b provider parity and repository root-patch migration, then #184 B-11c29a",
+      "owner_issue": "#323",
+      "move_owner": "#184 B-11c29a"
+    },
+    {
+      "symbol": "_encode_with_comfy_clip",
+      "root_signature": {
+        "parameters": [
+          {
+            "name": "clip",
+            "kind": "positional_or_keyword",
+            "annotation": null,
+            "default": null
+          },
+          {
+            "name": "text",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          }
+        ],
+        "return": null
+      },
+      "adapter_binding": {
+        "alias": "_adapter_encode_with_comfy_clip",
+        "target": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip"
+      },
+      "root_dependencies": [
+        "_adapter_encode_with_comfy_clip",
+        "_find_comfy_node_class"
+      ],
+      "canonical_target": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
+      "production_consumers": [
+        {
+          "module": "easyuse_anima.aio.conditioning",
+          "binder": "_bind_aio_conditioning_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.legacy_generation",
+          "binder": "_bind_aio_legacy_generation_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.nodes.prompt_data_nodes",
+          "binder": "_bind_prompt_data_node_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.nodes.regional_nodes",
+          "binder": "_bind_regional_node_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.nodes.sam3_nodes",
+          "binder": "_bind_sam3_node_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.prompt.artist_mix",
+          "binder": "_bind_artist_mix_runtime",
+          "root_observation": "call_time"
+        }
+      ],
+      "repository_monkeypatch_consumers": {
+        "root": [
+          "tests/test_aio_conditioning.py",
+          "tests/test_aio_nodes.py",
+          "tests/test_prompt_corrector.py",
+          "tests/test_prompt_studio_regional.py",
+          "tests/test_sam3_nodes.py"
+        ],
+        "canonical": []
+      },
+      "confirmed_external_consumers": [],
+      "external_evidence_ref": "github_public_code_search_2026_07_23",
+      "host_lookup_order": [
+        "resolve CLIPTextEncode with the injected node lookup",
+        "construct the node class",
+        "read encode",
+        "call encode(clip, text)",
+        "return the first item from a non-empty tuple"
+      ],
+      "error_result_contract": [
+        "missing CLIPTextEncode raises the existing RuntimeError",
+        "missing encode raises the existing RuntimeError",
+        "non-tuple or empty result raises the existing RuntimeError",
+        "successful invocation returns result[0]"
+      ],
+      "optional_dependency_behavior": [
+        "CLIPTextEncode is required only when encoding is selected",
+        "the invocation adapter imports no optional node pack"
+      ],
+      "compatibility_classification": "pure_helper_with_provider_input",
+      "root_seam_classification": "unsupported_test_only",
+      "call_time_replacement_required": false,
+      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "root_removal_gate": "E-07b injected provider lookup parity and repository root-patch migration, then #184 B-11c29d",
+      "owner_issue": "#323",
+      "move_owner": "#184 B-11c29d"
+    },
+    {
+      "symbol": "_find_comfy_node_class",
+      "root_signature": {
+        "parameters": [
+          {
+            "name": "node_id",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          }
+        ],
+        "return": null
+      },
+      "adapter_binding": {
+        "alias": "_adapter_find_comfy_node_class",
+        "target": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class"
+      },
+      "root_dependencies": [
+        "_adapter_find_comfy_node_class"
+      ],
+      "canonical_target": "ComfyHostProvider.find_node_class",
+      "production_consumers": [
+        {
+          "module": "easyuse_anima.aio.model_preparation",
+          "binder": "_bind_aio_model_preparation_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.output",
+          "binder": "_bind_aio_output_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.preview",
+          "binder": "_bind_aio_preview_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.resources",
+          "binder": "_bind_aio_resource_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.sampling",
+          "binder": "_bind_aio_sampling_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.image.sam3",
+          "binder": "_bind_sam3_runtime",
+          "root_observation": "call_time"
+        }
+      ],
+      "repository_monkeypatch_consumers": {
+        "root": [
+          "tests/test_aio_model_preparation.py",
+          "tests/test_aio_nodes.py",
+          "tests/test_aio_output.py",
+          "tests/test_aio_preview.py",
+          "tests/test_aio_resources.py",
+          "tests/test_aio_sampling.py",
+          "tests/test_comfy_adapters.py",
+          "tests/test_node_contracts.py",
+          "tests/test_prompt_corrector.py",
+          "tests/test_sam3_nodes.py"
+        ],
+        "canonical": []
+      },
+      "confirmed_external_consumers": [],
+      "external_evidence_ref": "github_public_code_search_2026_07_23",
+      "host_lookup_order": [
+        "import host nodes at call time",
+        "check NODE_CLASS_MAPPINGS[node_id]",
+        "check host nodes attribute named node_id",
+        "scan loaded modules in current sys.modules order for NODE_CLASS_MAPPINGS[node_id]",
+        "return None"
+      ],
+      "error_result_contract": [
+        "host mapping and attribute exceptions fall through to loaded-module scan",
+        "returns the first non-None class",
+        "missing class returns None"
+      ],
+      "optional_dependency_behavior": [
+        "ComfyUI nodes is optional until lookup",
+        "loaded optional custom-node modules are discovered without importing them"
+      ],
+      "compatibility_classification": "provider_owned",
+      "root_seam_classification": "unsupported_test_only",
+      "call_time_replacement_required": false,
+      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "root_removal_gate": "E-07b fake-provider migration and lookup-order parity, then #184 B-11c29b",
+      "owner_issue": "#323",
+      "move_owner": "#184 B-11c29b"
+    },
+    {
+      "symbol": "_find_comfy_node_mapping_class",
+      "root_signature": {
+        "parameters": [
+          {
+            "name": "node_id",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          }
+        ],
+        "return": null
+      },
+      "adapter_binding": null,
+      "root_dependencies": [],
+      "canonical_target": "ComfyHostProvider.find_node_mapping_class",
+      "production_consumers": [
+        {
+          "module": "easyuse_anima.image.sam3",
+          "binder": "_bind_sam3_runtime",
+          "root_observation": "call_time"
+        }
+      ],
+      "repository_monkeypatch_consumers": {
+        "root": [
+          "tests/test_sam3_nodes.py"
+        ],
+        "canonical": []
+      },
+      "confirmed_external_consumers": [],
+      "external_evidence_ref": "github_public_code_search_2026_07_23",
+      "host_lookup_order": [
+        "import host nodes at call time",
+        "read NODE_CLASS_MAPPINGS or an empty mapping",
+        "return mapping.get(node_id)"
+      ],
+      "error_result_contract": [
+        "any import, attribute, or mapping failure returns None",
+        "host attributes and loaded modules are not scanned by this direct-mapping helper"
+      ],
+      "optional_dependency_behavior": [
+        "ComfyUI nodes is optional until lookup",
+        "no optional custom-node module is imported"
+      ],
+      "compatibility_classification": "provider_owned",
+      "root_seam_classification": "unsupported_test_only",
+      "call_time_replacement_required": false,
+      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "root_removal_gate": "E-07b direct-mapping parity and SAM3 test injection, then #184 B-11c29b",
+      "owner_issue": "#323",
+      "move_owner": "#184 B-11c29b"
+    },
+    {
+      "symbol": "_find_loaded_node_class",
+      "root_signature": {
+        "parameters": [
+          {
+            "name": "node_id",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          }
+        ],
+        "return": null
+      },
+      "adapter_binding": {
+        "alias": "_adapter_find_loaded_node_class",
+        "target": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class"
+      },
+      "root_dependencies": [
+        "_adapter_find_loaded_node_class",
+        "_find_comfy_node_class"
+      ],
+      "canonical_target": "ComfyHostProvider.find_loaded_node_class",
+      "production_consumers": [
+        {
+          "module": "easyuse_anima.prompt.conditioning",
+          "binder": "_bind_conditioning_runtime",
+          "root_observation": "call_time"
+        }
+      ],
+      "repository_monkeypatch_consumers": {
+        "root": [],
+        "canonical": []
+      },
+      "confirmed_external_consumers": [],
+      "external_evidence_ref": "github_public_code_search_2026_07_23",
+      "host_lookup_order": [
+        "call the injected general node lookup",
+        "return its non-None result",
+        "scan loaded modules in current sys.modules order for NODE_CLASS_MAPPINGS[node_id]",
+        "return None"
+      ],
+      "error_result_contract": [
+        "returns the first non-None class",
+        "missing class returns None"
+      ],
+      "optional_dependency_behavior": [
+        "already loaded optional custom-node modules are observed",
+        "no optional custom-node module is imported"
+      ],
+      "compatibility_classification": "provider_owned",
+      "root_seam_classification": "unsupported_test_only",
+      "call_time_replacement_required": false,
+      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "root_removal_gate": "E-07b provider parity with no new root-patch dependency, then #184 B-11c29b",
+      "owner_issue": "#323",
+      "move_owner": "#184 B-11c29b"
+    },
+    {
+      "symbol": "_require_any_custom_node_class",
+      "root_signature": {
+        "parameters": [
+          {
+            "name": "node_ids",
+            "kind": "positional_or_keyword",
+            "annotation": "tuple[str, ...]",
+            "default": null
+          },
+          {
+            "name": "node_pack",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          },
+          {
+            "name": "install_hint",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          }
+        ],
+        "return": null
+      },
+      "adapter_binding": {
+        "alias": "_adapter_require_any_custom_node_class",
+        "target": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class"
+      },
+      "root_dependencies": [
+        "_adapter_require_any_custom_node_class",
+        "_find_comfy_node_class"
+      ],
+      "canonical_target": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
+      "production_consumers": [
+        {
+          "module": "easyuse_anima.aio.model_preparation",
+          "binder": "_bind_aio_model_preparation_runtime",
+          "root_observation": "call_time"
+        }
+      ],
+      "repository_monkeypatch_consumers": {
+        "root": [
+          "tests/test_aio_model_preparation.py"
+        ],
+        "canonical": []
+      },
+      "confirmed_external_consumers": [],
+      "external_evidence_ref": "github_public_code_search_2026_07_23",
+      "host_lookup_order": [
+        "iterate node_ids in caller order",
+        "call the injected node lookup for each candidate",
+        "return the first (node_id, class) pair",
+        "raise after all candidates are missing"
+      ],
+      "error_result_contract": [
+        "candidate order is stable",
+        "missing candidates use the existing joined RuntimeError text",
+        "successful lookup returns the matching node id and class"
+      ],
+      "optional_dependency_behavior": [
+        "candidate custom-node packs remain optional until the feature is selected",
+        "missing selected capability raises only at use time"
+      ],
+      "compatibility_classification": "pure_helper_with_provider_input",
+      "root_seam_classification": "unsupported_test_only",
+      "call_time_replacement_required": false,
+      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "root_removal_gate": "E-07b injected lookup and exact error parity, then #184 B-11c29c",
+      "owner_issue": "#323",
+      "move_owner": "#184 B-11c29c"
+    },
+    {
+      "symbol": "_require_custom_node_class",
+      "root_signature": {
+        "parameters": [
+          {
+            "name": "node_id",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          },
+          {
+            "name": "node_pack",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          },
+          {
+            "name": "install_hint",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "default": null
+          }
+        ],
+        "return": null
+      },
+      "adapter_binding": {
+        "alias": "_adapter_require_custom_node_class",
+        "target": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class"
+      },
+      "root_dependencies": [
+        "_adapter_require_custom_node_class",
+        "_find_comfy_node_class"
+      ],
+      "canonical_target": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
+      "production_consumers": [
+        {
+          "module": "easyuse_anima.aio.legacy_generation",
+          "binder": "_bind_aio_legacy_generation_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.model_preparation",
+          "binder": "_bind_aio_model_preparation_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.output",
+          "binder": "_bind_aio_output_runtime",
+          "root_observation": "call_time"
+        },
+        {
+          "module": "easyuse_anima.aio.sampling",
+          "binder": "_bind_aio_sampling_runtime",
+          "root_observation": "call_time"
+        }
+      ],
+      "repository_monkeypatch_consumers": {
+        "root": [
+          "tests/test_aio_model_preparation.py",
+          "tests/test_aio_nodes.py",
+          "tests/test_aio_output.py",
+          "tests/test_aio_sampling.py"
+        ],
+        "canonical": []
+      },
+      "confirmed_external_consumers": [],
+      "external_evidence_ref": "github_public_code_search_2026_07_23",
+      "host_lookup_order": [
+        "call the injected node lookup once",
+        "return the non-None class",
+        "raise with node id, node pack, and install hint"
+      ],
+      "error_result_contract": [
+        "successful lookup returns the class object unchanged",
+        "missing class uses the existing exact RuntimeError text"
+      ],
+      "optional_dependency_behavior": [
+        "the custom-node pack remains optional until the feature is selected",
+        "missing selected capability raises only at use time"
+      ],
+      "compatibility_classification": "pure_helper_with_provider_input",
+      "root_seam_classification": "unsupported_test_only",
+      "call_time_replacement_required": false,
+      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "root_removal_gate": "E-07b injected lookup and exact error parity, then #184 B-11c29c",
+      "owner_issue": "#323",
+      "move_owner": "#184 B-11c29c"
+    }
+  ],
+  "next_contracts": {
+    "E-02a": {
+      "type": "Contract",
+      "production_files": [
+        "easyuse_anima/infrastructure/comfy/provider.py",
+        "easyuse_anima/runtime.py"
+      ],
+      "production_symbols": [
+        "ComfyHostProvider.max_resolution(self) -> int",
+        "ComfyHostProvider.find_node_class(self, node_id: str)",
+        "ComfyHostProvider.find_node_mapping_class(self, node_id: str)",
+        "ComfyHostProvider.find_loaded_node_class(self, node_id: str)",
+        "RuntimeServices(comfy: ComfyHostProvider)",
+        "install_runtime(runtime: RuntimeServices) -> RuntimeServices",
+        "get_runtime() -> RuntimeServices"
+      ],
+      "test_files": [
+        "tests/test_runtime_services.py"
+      ],
+      "forbidden": [
+        "default provider implementation",
+        "host lookup",
+        "bootstrap wiring",
+        "root or canonical caller changes",
+        "feature service placeholders"
+      ]
+    },
+    "E-07a": {
+      "type": "Contract",
+      "production_files": [
+        "easyuse_anima/bootstrap.py",
+        "easyuse_anima/infrastructure/comfy/provider.py"
+      ],
+      "production_symbols": [
+        "DefaultComfyHostProvider.max_resolution(self) -> int",
+        "DefaultComfyHostProvider.find_node_class(self, node_id: str)",
+        "DefaultComfyHostProvider.find_node_mapping_class(self, node_id: str)",
+        "DefaultComfyHostProvider.find_loaded_node_class(self, node_id: str)"
+      ],
+      "test_files": [
+        "tests/test_comfy_host_provider.py",
+        "tests/test_runtime_services.py"
+      ],
+      "forbidden": [
+        "capability or invocation helper wiring",
+        "root wrapper move or removal",
+        "lookup cache or snapshot",
+        "feature migration"
+      ]
+    }
+  }
+}

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -14,9 +14,30 @@ ENTRYPOINT_PATH = ROOT / "__init__.py"
 REGISTRATION_PATH = ROOT / "easyuse_anima" / "registration.py"
 NODES_PATH = ROOT / "nodes.py"
 FIXTURE_PATH = ROOT / "tests" / "fixtures" / "python_compatibility_surface.v1.json"
+COMFY_HOST_LEDGER_PATH = (
+    ROOT / "tests" / "fixtures" / "comfy_host_compatibility.v1.json"
+)
 
 SCHEMA_VERSION = 1
 BASE_COMMIT = "eb0843d3e8c26c326e34e5c77dd1eb302b4a9933"
+COMFY_HOST_LEDGER_SCHEMA_VERSION = 1
+COMFY_HOST_WRAPPERS = (
+    "_comfy_max_resolution",
+    "_encode_with_comfy_clip",
+    "_find_comfy_node_class",
+    "_find_comfy_node_mapping_class",
+    "_find_loaded_node_class",
+    "_require_any_custom_node_class",
+    "_require_custom_node_class",
+)
+COMFY_HOST_CLASSIFICATIONS = (
+    "provider_owned",
+    "pure_helper_with_provider_input",
+    "transitional_root_override",
+    "unsupported_test_only",
+    "supported_public",
+)
+COMFY_HOST_ROOT_TEST_ALIASES = {"easy_nodes", "nodes", "root_module"}
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -949,6 +970,264 @@ def _runtime_resolver_consumers(
     }
 
 
+def _function_signature(node: ast.FunctionDef) -> dict[str, Any]:
+    positional = [*node.args.posonlyargs, *node.args.args]
+    positional_defaults = [None] * (
+        len(positional) - len(node.args.defaults)
+    ) + list(node.args.defaults)
+    parameters = []
+    for argument, default in zip(positional, positional_defaults):
+        parameters.append(
+            {
+                "name": argument.arg,
+                "kind": (
+                    "positional_only"
+                    if argument in node.args.posonlyargs
+                    else "positional_or_keyword"
+                ),
+                "annotation": (
+                    ast.unparse(argument.annotation)
+                    if argument.annotation is not None
+                    else None
+                ),
+                "default": ast.unparse(default) if default is not None else None,
+            }
+        )
+    if node.args.vararg is not None:
+        parameters.append(
+            {
+                "name": node.args.vararg.arg,
+                "kind": "var_positional",
+                "annotation": (
+                    ast.unparse(node.args.vararg.annotation)
+                    if node.args.vararg.annotation is not None
+                    else None
+                ),
+                "default": None,
+            }
+        )
+    for argument, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+        parameters.append(
+            {
+                "name": argument.arg,
+                "kind": "keyword_only",
+                "annotation": (
+                    ast.unparse(argument.annotation)
+                    if argument.annotation is not None
+                    else None
+                ),
+                "default": ast.unparse(default) if default is not None else None,
+            }
+        )
+    if node.args.kwarg is not None:
+        parameters.append(
+            {
+                "name": node.args.kwarg.arg,
+                "kind": "var_keyword",
+                "annotation": (
+                    ast.unparse(node.args.kwarg.annotation)
+                    if node.args.kwarg.annotation is not None
+                    else None
+                ),
+                "default": None,
+            }
+        )
+    return {
+        "parameters": parameters,
+        "return": ast.unparse(node.returns) if node.returns is not None else None,
+    }
+
+
+def _comfy_host_root_inventory(
+    tree: ast.Module,
+    canonical_bindings: dict[str, str],
+    ledger: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    adapter_aliases = {
+        entry["symbol"]: entry["adapter_binding"]["alias"]
+        for entry in ledger["symbols"]
+        if entry["adapter_binding"] is not None
+    }
+    dependency_names = set(COMFY_HOST_WRAPPERS) | set(adapter_aliases.values())
+    inventory = {}
+    for symbol in COMFY_HOST_WRAPPERS:
+        definitions = [
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == symbol
+        ]
+        if len(definitions) != 1 or not isinstance(definitions[0], ast.FunctionDef):
+            raise AssertionError(
+                f"{symbol} must have exactly one synchronous root definition"
+            )
+        definition = definitions[0]
+        alias = adapter_aliases.get(symbol)
+        inventory[symbol] = {
+            "root_signature": _function_signature(definition),
+            "adapter_binding": (
+                {
+                    "alias": alias,
+                    "target": canonical_bindings.get(alias),
+                }
+                if alias is not None
+                else None
+            ),
+            "root_dependencies": sorted(
+                {
+                    node.id
+                    for node in ast.walk(definition)
+                    if isinstance(node, ast.Name)
+                    and isinstance(node.ctx, ast.Load)
+                    and node.id in dependency_names
+                }
+            ),
+        }
+    return inventory
+
+
+def _binder_observation_mode(module: str, binder_name: str) -> str:
+    tree = _read_tree(_module_path(module))
+    binders = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == binder_name
+    ]
+    if len(binders) != 1:
+        raise AssertionError(f"{module}:{binder_name} must have exactly one binder")
+    binder = binders[0]
+    for node in ast.walk(binder):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(
+            isinstance(target, ast.Name) and target.id == "_RUNTIME_RESOLVER"
+            for target in targets
+        ):
+            continue
+        if isinstance(node.value, ast.Name) and node.value.id == "resolve_helper":
+            return "call_time"
+
+    nested_functions = {
+        node.name: node
+        for node in ast.walk(binder)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node is not binder
+    }
+    returned_names = {
+        node.value.id
+        for node in ast.walk(binder)
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Name)
+    }
+    for name in returned_names:
+        nested = nested_functions.get(name)
+        if nested is None:
+            continue
+        if any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "resolve_helper"
+            for node in ast.walk(nested)
+        ):
+            return "call_time"
+    return "bind_time"
+
+
+def _comfy_host_runtime_consumers(
+    tree: ast.Module,
+    canonical_bindings: dict[str, str],
+) -> dict[str, list[dict[str, str]]]:
+    binder_targets = _runtime_binder_targets(tree, canonical_bindings)
+    target_binders = {module: binder for binder, module in binder_targets.items()}
+    resolver_consumers = _runtime_resolver_consumers(
+        tree,
+        canonical_bindings,
+        set(COMFY_HOST_WRAPPERS),
+    )
+    result = {}
+    for symbol in COMFY_HOST_WRAPPERS:
+        consumers = []
+        for module in resolver_consumers.get(symbol, []):
+            binder = target_binders.get(module)
+            if binder is None:
+                raise AssertionError(f"{symbol} consumer has no root binder: {module}")
+            consumers.append(
+                {
+                    "module": module,
+                    "binder": binder,
+                    "root_observation": _binder_observation_mode(module, binder),
+                }
+            )
+        result[symbol] = consumers
+    return result
+
+
+def _patch_call_target(node: ast.Call) -> tuple[str, str] | None:
+    if (
+        isinstance(node.func, ast.Name)
+        and node.func.id == "patch"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        target = node.args[0].value
+        symbol = target.rsplit(".", 1)[-1]
+        if target.startswith("nodes.") and symbol in COMFY_HOST_WRAPPERS:
+            return "root", symbol
+    if (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "object"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "patch"
+        and len(node.args) >= 2
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value in COMFY_HOST_WRAPPERS
+    ):
+        owner = ast.unparse(node.args[0])
+        scope = "root" if owner in COMFY_HOST_ROOT_TEST_ALIASES else "canonical"
+        return scope, node.args[1].value
+    return None
+
+
+def _comfy_host_monkeypatch_consumers() -> dict[str, dict[str, list[str]]]:
+    consumers = {
+        symbol: {"root": set(), "canonical": set()}
+        for symbol in COMFY_HOST_WRAPPERS
+    }
+    for path in sorted((ROOT / "tests").glob("test_*.py")):
+        tree = _read_tree(path)
+        relative = path.relative_to(ROOT).as_posix()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                target = _patch_call_target(node)
+                if target is not None:
+                    scope, symbol = target
+                    consumers[symbol][scope].add(relative)
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr in COMFY_HOST_WRAPPERS
+                ):
+                    owner = ast.unparse(target.value)
+                    scope = (
+                        "root"
+                        if owner in COMFY_HOST_ROOT_TEST_ALIASES
+                        else "canonical"
+                    )
+                    consumers[target.attr][scope].add(relative)
+    return {
+        symbol: {
+            scope: sorted(paths)
+            for scope, paths in classified.items()
+        }
+        for symbol, classified in consumers.items()
+    }
+
+
 def _root_residuals(tree: ast.Module) -> dict[str, list[str]]:
     functions = sorted(
         node.name
@@ -1635,6 +1914,231 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                     "test-only consumption is not public support evidence",
                     group["evidence"],
                 )
+
+
+class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.ledger = json.loads(
+            COMFY_HOST_LEDGER_PATH.read_text(encoding="utf-8")
+        )
+        cls.entries = {
+            entry["symbol"]: entry for entry in cls.ledger["symbols"]
+        }
+
+    def test_ledger_schema_covers_each_host_wrapper_once(self):
+        self.assertEqual(
+            self.ledger["schema_version"],
+            COMFY_HOST_LEDGER_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            self.ledger["enums"]["compatibility_classifications"],
+            list(COMFY_HOST_CLASSIFICATIONS),
+        )
+        symbols = [entry["symbol"] for entry in self.ledger["symbols"]]
+        self.assertEqual(symbols, list(COMFY_HOST_WRAPPERS))
+        self.assertEqual(len(symbols), len(set(symbols)))
+
+        required = {
+            "symbol",
+            "root_signature",
+            "adapter_binding",
+            "root_dependencies",
+            "canonical_target",
+            "production_consumers",
+            "repository_monkeypatch_consumers",
+            "confirmed_external_consumers",
+            "external_evidence_ref",
+            "host_lookup_order",
+            "error_result_contract",
+            "optional_dependency_behavior",
+            "compatibility_classification",
+            "root_seam_classification",
+            "call_time_replacement_required",
+            "replacement_mechanism",
+            "root_removal_gate",
+            "owner_issue",
+            "move_owner",
+        }
+        for entry in self.ledger["symbols"]:
+            self.assertTrue(required.issubset(entry), entry["symbol"])
+
+    def test_root_signatures_aliases_and_dependencies_are_exact(self):
+        tree = _read_tree(NODES_PATH)
+        import_try = _root_import_try(tree)
+        canonical, _legacy = _branch_bindings(
+            import_try.body,
+            expected_level=1,
+        )
+        actual = _comfy_host_root_inventory(tree, canonical, self.ledger)
+        expected = {
+            symbol: {
+                "root_signature": entry["root_signature"],
+                "adapter_binding": entry["adapter_binding"],
+                "root_dependencies": entry["root_dependencies"],
+            }
+            for symbol, entry in self.entries.items()
+        }
+        self.assertEqual(actual, expected)
+
+    def test_production_consumers_binders_and_observation_time_are_exact(self):
+        tree = _read_tree(NODES_PATH)
+        import_try = _root_import_try(tree)
+        canonical, _legacy = _branch_bindings(
+            import_try.body,
+            expected_level=1,
+        )
+        actual = _comfy_host_runtime_consumers(tree, canonical)
+        expected = {
+            symbol: entry["production_consumers"]
+            for symbol, entry in self.entries.items()
+        }
+        self.assertEqual(actual, expected)
+        self.assertEqual(
+            sum(len(consumers) for consumers in actual.values()),
+            self.ledger["expected_counts"]["production_consumer_slots"],
+        )
+        self.assertEqual(
+            len(
+                {
+                    consumer["module"]
+                    for consumers in actual.values()
+                    for consumer in consumers
+                }
+            ),
+            self.ledger["expected_counts"]["unique_production_modules"],
+        )
+
+    def test_repository_monkeypatch_consumers_are_exact_and_classified(self):
+        actual = _comfy_host_monkeypatch_consumers()
+        expected = {
+            symbol: entry["repository_monkeypatch_consumers"]
+            for symbol, entry in self.entries.items()
+        }
+        self.assertEqual(actual, expected)
+        root_files = {
+            path
+            for classified in actual.values()
+            for path in classified["root"]
+        }
+        canonical_files = {
+            path
+            for classified in actual.values()
+            for path in classified["canonical"]
+        }
+        self.assertEqual(
+            len(root_files),
+            self.ledger["expected_counts"]["root_monkeypatch_test_files"],
+        )
+        self.assertEqual(
+            len(canonical_files),
+            self.ledger["expected_counts"][
+                "canonical_monkeypatch_test_files"
+            ],
+        )
+
+    def test_support_and_removal_decisions_cannot_drift_silently(self):
+        provider_owned = {
+            "_comfy_max_resolution",
+            "_find_comfy_node_class",
+            "_find_comfy_node_mapping_class",
+            "_find_loaded_node_class",
+        }
+        pure_helpers = set(COMFY_HOST_WRAPPERS) - provider_owned
+        for symbol, entry in self.entries.items():
+            expected_classification = (
+                "provider_owned"
+                if symbol in provider_owned
+                else "pure_helper_with_provider_input"
+            )
+            self.assertEqual(
+                entry["compatibility_classification"],
+                expected_classification,
+            )
+            self.assertIn(
+                entry["compatibility_classification"],
+                COMFY_HOST_CLASSIFICATIONS,
+            )
+            self.assertEqual(
+                entry["root_seam_classification"],
+                "unsupported_test_only",
+            )
+            self.assertFalse(entry["call_time_replacement_required"])
+            self.assertEqual(entry["confirmed_external_consumers"], [])
+            self.assertEqual(
+                entry["external_evidence_ref"],
+                "github_public_code_search_2026_07_23",
+            )
+            self.assertEqual(
+                entry["replacement_mechanism"],
+                "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+            )
+            self.assertTrue(entry["root_removal_gate"])
+            self.assertTrue(entry["host_lookup_order"])
+            self.assertTrue(entry["error_result_contract"])
+            self.assertTrue(entry["optional_dependency_behavior"])
+            self.assertEqual(entry["owner_issue"], "#323")
+            self.assertTrue(entry["move_owner"].startswith("#184 B-11c29"))
+        self.assertEqual(
+            pure_helpers,
+            {
+                "_encode_with_comfy_clip",
+                "_require_any_custom_node_class",
+                "_require_custom_node_class",
+            },
+        )
+
+    def test_external_search_evidence_is_scoped_and_non_exhaustive(self):
+        evidence = self.ledger["external_evidence"][
+            "github_public_code_search_2026_07_23"
+        ]
+        self.assertEqual(evidence["query_symbols"], list(COMFY_HOST_WRAPPERS))
+        self.assertEqual(evidence["max_results_per_symbol"], 100)
+        self.assertEqual(evidence["confirmed_external_repositories"], [])
+        self.assertFalse(evidence["exhaustive"])
+        self.assertTrue(evidence["limitations"])
+
+    def test_next_contracts_have_exact_signatures_and_allowed_boundaries(self):
+        contracts = self.ledger["next_contracts"]
+        self.assertEqual(set(contracts), {"E-02a", "E-07a"})
+        self.assertEqual(
+            contracts["E-02a"]["production_files"],
+            [
+                "easyuse_anima/infrastructure/comfy/provider.py",
+                "easyuse_anima/runtime.py",
+            ],
+        )
+        self.assertEqual(
+            contracts["E-02a"]["production_symbols"],
+            [
+                "ComfyHostProvider.max_resolution(self) -> int",
+                "ComfyHostProvider.find_node_class(self, node_id: str)",
+                "ComfyHostProvider.find_node_mapping_class(self, node_id: str)",
+                "ComfyHostProvider.find_loaded_node_class(self, node_id: str)",
+                "RuntimeServices(comfy: ComfyHostProvider)",
+                "install_runtime(runtime: RuntimeServices) -> RuntimeServices",
+                "get_runtime() -> RuntimeServices",
+            ],
+        )
+        self.assertEqual(
+            contracts["E-07a"]["production_files"],
+            [
+                "easyuse_anima/bootstrap.py",
+                "easyuse_anima/infrastructure/comfy/provider.py",
+            ],
+        )
+        self.assertEqual(
+            contracts["E-07a"]["production_symbols"],
+            [
+                "DefaultComfyHostProvider.max_resolution(self) -> int",
+                "DefaultComfyHostProvider.find_node_class(self, node_id: str)",
+                "DefaultComfyHostProvider.find_node_mapping_class(self, node_id: str)",
+                "DefaultComfyHostProvider.find_loaded_node_class(self, node_id: str)",
+            ],
+        )
+        for contract in contracts.values():
+            self.assertTrue(contract["test_files"])
+            self.assertTrue(contract["forbidden"])
 
 
 def write_fixture() -> None:


### PR DESCRIPTION
## 목적

Issue #323의 E-01a만 수행합니다. 7개 Comfy host wrapper의 실제 caller/binder/monkeypatch/호환성 결정을 machine-readable ledger와 gate로 고정합니다.

- 기준: `dev@4f80cc06cd3bb58f5273bff87d1d9c5978a017fa`
- parent: #187
- blocked extraction: #184
- 유형: Contract/docs/gate
- production 변경: 없음

## 편집 전 inventory

Root binder 공통 경로는 `nodes.py`의 `resolve_helper=lambda name: globals()[name]`입니다. 캐시나 snapshot은 없으며, 22개 production consumer 슬롯 모두 resolver 또는 closure를 통해 root 교체를 호출 시점에 관찰합니다.

| symbol | 현재 root signature / alias | production caller + binder | root monkeypatch test consumer |
| --- | --- | --- | --- |
| `_comfy_max_resolution` | `() -> int`; `_adapter_comfy_max_resolution` | `aio.generation_normalization` / `_bind_aio_generation_normalization_runtime` (호출 중 resolve), `nodes.impact_detailer_nodes` / `_bind_impact_detailer_node_runtime` (call-time closure), `nodes.sam3_nodes` / `_bind_sam3_node_runtime` (call-time closure) | `test_aio_schema_contract.py`; canonical-module patch는 `test_node_contracts.py`, `test_sam3_nodes.py`로 별도 분류 |
| `_find_comfy_node_class` | `(node_id: str)`; `_adapter_find_comfy_node_class` | `aio.model_preparation`, `aio.output`, `aio.preview`, `aio.resources`, `aio.sampling`의 각 `_bind_*_runtime` (호출 중 resolve), `image.sam3` / `_bind_sam3_runtime` (call-time proxy) | `test_aio_model_preparation.py`, `test_aio_nodes.py`, `test_aio_output.py`, `test_aio_preview.py`, `test_aio_resources.py`, `test_aio_sampling.py`, `test_comfy_adapters.py`, `test_node_contracts.py`, `test_prompt_corrector.py`, `test_sam3_nodes.py` |
| `_find_comfy_node_mapping_class` | `(node_id: str)`; direct root implementation | `image.sam3` / `_bind_sam3_runtime` (call-time proxy) | `test_sam3_nodes.py` |
| `_require_custom_node_class` | `(node_id: str, node_pack: str, install_hint: str)`; `_adapter_require_custom_node_class` | `aio.legacy_generation`, `aio.model_preparation`, `aio.output`, `aio.sampling`의 각 `_bind_*_runtime` (호출 중 resolve) | `test_aio_model_preparation.py`, `test_aio_nodes.py`, `test_aio_output.py`, `test_aio_sampling.py`; resolver-map 주입은 `test_aio_legacy_generation.py`로 별도 분류 |
| `_require_any_custom_node_class` | `(node_ids: tuple[str, ...], node_pack: str, install_hint: str)`; `_adapter_require_any_custom_node_class` | `aio.model_preparation` / `_bind_aio_model_preparation_runtime` (호출 중 resolve) | `test_aio_model_preparation.py` |
| `_encode_with_comfy_clip` | `(clip, text: str)`; `_adapter_encode_with_comfy_clip` | `aio.conditioning`, `aio.legacy_generation` (호출 중 resolve), `nodes.prompt_data_nodes`, `prompt.artist_mix` (call-time proxy), `nodes.regional_nodes`, `nodes.sam3_nodes` (call-time closure) | `test_aio_conditioning.py`, `test_aio_nodes.py`, `test_prompt_corrector.py`, `test_prompt_studio_regional.py`, `test_sam3_nodes.py` |
| `_find_loaded_node_class` | `(node_id: str)`; `_adapter_find_loaded_node_class` | `prompt.conditioning` / `_bind_conditioning_runtime` (호출 중 resolve) | 없음 |

### alias / global-state 판정

- adapter alias가 있는 6개 심볼은 `easyuse_anima.infrastructure.comfy.capabilities` 또는 `invocation`에서 root로 import됩니다.
- `_find_comfy_node_mapping_class`만 root가 host `nodes.NODE_CLASS_MAPPINGS`를 직접 조회합니다.
- `_require_custom_node_class`, `_require_any_custom_node_class`, `_encode_with_comfy_clip`, `_find_loaded_node_class`는 root `_find_comfy_node_class`를 호출 시점에 다시 읽습니다.
- `_RUNTIME_RESOLVER` 직접 조회와 closure proxy가 혼재하지만 모두 매 호출마다 root `globals()[name]`을 다시 해석합니다. ledger가 이 관찰 시점을 consumer별로 고정합니다.
- provider cache, lookup snapshot, mutable override registry는 현재 없으며 이번 PR에서도 추가하지 않습니다.

### 외부 소비자 evidence

2026-07-23에 GitHub public code index에서 7개 exact symbol을 각각 최대 100건 검색했습니다. 이 저장소 밖의 확인된 hit는 0건입니다. 이는 비공개/미색인 코드를 포괄하지 않는 비완전 증거로 기록하며, public support 근거로 확대하지 않습니다.

### 호환성 결정

- durable owner: discovery 4개는 `provider_owned`; requirement/CLIP 3개는 `pure_helper_with_provider_input`.
- root underscore seam 7개는 모두 `unsupported_test_only`.
- 저장소 테스트는 E-07b에서 fake provider 또는 explicit lookup injection으로 이관합니다.
- 그때까지 root 구현은 유지하지만, 테스트 의존만으로 call-time root override를 영구 지원하지 않습니다.
- 각 심볼의 lookup/error/result 순서와 optional dependency 의미는 ledger에 별도 고정합니다.

## E-01a allowed boundary

- `tests/fixtures/*compatibility*`
- `tests/test_python_compatibility_surface.py`
- `docs/architecture/*`
- 필요할 때만 backend analyzer/import-boundary test/tool

금지: production 파일, wrapper Move, runtime/provider 구현, compatibility fixture 약화.

## 다음 Contract 경계

E-02a는 runtime shell이 실제 `comfy` 타입을 참조할 수 있도록 다음 파일만 허용합니다.

- `easyuse_anima/infrastructure/comfy/provider.py`: `ComfyHostProvider` Protocol 선언만
- `easyuse_anima/runtime.py`: frozen `RuntimeServices(comfy: ComfyHostProvider)`, `install_runtime`, `get_runtime`
- `tests/test_runtime_services.py`
- 관련 architecture 문서

E-02a에서는 default provider, host lookup, bootstrap wiring, root/canonical caller 변경을 금지합니다.

E-07a는 다음 파일만 허용합니다.

- `easyuse_anima/infrastructure/comfy/provider.py`: lazy `DefaultComfyHostProvider`
- `easyuse_anima/bootstrap.py`: default provider 조립/동일 runtime 재사용
- `tests/test_comfy_host_provider.py`, 필요한 runtime/bootstrap integration test
- 관련 architecture 문서

E-07a에서는 capability/invocation wiring, root wrapper 이동/제거, cache, feature migration을 금지합니다. E-07b가 ledger에 따라 wiring과 테스트 이관을 별도 소유합니다.

## 변경 파일

- `tests/fixtures/comfy_host_compatibility.v1.json`: 7개 심볼 decision ledger와 E-02a/E-07a manifest
- `tests/test_python_compatibility_surface.py`: signature/alias/caller/binder/observation/monkeypatch/support drift gate
- `docs/architecture/comfy-host-provider-bridge.md`: E-01a 결론과 다음 allowed boundary

## 검증

- focused: `python -X utf8 -m unittest tests.test_python_compatibility_surface -v` — 19/19 통과
- official full: `tools/check_custom_node.ps1 -Project <PR worktree> -Profile full` — 통과
  - Python unittest 939개 통과
  - frontend 114개 통과
  - Pyright baseline ratchet 통과
  - Python import-boundary gate 통과
  - `git diff --check` 통과
  - Ruff 113건은 기존 G-01 report-only이며 blocking failure 없음

Package/Registry/live smoke는 production·entrypoint 변경이 없으므로 수행하지 않았습니다.

## 남은 위험 / 미확인

- 공개 GitHub code index 검색은 private/unindexed source를 포괄하지 않습니다.
- E-07b가 저장소 root monkeypatch test를 fake provider/injection으로 옮기기 전까지 root 구현은 유지해야 합니다.

Refs #184
Refs #187
Refs #188
Refs #323