### PR TITLE
feat: add RuntimeServices and default Comfy host provider

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,9 +28,19 @@ from .easyuse_anima.registration import (
 )
 from .wildcard_engine import ensure_default_wildcard_root
 
+
+def _load_comfy_nodes():
+    try:
+        import nodes as comfy_nodes  # type: ignore
+    except Exception:
+        return None
+    return comfy_nodes
+
+
 _initialize(
     register_routes=api.register_routes,
     initialize_wildcards=ensure_default_wildcard_root,
+    load_comfy_nodes=_load_comfy_nodes,
 )
 
 WEB_DIRECTORY = "./web"

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -344,7 +344,7 @@ Exit:
 
 ### E-02a — Minimal runtime shell
 
-- **State:** BLOCKED in Draft PR #327 by the package-closure gate
+- **State:** COMPLETE in PR #327 (combined Contract with E-07a)
 - **Owner:** #323 / parent #187
 - **Type:** Contract
 
@@ -378,9 +378,22 @@ mutation, or feature code importing runtime.
 
 ### E-07a — Provider Contract and default lazy provider
 
-- **State:** BLOCKED by E-02a / PR #327
+- **State:** COMPLETE in PR #327 (combined Contract with E-02a)
 - **Owner:** #323 / parent #187
 - **Type:** Contract
+
+PR #327 combines E-02a and E-07a because the package-closure gate cannot admit
+the new runtime/provider modules while both remain unreachable. The combined
+production boundary is exactly the union of the two Contract units:
+
+```text
+easyuse_anima/runtime.py
+easyuse_anima/bootstrap.py
+easyuse_anima/infrastructure/comfy/provider.py
+```
+
+This sequencing correction does not add a package-closure exception and does
+not authorize E-07b wiring, a wrapper Move, or a Behavior change.
 
 Allowed production files:
 
@@ -523,10 +536,10 @@ and D-12 unless a separate behavior-preserving owner is proven.
 ```text
 COMPLETE: B-11c28 / PR #322
 COMPLETE: E-01a scoped inventory / PR #325
+COMPLETE: E-02a minimal runtime shell / PR #327
+COMPLETE: E-07a default host provider / PR #327
 
-BLOCKED:  E-02a minimal runtime shell / Draft PR #327
-BLOCKED:  E-07a default host provider
-BLOCKED:  E-07b wiring and compatibility gate
+READY:    E-07b wiring and compatibility gate
 BLOCKED:  B-11c29a-d wrapper Moves/retirements
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim
@@ -584,17 +597,14 @@ Read docs/architecture/comfy-host-provider-bridge.md, Issue #323, Issue #184's
 latest blocker/completion evidence, Issue #187, python-backend.md, ADR-002, and
 the E-01a compatibility ledger before editing.
 
-E-01a is complete in PR #325. E-02a Draft PR #327 is blocked because its two
-new production modules are shipped but unreachable from the current runtime
-import closure, while the exact E-02a boundary forbids bootstrap or existing
-caller changes. Do not update only the analyzer snapshot, weaken the
-package-closure gate, or start E-07a until #323 records a revised allowed-file
-and sequencing decision.
+E-01a is complete in PR #325. E-02a and E-07a are complete together in PR #327
+because bootstrap reachability is required by the package-closure gate. Start
+with E-07b only and follow its exact compatibility and wiring boundary in
+tests/fixtures/comfy_host_compatibility.v1.json. Do not move or remove the seven
+root wrappers, add lookup caching, or migrate feature behavior in E-07b.
 
-After the E-02a blocker is resolved and merged, execute E-07a and then E-07b as
-separate Contract/gate units. Only after their exit gates pass may #184 resume
-B-11c29 wrapper Moves. Target dev, use one task ID per branch, run focused
-tests and the official full runner, and record exact base/head SHA,
-compatibility decisions, package/live status, rollback boundary, and next task.
-Do not release from this sequence.
+Only after the E-07b exit gates pass may #184 resume B-11c29 wrapper Moves.
+Target dev, use one task ID per branch, run focused tests and the official full
+runner, and record exact base/head SHA, compatibility decisions, package/live
+status, rollback boundary, and next task. Do not release from this sequence.
 ```

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -344,7 +344,7 @@ Exit:
 
 ### E-02a — Minimal runtime shell
 
-- **State:** BLOCKED by E-01a
+- **State:** COMPLETE in PR #327
 - **Owner:** #323 / parent #187
 - **Type:** Contract
 
@@ -378,7 +378,7 @@ mutation, or feature code importing runtime.
 
 ### E-07a — Provider Contract and default lazy provider
 
-- **State:** BLOCKED by E-01a and E-02a interface review
+- **State:** READY after E-02a / PR #327
 - **Owner:** #323 / parent #187
 - **Type:** Contract
 
@@ -523,9 +523,9 @@ and D-12 unless a separate behavior-preserving owner is proven.
 ```text
 COMPLETE: B-11c28 / PR #322
 COMPLETE: E-01a scoped inventory / PR #325
+COMPLETE: E-02a minimal runtime shell / PR #327
 
-READY:    E-02a minimal runtime shell
-BLOCKED:  E-07a default host provider
+READY:    E-07a default host provider
 BLOCKED:  E-07b wiring and compatibility gate
 BLOCKED:  B-11c29a-d wrapper Moves/retirements
 BLOCKED:  B-11c30 binder/resolver migration audit
@@ -584,17 +584,15 @@ Read docs/architecture/comfy-host-provider-bridge.md, Issue #323, Issue #184's
 latest blocker/completion evidence, Issue #187, python-backend.md, ADR-002, and
 the E-01a compatibility ledger before editing.
 
-E-01a is complete in PR #325. Start with E-02a only and follow the exact
-production symbols, allowed files, tests, and forbidden work in
-tests/fixtures/comfy_host_compatibility.v1.json. Declare the narrow
-ComfyHostProvider Protocol needed to type the frozen RuntimeServices shell,
-then implement only install/access semantics. Do not implement the default
-provider, host lookup, bootstrap wiring, feature placeholders, or root/canonical
-caller changes in E-02a.
+E-01a and E-02a are complete in PR #325 and PR #327. Start with E-07a only and
+follow the exact production symbols, allowed files, tests, and forbidden work
+in tests/fixtures/comfy_host_compatibility.v1.json. Implement the default lazy
+provider and compose it at bootstrap without capability/invocation helper
+wiring, root wrapper moves, lookup caching, or feature migration.
 
-After E-02a merges, execute one Contract unit at a time: E-07a, then E-07b.
-Only after their exit gates pass may #184 resume B-11c29 wrapper Moves.
-Target dev, use one task ID per branch, run focused tests and the official full
-runner, and record exact base/head SHA, compatibility decisions, package/live
-status, rollback boundary, and next task. Do not release from this sequence.
+After E-07a merges, execute E-07b as its own Contract/gate unit. Only after its
+exit gates pass may #184 resume B-11c29 wrapper Moves. Target dev, use one task
+ID per branch, run focused tests and the official full runner, and record exact
+base/head SHA, compatibility decisions, package/live status, rollback boundary,
+and next task. Do not release from this sequence.
 ```

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -383,21 +383,27 @@ mutation, or feature code importing runtime.
 - **Type:** Contract
 
 PR #327 combines E-02a and E-07a because the package-closure gate cannot admit
-the new runtime/provider modules while both remain unreachable. The combined
-production boundary is exactly the union of the two Contract units:
+the new runtime/provider modules while both remain unreachable. The production
+boundary is the union of the two Contract units plus the root entrypoint's
+adapter-only host-module loader:
 
 ```text
+__init__.py
 easyuse_anima/runtime.py
 easyuse_anima/bootstrap.py
 easyuse_anima/infrastructure/comfy/provider.py
 ```
 
-This sequencing correction does not add a package-closure exception and does
-not authorize E-07b wiring, a wrapper Move, or a Behavior change.
+The root entrypoint owns the actual `import nodes` operation and injects a
+call-time loader into bootstrap. Canonical code therefore does not import a
+root shim, while the provider still observes delayed host availability without
+caching. This sequencing correction does not add a package-closure exception
+and does not authorize E-07b wiring, a wrapper Move, or a Behavior change.
 
 Allowed production files:
 
 ```text
+__init__.py
 easyuse_anima/bootstrap.py
 easyuse_anima/infrastructure/comfy/provider.py
 ```

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -344,7 +344,7 @@ Exit:
 
 ### E-02a — Minimal runtime shell
 
-- **State:** COMPLETE in PR #327
+- **State:** BLOCKED in Draft PR #327 by the package-closure gate
 - **Owner:** #323 / parent #187
 - **Type:** Contract
 
@@ -378,7 +378,7 @@ mutation, or feature code importing runtime.
 
 ### E-07a — Provider Contract and default lazy provider
 
-- **State:** READY after E-02a / PR #327
+- **State:** BLOCKED by E-02a / PR #327
 - **Owner:** #323 / parent #187
 - **Type:** Contract
 
@@ -523,9 +523,9 @@ and D-12 unless a separate behavior-preserving owner is proven.
 ```text
 COMPLETE: B-11c28 / PR #322
 COMPLETE: E-01a scoped inventory / PR #325
-COMPLETE: E-02a minimal runtime shell / PR #327
 
-READY:    E-07a default host provider
+BLOCKED:  E-02a minimal runtime shell / Draft PR #327
+BLOCKED:  E-07a default host provider
 BLOCKED:  E-07b wiring and compatibility gate
 BLOCKED:  B-11c29a-d wrapper Moves/retirements
 BLOCKED:  B-11c30 binder/resolver migration audit
@@ -584,15 +584,17 @@ Read docs/architecture/comfy-host-provider-bridge.md, Issue #323, Issue #184's
 latest blocker/completion evidence, Issue #187, python-backend.md, ADR-002, and
 the E-01a compatibility ledger before editing.
 
-E-01a and E-02a are complete in PR #325 and PR #327. Start with E-07a only and
-follow the exact production symbols, allowed files, tests, and forbidden work
-in tests/fixtures/comfy_host_compatibility.v1.json. Implement the default lazy
-provider and compose it at bootstrap without capability/invocation helper
-wiring, root wrapper moves, lookup caching, or feature migration.
+E-01a is complete in PR #325. E-02a Draft PR #327 is blocked because its two
+new production modules are shipped but unreachable from the current runtime
+import closure, while the exact E-02a boundary forbids bootstrap or existing
+caller changes. Do not update only the analyzer snapshot, weaken the
+package-closure gate, or start E-07a until #323 records a revised allowed-file
+and sequencing decision.
 
-After E-07a merges, execute E-07b as its own Contract/gate unit. Only after its
-exit gates pass may #184 resume B-11c29 wrapper Moves. Target dev, use one task
-ID per branch, run focused tests and the official full runner, and record exact
-base/head SHA, compatibility decisions, package/live status, rollback boundary,
-and next task. Do not release from this sequence.
+After the E-02a blocker is resolved and merged, execute E-07a and then E-07b as
+separate Contract/gate units. Only after their exit gates pass may #184 resume
+B-11c29 wrapper Moves. Target dev, use one task ID per branch, run focused
+tests and the official full runner, and record exact base/head SHA,
+compatibility decisions, package/live status, rollback boundary, and next task.
+Do not release from this sequence.
 ```

--- a/easyuse_anima/bootstrap.py
+++ b/easyuse_anima/bootstrap.py
@@ -6,9 +6,13 @@ import logging
 import threading
 from collections.abc import Callable
 
+from .infrastructure.comfy.provider import DefaultComfyHostProvider
+from .runtime import RuntimeServices, install_runtime
+
 _LOGGER = logging.getLogger("ComfyUI-EasyUseAnima")
 _INITIALIZE_LOCK = threading.Lock()
 _WILDCARDS_INITIALIZED = False
+_DEFAULT_RUNTIME = RuntimeServices(comfy=DefaultComfyHostProvider())
 
 
 def initialize(
@@ -20,6 +24,7 @@ def initialize(
 
     global _WILDCARDS_INITIALIZED
     with _INITIALIZE_LOCK:
+        install_runtime(_DEFAULT_RUNTIME)
         register_routes()
         if _WILDCARDS_INITIALIZED:
             return

--- a/easyuse_anima/bootstrap.py
+++ b/easyuse_anima/bootstrap.py
@@ -12,19 +12,32 @@ from .runtime import RuntimeServices, install_runtime
 _LOGGER = logging.getLogger("ComfyUI-EasyUseAnima")
 _INITIALIZE_LOCK = threading.Lock()
 _WILDCARDS_INITIALIZED = False
-_DEFAULT_RUNTIME = RuntimeServices(comfy=DefaultComfyHostProvider())
+_DEFAULT_RUNTIME: RuntimeServices | None = None
+
+
+def _missing_comfy_nodes() -> None:
+    return None
 
 
 def initialize(
     *,
     register_routes: Callable[[], bool],
     initialize_wildcards: Callable[[], object],
+    load_comfy_nodes: Callable[[], object | None] = _missing_comfy_nodes,
 ) -> None:
     """Initialize routes and the default wildcard root without duplicate work."""
 
-    global _WILDCARDS_INITIALIZED
+    global _DEFAULT_RUNTIME, _WILDCARDS_INITIALIZED
     with _INITIALIZE_LOCK:
-        install_runtime(_DEFAULT_RUNTIME)
+        runtime = _DEFAULT_RUNTIME
+        if runtime is None:
+            runtime = RuntimeServices(
+                comfy=DefaultComfyHostProvider(load_comfy_nodes),
+            )
+            install_runtime(runtime)
+            _DEFAULT_RUNTIME = runtime
+        else:
+            install_runtime(runtime)
         register_routes()
         if _WILDCARDS_INITIALIZED:
             return

--- a/easyuse_anima/infrastructure/comfy/provider.py
+++ b/easyuse_anima/infrastructure/comfy/provider.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from .capabilities import (
+    _comfy_max_resolution,
+    _find_comfy_node_class,
+    _find_loaded_node_class,
+)
+
 
 class ComfyHostProvider(Protocol):
     """Narrow port for discovering capabilities exposed by the ComfyUI host."""
@@ -17,4 +23,32 @@ class ComfyHostProvider(Protocol):
     def find_loaded_node_class(self, node_id: str) -> type[object] | None: ...
 
 
-__all__ = ("ComfyHostProvider",)
+def _load_comfy_nodes() -> object | None:
+    try:
+        import nodes as comfy_nodes  # type: ignore
+    except Exception:
+        return None
+    return comfy_nodes
+
+
+class DefaultComfyHostProvider:
+    """Discover host capabilities lazily without caching ComfyUI state."""
+
+    def max_resolution(self) -> int:
+        return _comfy_max_resolution(_load_comfy_nodes())
+
+    def find_node_class(self, node_id: str) -> type[object] | None:
+        return _find_comfy_node_class(node_id, _load_comfy_nodes())
+
+    def find_node_mapping_class(self, node_id: str) -> type[object] | None:
+        try:
+            mappings = getattr(_load_comfy_nodes(), "NODE_CLASS_MAPPINGS", {})
+            return mappings.get(node_id)
+        except Exception:
+            return None
+
+    def find_loaded_node_class(self, node_id: str) -> type[object] | None:
+        return _find_loaded_node_class(node_id, self.find_node_class)
+
+
+__all__ = ("ComfyHostProvider", "DefaultComfyHostProvider")

--- a/easyuse_anima/infrastructure/comfy/provider.py
+++ b/easyuse_anima/infrastructure/comfy/provider.py
@@ -1,0 +1,20 @@
+"""ComfyUI host-discovery contract."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ComfyHostProvider(Protocol):
+    """Narrow port for discovering capabilities exposed by the ComfyUI host."""
+
+    def max_resolution(self) -> int: ...
+
+    def find_node_class(self, node_id: str) -> type[object] | None: ...
+
+    def find_node_mapping_class(self, node_id: str) -> type[object] | None: ...
+
+    def find_loaded_node_class(self, node_id: str) -> type[object] | None: ...
+
+
+__all__ = ("ComfyHostProvider",)

--- a/easyuse_anima/infrastructure/comfy/provider.py
+++ b/easyuse_anima/infrastructure/comfy/provider.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+from collections.abc import Callable
 from typing import Protocol
 
 from .capabilities import (
@@ -23,26 +25,34 @@ class ComfyHostProvider(Protocol):
     def find_loaded_node_class(self, node_id: str) -> type[object] | None: ...
 
 
-def _load_comfy_nodes() -> object | None:
-    try:
-        import nodes as comfy_nodes  # type: ignore
-    except Exception:
-        return None
-    return comfy_nodes
+def _loaded_comfy_nodes() -> object | None:
+    return sys.modules.get("nodes")
 
 
 class DefaultComfyHostProvider:
     """Discover host capabilities lazily without caching ComfyUI state."""
 
+    def __init__(
+        self,
+        load_comfy_nodes: Callable[[], object | None] = _loaded_comfy_nodes,
+    ) -> None:
+        self._load_comfy_nodes = load_comfy_nodes
+
+    def _comfy_nodes(self) -> object | None:
+        try:
+            return self._load_comfy_nodes()
+        except Exception:
+            return None
+
     def max_resolution(self) -> int:
-        return _comfy_max_resolution(_load_comfy_nodes())
+        return _comfy_max_resolution(self._comfy_nodes())
 
     def find_node_class(self, node_id: str) -> type[object] | None:
-        return _find_comfy_node_class(node_id, _load_comfy_nodes())
+        return _find_comfy_node_class(node_id, self._comfy_nodes())
 
     def find_node_mapping_class(self, node_id: str) -> type[object] | None:
         try:
-            mappings = getattr(_load_comfy_nodes(), "NODE_CLASS_MAPPINGS", {})
+            mappings = getattr(self._comfy_nodes(), "NODE_CLASS_MAPPINGS", {})
             return mappings.get(node_id)
         except Exception:
             return None

--- a/easyuse_anima/runtime.py
+++ b/easyuse_anima/runtime.py
@@ -1,0 +1,45 @@
+"""Process-runtime installation and access contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .infrastructure.comfy.provider import ComfyHostProvider
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeServices:
+    """Process-lifetime services currently ready for composition."""
+
+    comfy: ComfyHostProvider
+
+
+_RUNTIME_SERVICES: RuntimeServices | None = None
+
+
+def install_runtime(runtime: RuntimeServices) -> RuntimeServices:
+    """Install the process runtime, allowing only an identical repeat."""
+
+    global _RUNTIME_SERVICES
+
+    installed = _RUNTIME_SERVICES
+    if installed is None:
+        _RUNTIME_SERVICES = runtime
+        return runtime
+    if installed is runtime:
+        return installed
+    raise RuntimeError(
+        "[EasyUseAnima] A different RuntimeServices instance is already installed."
+    )
+
+
+def get_runtime() -> RuntimeServices:
+    """Return the installed process runtime."""
+
+    runtime = _RUNTIME_SERVICES
+    if runtime is None:
+        raise RuntimeError("[EasyUseAnima] RuntimeServices has not been installed.")
+    return runtime
+
+
+__all__ = ("RuntimeServices", "get_runtime", "install_runtime")

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -593,6 +593,7 @@
     "E-07a": {
       "type": "Contract",
       "production_files": [
+        "__init__.py",
         "easyuse_anima/bootstrap.py",
         "easyuse_anima/infrastructure/comfy/provider.py"
       ],

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -7013,6 +7013,60 @@
       },
       {
         "alias": null,
+        "bound_name": "DefaultComfyHostProvider",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".infrastructure.comfy.provider:DefaultComfyHostProvider",
+        "kind": "static_from",
+        "line": 9,
+        "name": "DefaultComfyHostProvider",
+        "optional": false,
+        "requested": ".infrastructure.comfy.provider",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "RuntimeServices",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".runtime:RuntimeServices",
+        "kind": "static_from",
+        "line": 10,
+        "name": "RuntimeServices",
+        "optional": false,
+        "requested": ".runtime",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "install_runtime",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".runtime:install_runtime",
+        "kind": "static_from",
+        "line": 10,
+        "name": "install_runtime",
+        "optional": false,
+        "requested": ".runtime",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/bootstrap.py",
+        "target": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
         "bound_name": "json",
         "branch_context": [],
         "classification": "external",
@@ -7923,6 +7977,119 @@
         "role": "ordinary",
         "scope": "_common_upscale_image",
         "source": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_comfy_max_resolution",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".capabilities:_comfy_max_resolution",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_comfy_max_resolution",
+        "optional": false,
+        "requested": ".capabilities",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py",
+        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_find_comfy_node_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".capabilities:_find_comfy_node_class",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_find_comfy_node_class",
+        "optional": false,
+        "requested": ".capabilities",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py",
+        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_find_loaded_node_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".capabilities:_find_loaded_node_class",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_find_loaded_node_class",
+        "optional": false,
+        "requested": ".capabilities",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py",
+        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 27
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 28,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
+        "scope": "_load_comfy_nodes",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
         "alias": null,
@@ -14205,6 +14372,58 @@
         "scope": "<module>",
         "source": "easyuse_anima/registration.py",
         "target": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "ComfyHostProvider",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".infrastructure.comfy.provider:ComfyHostProvider",
+        "kind": "static_from",
+        "line": 7,
+        "name": "ComfyHostProvider",
+        "optional": false,
+        "requested": ".infrastructure.comfy.provider",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/runtime.py",
+        "target": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
         "alias": null,
@@ -37331,6 +37550,14 @@
         "to": "easyuse_anima/aio/generation_values.py"
       },
       {
+        "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "from": "easyuse_anima/bootstrap.py",
+        "to": "easyuse_anima/runtime.py"
+      },
+      {
         "from": "easyuse_anima/image/detailer.py",
         "to": "easyuse_anima/image/geometry.py"
       },
@@ -37345,6 +37572,10 @@
       {
         "from": "easyuse_anima/image/scaling.py",
         "to": "easyuse_anima/image/geometry.py"
+      },
+      {
+        "from": "easyuse_anima/infrastructure/comfy/provider.py",
+        "to": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
         "from": "easyuse_anima/lora/preset.py",
@@ -37621,6 +37852,10 @@
       {
         "from": "easyuse_anima/registration.py",
         "to": "easyuse_anima/nodes/wildcard_nodes.py"
+      },
+      {
+        "from": "easyuse_anima/runtime.py",
+        "to": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
         "from": "easyuse_anima/workflow.py",
@@ -38129,6 +38364,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/infrastructure/comfy/provider.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/infrastructure/comfy/resources.py"
         ]
       },
@@ -38321,6 +38562,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/runtime.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/workflow.py"
         ]
       },
@@ -38357,7 +38604,7 @@
     ]
   },
   "inventory": {
-    "module_count": 83,
+    "module_count": 85,
     "modules": [
       {
         "is_package": true,
@@ -38745,14 +38992,14 @@
       },
       {
         "is_package": false,
-        "loc": 37,
+        "loc": 42,
         "module": "easyuse_anima.bootstrap",
-        "normalized_git_blob_sha1": "a114f2473296dbb4cb5f27429f115354448ca698",
+        "normalized_git_blob_sha1": "7c7a866a308f260fd5b645ea480a323606ff8dd7",
         "path": "easyuse_anima/bootstrap.py",
         "top_level": {
           "class_count": 0,
           "function_count": 1,
-          "global_count": 4
+          "global_count": 5
         }
       },
       {
@@ -38896,6 +39143,18 @@
         "top_level": {
           "class_count": 0,
           "function_count": 4,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 54,
+        "module": "easyuse_anima.infrastructure.comfy.provider",
+        "normalized_git_blob_sha1": "6bf34c42d39429fe272afeaebe891f4110be818b",
+        "path": "easyuse_anima/infrastructure/comfy/provider.py",
+        "top_level": {
+          "class_count": 2,
+          "function_count": 1,
           "global_count": 1
         }
       },
@@ -39281,6 +39540,18 @@
           "class_count": 0,
           "function_count": 0,
           "global_count": 3
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 45,
+        "module": "easyuse_anima.runtime",
+        "normalized_git_blob_sha1": "db75d050be2939fe72a9a5f4e05b20ed406fa49b",
+        "path": "easyuse_anima/runtime.py",
+        "top_level": {
+          "class_count": 1,
+          "function_count": 2,
+          "global_count": 2
         }
       },
       {
@@ -50727,6 +50998,47 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 27
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 28,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/infrastructure/comfy/resources.py"
       },
       {
@@ -51901,6 +52213,28 @@
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/runtime.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/runtime.py"
       },
       {
         "branch_context": [],
@@ -53102,6 +53436,25 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
+            "line": 27
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 28,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
             "line": 10
           }
         ],
@@ -53599,6 +53952,7 @@
       "easyuse_anima/infrastructure/comfy/__init__.py",
       "easyuse_anima/infrastructure/comfy/capabilities.py",
       "easyuse_anima/infrastructure/comfy/invocation.py",
+      "easyuse_anima/infrastructure/comfy/provider.py",
       "easyuse_anima/infrastructure/comfy/resources.py",
       "easyuse_anima/lora/__init__.py",
       "easyuse_anima/lora/metadata.py",
@@ -53631,6 +53985,7 @@
       "easyuse_anima/prompt/fields.py",
       "easyuse_anima/prompt/regional.py",
       "easyuse_anima/registration.py",
+      "easyuse_anima/runtime.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -53684,6 +54039,7 @@
       "easyuse_anima/infrastructure/comfy/__init__.py",
       "easyuse_anima/infrastructure/comfy/capabilities.py",
       "easyuse_anima/infrastructure/comfy/invocation.py",
+      "easyuse_anima/infrastructure/comfy/provider.py",
       "easyuse_anima/infrastructure/comfy/resources.py",
       "easyuse_anima/lora/__init__.py",
       "easyuse_anima/lora/metadata.py",
@@ -53716,6 +54072,7 @@
       "easyuse_anima/prompt/fields.py",
       "easyuse_anima/prompt/regional.py",
       "easyuse_anima/registration.py",
+      "easyuse_anima/runtime.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -54507,7 +54864,7 @@
         "column": 10,
         "context": "assign:_LOGGER",
         "kind": "import_time_call",
-        "line": 9,
+        "line": 12,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -54516,7 +54873,25 @@
         "column": 19,
         "context": "assign:_INITIALIZE_LOCK",
         "kind": "import_time_call",
-        "line": 10,
+        "line": 13,
+        "module": "easyuse_anima/bootstrap.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "RuntimeServices",
+        "column": 19,
+        "context": "assign:_DEFAULT_RUNTIME",
+        "kind": "import_time_call",
+        "line": 15,
+        "module": "easyuse_anima/bootstrap.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "DefaultComfyHostProvider",
+        "column": 41,
+        "context": "assign:_DEFAULT_RUNTIME",
+        "kind": "import_time_call",
+        "line": 15,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -54905,6 +55280,15 @@
         "kind": "import_time_call",
         "line": 25,
         "module": "easyuse_anima/prompt/fields.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:RuntimeServices",
+        "kind": "import_time_call",
+        "line": 10,
+        "module": "easyuse_anima/runtime.py",
         "scope": "<module>"
       },
       {
@@ -55552,7 +55936,7 @@
       },
       {
         "kind": "list",
-        "line": 37,
+        "line": 42,
         "module": "easyuse_anima/bootstrap.py",
         "name": "__all__"
       },
@@ -55914,7 +56298,7 @@
           "lock"
         ],
         "initializer": "threading.Lock",
-        "line": 10,
+        "line": 13,
         "module": "easyuse_anima/bootstrap.py",
         "name": "_INITIALIZE_LOCK"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -426,6 +426,31 @@
         "target": "wildcard_engine.py"
       },
       {
+        "alias": "comfy_nodes",
+        "bound_name": "comfy_nodes",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 33
+          }
+        ],
+        "classification": "external",
+        "column": 8,
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 34,
+        "name": null,
+        "optional": true,
+        "requested": "nodes",
+        "role": "optional_dependency",
+        "scope": "_load_comfy_nodes",
+        "source": "__init__.py"
+      },
+      {
         "alias": null,
         "bound_name": "correct_prompt",
         "branch_context": [],
@@ -7997,6 +8022,40 @@
       },
       {
         "alias": null,
+        "bound_name": "sys",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "sys",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "sys",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "alias": null,
         "bound_name": "Protocol",
         "branch_context": [],
         "classification": "external",
@@ -8004,7 +8063,7 @@
         "conditional": false,
         "imported": "typing:Protocol",
         "kind": "static_from",
-        "line": 5,
+        "line": 7,
         "name": "Protocol",
         "optional": false,
         "requested": "typing",
@@ -8021,7 +8080,7 @@
         "conditional": false,
         "imported": ".capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 7,
+        "line": 9,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": ".capabilities",
@@ -8039,7 +8098,7 @@
         "conditional": false,
         "imported": ".capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 7,
+        "line": 9,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": ".capabilities",
@@ -8057,7 +8116,7 @@
         "conditional": false,
         "imported": ".capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 7,
+        "line": 9,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": ".capabilities",
@@ -8065,31 +8124,6 @@
         "scope": "<module>",
         "source": "easyuse_anima/infrastructure/comfy/provider.py",
         "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 27
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 28,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_load_comfy_nodes",
-        "source": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
         "alias": null,
@@ -38608,13 +38642,13 @@
     "modules": [
       {
         "is_package": true,
-        "loc": 42,
+        "loc": 52,
         "module": "__root__",
-        "normalized_git_blob_sha1": "29a0befc1c5aa8c8aa3db3f755ca5816f3f700f4",
+        "normalized_git_blob_sha1": "12ab225bf2436a2c76323d5b8fcd2fe6bd50cffe",
         "path": "__init__.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 0,
+          "function_count": 1,
           "global_count": 2
         }
       },
@@ -38992,13 +39026,13 @@
       },
       {
         "is_package": false,
-        "loc": 42,
+        "loc": 55,
         "module": "easyuse_anima.bootstrap",
-        "normalized_git_blob_sha1": "7c7a866a308f260fd5b645ea480a323606ff8dd7",
+        "normalized_git_blob_sha1": "69651a9eb42f2ce9faae414662e7fa92ea1af62e",
         "path": "easyuse_anima/bootstrap.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 1,
+          "function_count": 2,
           "global_count": 5
         }
       },
@@ -39148,9 +39182,9 @@
       },
       {
         "is_package": false,
-        "loc": 54,
+        "loc": 64,
         "module": "easyuse_anima.infrastructure.comfy.provider",
-        "normalized_git_blob_sha1": "6bf34c42d39429fe272afeaebe891f4110be818b",
+        "normalized_git_blob_sha1": "734257d54c6eeabf061d2714a2f1e1cbfe7b3834",
         "path": "easyuse_anima/infrastructure/comfy/provider.py",
         "top_level": {
           "class_count": 2,
@@ -48689,6 +48723,25 @@
     ],
     "external_imports": [
       {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 33
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 34,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "__init__.py"
+      },
+      {
         "branch_context": [],
         "classification": "external",
         "conditional": false,
@@ -51004,30 +51057,33 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Protocol",
-        "kind": "static_from",
+        "imported": "sys",
+        "kind": "static_import",
         "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 27
-          }
-        ],
+        "branch_context": [],
         "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 28,
-        "optional": true,
-        "role": "optional_dependency",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
@@ -52915,6 +52971,25 @@
           {
             "branch": "body",
             "handles_import_failure": true,
+            "has_import_fallback_handler": false,
+            "kind": "try",
+            "line": 33
+          }
+        ],
+        "classification": "external",
+        "conditional": true,
+        "imported": "nodes",
+        "kind": "static_import",
+        "line": 34,
+        "optional": true,
+        "role": "optional_dependency",
+        "source": "__init__.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
             "has_import_fallback_handler": true,
             "kind": "try",
             "line": 15
@@ -53428,25 +53503,6 @@
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/infrastructure/comfy/invocation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 27
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 28,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
         "branch_context": [
@@ -54090,7 +54146,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 31,
+        "line": 40,
         "module": "__init__.py",
         "scope": "<module>"
       },
@@ -54874,24 +54930,6 @@
         "context": "assign:_INITIALIZE_LOCK",
         "kind": "import_time_call",
         "line": 13,
-        "module": "easyuse_anima/bootstrap.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "RuntimeServices",
-        "column": 19,
-        "context": "assign:_DEFAULT_RUNTIME",
-        "kind": "import_time_call",
-        "line": 15,
-        "module": "easyuse_anima/bootstrap.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "DefaultComfyHostProvider",
-        "column": 41,
-        "context": "assign:_DEFAULT_RUNTIME",
-        "kind": "import_time_call",
-        "line": 15,
         "module": "easyuse_anima/bootstrap.py",
         "scope": "<module>"
       },
@@ -55828,7 +55866,7 @@
     "mutable_globals": [
       {
         "kind": "list",
-        "line": 38,
+        "line": 48,
         "module": "__init__.py",
         "name": "__all__"
       },
@@ -55936,7 +55974,7 @@
       },
       {
         "kind": "list",
-        "line": 42,
+        "line": 55,
         "module": "easyuse_anima/bootstrap.py",
         "name": "__all__"
       },

--- a/tests/test_comfy_host_provider.py
+++ b/tests/test_comfy_host_provider.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from easyuse_anima.infrastructure.comfy.provider import DefaultComfyHostProvider
+
+
+class DefaultComfyHostProviderTests(unittest.TestCase):
+    def setUp(self):
+        self.provider = DefaultComfyHostProvider()
+
+    @staticmethod
+    def host_module(**attributes):
+        module = types.ModuleType("nodes")
+        for name, value in attributes.items():
+            setattr(module, name, value)
+        return module
+
+    def test_max_resolution_preserves_delayed_lookup_and_fallbacks(self):
+        with patch.dict(sys.modules, {"nodes": None}):
+            self.assertEqual(self.provider.max_resolution(), 16384)
+
+        host = self.host_module(MAX_RESOLUTION="8192")
+        with patch.dict(sys.modules, {"nodes": host}):
+            self.assertEqual(self.provider.max_resolution(), 8192)
+
+        host.MAX_RESOLUTION = "invalid"
+        with patch.dict(sys.modules, {"nodes": host}):
+            self.assertEqual(self.provider.max_resolution(), 16384)
+
+        missing = self.host_module()
+        with patch.dict(sys.modules, {"nodes": missing}):
+            self.assertEqual(self.provider.max_resolution(), 16384)
+
+    def test_node_lookup_preserves_mapping_attribute_and_loaded_module_order(self):
+        mapping_id = "EasyUseAnimaProviderMappingNode"
+        attribute_id = "EasyUseAnimaProviderAttributeNode"
+        loaded_id = "EasyUseAnimaProviderLoadedNode"
+        mapping_class = type("MappingNode", (), {})
+        attribute_class = type("AttributeNode", (), {})
+        loaded_class = type("LoadedNode", (), {})
+        host = self.host_module(NODE_CLASS_MAPPINGS={mapping_id: mapping_class})
+        setattr(host, mapping_id, attribute_class)
+        setattr(host, attribute_id, attribute_class)
+        loaded_module = types.ModuleType("easyuse_anima_provider_loaded_nodes")
+        loaded_module.NODE_CLASS_MAPPINGS = {loaded_id: loaded_class}
+
+        with patch.dict(
+            sys.modules,
+            {
+                "nodes": host,
+                loaded_module.__name__: loaded_module,
+            },
+        ):
+            self.assertIs(self.provider.find_node_class(mapping_id), mapping_class)
+            self.assertIs(self.provider.find_node_class(attribute_id), attribute_class)
+            self.assertIs(self.provider.find_node_class(loaded_id), loaded_class)
+
+    def test_mapping_lookup_uses_only_the_host_mapping(self):
+        node_id = "EasyUseAnimaProviderMappingOnlyNode"
+        mapping_class = type("MappingOnlyNode", (), {})
+        attribute_class = type("AttributeOnlyNode", (), {})
+        host = self.host_module(NODE_CLASS_MAPPINGS={node_id: mapping_class})
+        setattr(host, node_id, attribute_class)
+
+        with patch.dict(sys.modules, {"nodes": host}):
+            self.assertIs(
+                self.provider.find_node_mapping_class(node_id),
+                mapping_class,
+            )
+            host.NODE_CLASS_MAPPINGS = {}
+            self.assertIsNone(self.provider.find_node_mapping_class(node_id))
+
+    def test_loaded_lookup_preserves_explicit_lookup_before_module_scan(self):
+        node_id = "EasyUseAnimaProviderLoadedFallbackNode"
+        direct_class = type("DirectNode", (), {})
+        loaded_class = type("LoadedFallbackNode", (), {})
+        loaded_module = types.ModuleType("easyuse_anima_provider_loaded_fallback")
+        loaded_module.NODE_CLASS_MAPPINGS = {node_id: loaded_class}
+
+        with (
+            patch.dict(sys.modules, {loaded_module.__name__: loaded_module}),
+            patch.object(
+                self.provider,
+                "find_node_class",
+                side_effect=(direct_class, None),
+            ) as find_node_class,
+        ):
+            self.assertIs(self.provider.find_loaded_node_class(node_id), direct_class)
+            self.assertIs(self.provider.find_loaded_node_class(node_id), loaded_class)
+
+        self.assertEqual(find_node_class.call_args_list[0].args, (node_id,))
+        self.assertEqual(find_node_class.call_args_list[1].args, (node_id,))
+
+    def test_lookup_is_not_cached_between_host_updates(self):
+        node_id = "EasyUseAnimaProviderDynamicNode"
+        first_class = type("FirstNode", (), {})
+        second_class = type("SecondNode", (), {})
+
+        with patch.dict(
+            sys.modules,
+            {"nodes": self.host_module(NODE_CLASS_MAPPINGS={node_id: first_class})},
+        ):
+            self.assertIs(self.provider.find_node_class(node_id), first_class)
+
+        with patch.dict(
+            sys.modules,
+            {"nodes": self.host_module(NODE_CLASS_MAPPINGS={node_id: second_class})},
+        ):
+            self.assertIs(self.provider.find_node_class(node_id), second_class)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 83)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 83)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 83)
+        self.assertEqual(report["inventory"]["module_count"], 85)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 85)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 85)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -723,6 +723,7 @@ ignored/
                 "easyuse_anima/infrastructure/comfy/__init__.py",
                 "easyuse_anima/infrastructure/comfy/capabilities.py",
                 "easyuse_anima/infrastructure/comfy/invocation.py",
+                "easyuse_anima/infrastructure/comfy/provider.py",
                 "easyuse_anima/infrastructure/comfy/resources.py",
                 "easyuse_anima/lora/__init__.py",
                 "easyuse_anima/lora/metadata.py",
@@ -746,6 +747,7 @@ ignored/
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",
                 "easyuse_anima/registration.py",
+                "easyuse_anima/runtime.py",
                 "easyuse_anima/prompt/__init__.py",
                 "easyuse_anima/prompt/advanced.py",
                 "easyuse_anima/prompt/correction.py",
@@ -776,6 +778,7 @@ ignored/
                 "easyuse_anima/image/scaling.py",
                 "easyuse_anima/infrastructure/comfy/capabilities.py",
                 "easyuse_anima/infrastructure/comfy/invocation.py",
+                "easyuse_anima/infrastructure/comfy/provider.py",
                 "easyuse_anima/infrastructure/comfy/resources.py",
                 "easyuse_anima/lora/__init__.py",
                 "easyuse_anima/lora/metadata.py",
@@ -805,6 +808,7 @@ ignored/
                 "easyuse_anima/profiles/__init__.py",
                 "easyuse_anima/profiles/contract.py",
                 "easyuse_anima/profiles/mutation.py",
+                "easyuse_anima/runtime.py",
             }.issubset(report["registry"]["runtime_import_closure"])
         )
         self.assertIn(

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -2123,6 +2123,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
         self.assertEqual(
             contracts["E-07a"]["production_files"],
             [
+                "__init__.py",
                 "easyuse_anima/bootstrap.py",
                 "easyuse_anima/infrastructure/comfy/provider.py",
             ],

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -5,14 +5,15 @@ import sys
 import unittest
 from dataclasses import FrozenInstanceError
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from easyuse_anima import runtime as runtime_module
+from easyuse_anima import bootstrap, runtime as runtime_module
+from easyuse_anima.infrastructure.comfy.provider import DefaultComfyHostProvider
 from easyuse_anima.runtime import RuntimeServices, get_runtime, install_runtime
 
 
@@ -86,6 +87,52 @@ class RuntimeServicesTests(unittest.TestCase):
 
         self.assertIs(get_runtime(), first)
 
+    def test_bootstrap_installs_and_reuses_the_default_runtime(self):
+        register_routes = Mock(return_value=True)
+        initialize_wildcards = Mock(return_value=object())
+
+        with patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False):
+            bootstrap.initialize(
+                register_routes=register_routes,
+                initialize_wildcards=initialize_wildcards,
+            )
+            first = get_runtime()
+            bootstrap.initialize(
+                register_routes=register_routes,
+                initialize_wildcards=initialize_wildcards,
+            )
+
+        self.assertIs(first, bootstrap._DEFAULT_RUNTIME)
+        self.assertIsInstance(first.comfy, DefaultComfyHostProvider)
+        self.assertIs(get_runtime(), first)
+        self.assertEqual(register_routes.call_count, 2)
+        initialize_wildcards.assert_called_once_with()
+
+    def test_bootstrap_rejects_conflicting_runtime_before_startup_callbacks(self):
+        runtime = self.make_runtime()
+        register_routes = Mock(return_value=True)
+        initialize_wildcards = Mock(return_value=object())
+        install_runtime(runtime)
+
+        with (
+            patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False),
+            self.assertRaisesRegex(
+                RuntimeError,
+                (
+                    r"^\[EasyUseAnima\] A different RuntimeServices instance "
+                    r"is already installed\.$"
+                ),
+            ),
+        ):
+            bootstrap.initialize(
+                register_routes=register_routes,
+                initialize_wildcards=initialize_wildcards,
+            )
+
+        self.assertIs(get_runtime(), runtime)
+        register_routes.assert_not_called()
+        initialize_wildcards.assert_not_called()
+
     def test_import_does_not_require_comfyui_host_modules(self):
         script = """
 import builtins
@@ -101,7 +148,9 @@ def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
 builtins.__import__ = guarded_import
 
 from easyuse_anima.infrastructure.comfy.provider import ComfyHostProvider
+from easyuse_anima.infrastructure.comfy.provider import DefaultComfyHostProvider
 from easyuse_anima.runtime import RuntimeServices, get_runtime, install_runtime
+from easyuse_anima.bootstrap import initialize
 """
         result = subprocess.run(
             [sys.executable, "-c", script],

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -35,8 +35,11 @@ class RuntimeServicesTests(unittest.TestCase):
     def setUp(self):
         self.runtime_state = patch.object(runtime_module, "_RUNTIME_SERVICES", None)
         self.runtime_state.start()
+        self.default_runtime_state = patch.object(bootstrap, "_DEFAULT_RUNTIME", None)
+        self.default_runtime_state.start()
 
     def tearDown(self):
+        self.default_runtime_state.stop()
         self.runtime_state.stop()
 
     @staticmethod
@@ -90,21 +93,27 @@ class RuntimeServicesTests(unittest.TestCase):
     def test_bootstrap_installs_and_reuses_the_default_runtime(self):
         register_routes = Mock(return_value=True)
         initialize_wildcards = Mock(return_value=object())
+        host = type("Host", (), {"MAX_RESOLUTION": "8192"})()
+        load_comfy_nodes = Mock(return_value=host)
 
         with patch.object(bootstrap, "_WILDCARDS_INITIALIZED", False):
             bootstrap.initialize(
                 register_routes=register_routes,
                 initialize_wildcards=initialize_wildcards,
+                load_comfy_nodes=load_comfy_nodes,
             )
             first = get_runtime()
             bootstrap.initialize(
                 register_routes=register_routes,
                 initialize_wildcards=initialize_wildcards,
+                load_comfy_nodes=load_comfy_nodes,
             )
 
         self.assertIs(first, bootstrap._DEFAULT_RUNTIME)
         self.assertIsInstance(first.comfy, DefaultComfyHostProvider)
+        self.assertEqual(first.comfy.max_resolution(), 8192)
         self.assertIs(get_runtime(), first)
+        load_comfy_nodes.assert_called_once_with()
         self.assertEqual(register_routes.call_count, 2)
         initialize_wildcards.assert_called_once_with()
 

--- a/tests/test_runtime_services.py
+++ b/tests/test_runtime_services.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from easyuse_anima import runtime as runtime_module
+from easyuse_anima.runtime import RuntimeServices, get_runtime, install_runtime
+
+
+class FakeComfyHostProvider:
+    def max_resolution(self) -> int:
+        return 16384
+
+    def find_node_class(self, node_id: str) -> type[object] | None:
+        return None
+
+    def find_node_mapping_class(self, node_id: str) -> type[object] | None:
+        return None
+
+    def find_loaded_node_class(self, node_id: str) -> type[object] | None:
+        return None
+
+
+class RuntimeServicesTests(unittest.TestCase):
+    def setUp(self):
+        self.runtime_state = patch.object(runtime_module, "_RUNTIME_SERVICES", None)
+        self.runtime_state.start()
+
+    def tearDown(self):
+        self.runtime_state.stop()
+
+    @staticmethod
+    def make_runtime() -> RuntimeServices:
+        return RuntimeServices(comfy=FakeComfyHostProvider())
+
+    def test_runtime_value_is_frozen(self):
+        runtime = self.make_runtime()
+
+        with self.assertRaises(FrozenInstanceError):
+            runtime.comfy = FakeComfyHostProvider()
+
+    def test_isolated_construction_does_not_install_runtime(self):
+        self.make_runtime()
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] RuntimeServices has not been installed\.$",
+        ):
+            get_runtime()
+
+    def test_first_install_is_returned_and_available(self):
+        runtime = self.make_runtime()
+
+        self.assertIs(install_runtime(runtime), runtime)
+        self.assertIs(get_runtime(), runtime)
+
+    def test_reinstalling_same_runtime_identity_is_safe(self):
+        runtime = self.make_runtime()
+        install_runtime(runtime)
+
+        self.assertIs(install_runtime(runtime), runtime)
+        self.assertIs(get_runtime(), runtime)
+
+    def test_conflicting_runtime_is_rejected_without_replacing_first(self):
+        first = self.make_runtime()
+        second = self.make_runtime()
+        install_runtime(first)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            (
+                r"^\[EasyUseAnima\] A different RuntimeServices instance "
+                r"is already installed\.$"
+            ),
+        ):
+            install_runtime(second)
+
+        self.assertIs(get_runtime(), first)
+
+    def test_import_does_not_require_comfyui_host_modules(self):
+        script = """
+import builtins
+
+real_import = builtins.__import__
+forbidden = {"comfy", "folder_paths", "nodes", "server"}
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name.split(".", 1)[0] in forbidden:
+        raise AssertionError(f"unexpected host import: {name}")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = guarded_import
+
+from easyuse_anima.infrastructure.comfy.provider import ComfyHostProvider
+from easyuse_anima.runtime import RuntimeServices, get_runtime, install_runtime
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적

#323의 E-02a 최소 runtime shell과 E-07a default lazy Comfy host provider를 하나의 Contract 경계로 구현합니다. 두 신규 production module을 package runtime closure에 포함하려면 bootstrap reachability가 동시에 필요해, owner 결정에 따라 두 Contract를 PR #327에서 합쳤습니다. Move 또는 Behavior는 포함하지 않습니다.

## 작업 전 inventory

- base: `dev@f3539df4e423c6ec13a5bcab2501f67beefc3f15`
- initial head: `03d3623`
- exact validated head: `a6d2fdb43994e5b052d857e41d0acba4a0512797`
- 기존 production symbol/caller/alias/runtime install state: 모두 없음
- 기존 7개 root wrapper와 22개 production consumer slot: 변경 없음
- 추가 global state: `easyuse_anima.runtime`의 단일 installed-runtime slot과 bootstrap의 단일 default-runtime identity
- `get_runtime()` production consumer: 0. bootstrap은 install만 수행

## 변경

Production:

- `easyuse_anima/runtime.py`: frozen `RuntimeServices`, first/same/conflicting install 및 uninstalled access 계약
- `easyuse_anima/infrastructure/comfy/provider.py`: 4-method `ComfyHostProvider`와 무캐시 `DefaultComfyHostProvider`
- `easyuse_anima/bootstrap.py`: lock 안에서 default runtime을 한 번 조립·설치하고 기존 route/Wildcard 순서 유지
- root `__init__.py`: 실제 `import nodes`를 수행하는 call-time loader를 bootstrap에 주입

Gate/docs:

- runtime/provider/bootstrap focused tests
- analyzer baseline 85 shipped / 85 runtime closure / missing 0 / unreachable 0
- E-07a allowed-file ledger에 root entrypoint loader 경계 기록
- architecture queue를 E-07b READY로 전환

## 보존된 계약

- host module은 provider/bootstrap import 시 dereference하지 않음
- root entrypoint에서만 host import를 수행하고 canonical package는 root shim을 import하지 않음
- node lookup: host mapping → host attribute → loaded-module mapping 순서
- mapping-only lookup은 attribute/loaded module을 보지 않음
- loaded lookup과 max-resolution 정상/invalid/missing fallback 유지
- 매 호출마다 loader를 실행하며 cache/snapshot 없음
- conflicting runtime은 startup callback 실행 전에 명시적으로 거부
- root wrapper, runtime binder, feature caller, node/workflow 계약 변경 없음

## 검증

Focused:

- runtime/provider/bootstrap/compatibility: 37/37 통과
- analyzer current-surface gate: 통과
- import-boundary focused: 6 groups / 0 violations

Official full at `a6d2fdb`:

- Python unittest: 952 통과
- frontend JavaScript: 114 files 통과
- TypeScript 6.0.3 통과
- Pyright baseline ratchet: 통과
- G-03 import boundary: 6 groups / 0 violations
- diff gate: 통과
- Ruff 113건은 기존 G-01 report-only이며 신규 production 파일 진단 없음

Package/entrypoint:

- `comfy node validate`: 통과
- actual `comfy node pack`: 통과, 217 files
- required archive closure: root entrypoint, bootstrap, runtime, provider, capabilities 모두 포함
- source commit clean, package version 0.5.4

## 미실행/위험

- package를 ComfyUI 인스턴스에 설치하거나 실제 live ComfyUI를 시작하지 않음
- provider lookup은 fake/delayed host module parity tests로 검증
- capability/invocation helper wiring과 root wrapper test migration은 다음 E-07b 범위

## 제외/후속

- root wrapper move/removal, feature migration, lookup cache, seed/stage/cache Behavior 없음
- main/release/Registry/사용자 인스턴스 작업 없음
- rollback boundary: PR #327 단일 revert
- #323은 E-07b가 남으므로 열린 상태 유지

Closes no issue.