### PR TITLE
E-07b: Comfy host provider wiring 및 compatibility gate

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -433,7 +433,8 @@ Pre-edit inventory at the E-07b base:
 - 22 production consumer slots in 15 canonical modules resolve those names at
   call time through their existing binder/resolver contracts;
 - all seven root replacement seams are `unsupported_test_only`;
-- 13 repository test files still patch one or more root seams;
+- 16 repository test files still replace one or more root seams, including
+  `patch.multiple` and direct assignment forms omitted by the E-01a detector;
 - two repository test files patch canonical consumers directly; and
 - the installed runtime exposes exactly one narrow `ComfyHostProvider`.
 
@@ -450,6 +451,9 @@ Allowed test and gate files:
 tests/comfy_host_fakes.py
 tests/test_comfy_host_wiring.py
 tests/test_aio_conditioning.py
+tests/test_aio_generation_migrations.py
+tests/test_aio_generation_settings.py
+tests/test_aio_legacy_generation.py
 tests/test_aio_model_preparation.py
 tests/test_aio_nodes.py
 tests/test_aio_output.py

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -423,7 +423,7 @@ policy, or cache behavior.
 
 ### E-07b — Wiring and compatibility gate
 
-- **State:** READY after E-02a/E-07a PR #327 (`dev@c1fc221`)
+- **State:** COMPLETE in PR #328
 - **Owner:** #323 / parent #187 and #188 for gates
 - **Type:** Contract/gate
 
@@ -437,6 +437,24 @@ Pre-edit inventory at the E-07b base:
   `patch.multiple` and direct assignment forms omitted by the E-01a detector;
 - two repository test files patch canonical consumers directly; and
 - the installed runtime exposes exactly one narrow `ComfyHostProvider`.
+
+Completion evidence:
+
+- all 22 host-helper consumer slots in 15 canonical modules resolve the seven
+  owned seams through the installed provider while unrelated names retain the
+  existing root fallback;
+- all 16 repository root-replacement test files use the fake provider or an
+  explicit canonical lookup, leaving zero repository root replacements;
+- the two intentional canonical `_comfy_max_resolution` replacement files
+  remain recorded separately;
+- `get_runtime()` remains limited to `runtime.py` and the Comfy wiring adapter;
+- the resolver return annotation is `Any` because unrelated names continue
+  through the existing fallback and include non-callable constants and module
+  values; the seven provider-owned resolutions themselves remain callables;
+- the seven root wrapper implementations remain unchanged for the subsequent
+  rollback-sized Moves; and
+- the deterministic backend inventory contains 86 shipped and reachable
+  Python modules with no missing internal import.
 
 Allowed production files:
 
@@ -467,6 +485,7 @@ tests/test_prompt_corrector.py
 tests/test_prompt_studio_regional.py
 tests/test_sam3_nodes.py
 tests/test_python_compatibility_surface.py
+tests/test_python_backend_analyzer.py
 tests/fixtures/comfy_host_compatibility.v1.json
 tests/fixtures/python_backend_baseline.json
 docs/architecture/*
@@ -503,7 +522,7 @@ Forbidden:
 
 ### B-11c29a — Max-resolution wrapper
 
-- **State:** BLOCKED by E-07b
+- **State:** READY after E-07b PR #328
 - **Owner:** #184
 - **Type:** Move or retirement according to the ledger
 
@@ -513,7 +532,7 @@ lookup, requirement helpers, CLIP invocation, schema, or postprocess behavior.
 
 ### B-11c29b — Node discovery family
 
-- **State:** BLOCKED by B-11c29a and E-07b
+- **State:** BLOCKED by B-11c29a
 - **Owner:** #184
 - **Type:** Move/retirement, split further when the ledger requires
 
@@ -600,9 +619,10 @@ COMPLETE: B-11c28 / PR #322
 COMPLETE: E-01a scoped inventory / PR #325
 COMPLETE: E-02a minimal runtime shell / PR #327
 COMPLETE: E-07a default host provider / PR #327
+COMPLETE: E-07b wiring and compatibility gate / PR #328
 
-READY:    E-07b wiring and compatibility gate
-BLOCKED:  B-11c29a-d wrapper Moves/retirements
+READY:    B-11c29a max-resolution wrapper Move/retirement
+BLOCKED:  B-11c29b-d wrapper Moves/retirements
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -441,8 +441,9 @@ Pre-edit inventory at the E-07b base:
 Completion evidence:
 
 - all 22 host-helper consumer slots in 15 canonical modules resolve the seven
-  owned seams through the installed provider while unrelated names retain the
-  existing root fallback;
+  owned seams through the installed provider while unrelated names and the
+  pre-bootstrap flat-import compatibility path retain the existing root
+  fallback;
 - all 16 repository root-replacement test files use the fake provider or an
   explicit canonical lookup, leaving zero repository root replacements;
 - the two intentional canonical `_comfy_max_resolution` replacement files
@@ -486,8 +487,10 @@ tests/test_prompt_studio_regional.py
 tests/test_sam3_nodes.py
 tests/test_python_compatibility_surface.py
 tests/test_python_backend_analyzer.py
+tests/test_nodes_module_analyzer.py
 tests/fixtures/comfy_host_compatibility.v1.json
 tests/fixtures/python_backend_baseline.json
+tests/fixtures/python_compatibility_surface.v1.json
 docs/architecture/*
 ```
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -423,9 +423,50 @@ policy, or cache behavior.
 
 ### E-07b — Wiring and compatibility gate
 
-- **State:** BLOCKED by E-07a
+- **State:** READY after E-02a/E-07a PR #327 (`dev@c1fc221`)
 - **Owner:** #323 / parent #187 and #188 for gates
 - **Type:** Contract/gate
+
+Pre-edit inventory at the E-07b base:
+
+- the seven root implementations remain in `nodes.py`;
+- 22 production consumer slots in 15 canonical modules resolve those names at
+  call time through their existing binder/resolver contracts;
+- all seven root replacement seams are `unsupported_test_only`;
+- 13 repository test files still patch one or more root seams;
+- two repository test files patch canonical consumers directly; and
+- the installed runtime exposes exactly one narrow `ComfyHostProvider`.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/infrastructure/comfy/wiring.py
+```
+
+Allowed test and gate files:
+
+```text
+tests/comfy_host_fakes.py
+tests/test_comfy_host_wiring.py
+tests/test_aio_conditioning.py
+tests/test_aio_model_preparation.py
+tests/test_aio_nodes.py
+tests/test_aio_output.py
+tests/test_aio_preview.py
+tests/test_aio_resources.py
+tests/test_aio_sampling.py
+tests/test_aio_schema_contract.py
+tests/test_comfy_adapters.py
+tests/test_node_contracts.py
+tests/test_prompt_corrector.py
+tests/test_prompt_studio_regional.py
+tests/test_sam3_nodes.py
+tests/test_python_compatibility_surface.py
+tests/fixtures/comfy_host_compatibility.v1.json
+tests/fixtures/python_backend_baseline.json
+docs/architecture/*
+```
 
 Required work:
 
@@ -444,6 +485,17 @@ Exit:
 - canonical modules do not import root;
 - no new Pyright or import-boundary group appears; and
 - #184 can resume wrapper Moves without redesign.
+
+Forbidden:
+
+- moving, deleting, or changing the seven root implementations;
+- changing lookup order, fallback values, error text, node/workflow schemas, or
+  feature behavior;
+- importing root `nodes.py` from the canonical package;
+- adding a provider cache, snapshot, retry policy, or mutable override
+  registry; and
+- expanding `RuntimeServices` or calling `get_runtime()` from feature, domain,
+  or service modules.
 
 ### B-11c29a — Max-resolution wrapper
 

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -1,0 +1,49 @@
+"""Call-time wiring from root runtime resolvers to the Comfy host provider."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+from ...runtime import get_runtime
+from .capabilities import (
+    _require_any_custom_node_class,
+    _require_custom_node_class,
+)
+from .invocation import _encode_with_comfy_clip
+
+
+def resolve_comfy_host_helper(
+    name: str,
+    fallback: Callable[[str], Any],
+) -> Any:
+    """Resolve the seven E-07 host seams without importing the root shim."""
+
+    if name == "_comfy_max_resolution":
+        return get_runtime().comfy.max_resolution
+    if name == "_find_comfy_node_class":
+        return get_runtime().comfy.find_node_class
+    if name == "_find_comfy_node_mapping_class":
+        return get_runtime().comfy.find_node_mapping_class
+    if name == "_find_loaded_node_class":
+        return get_runtime().comfy.find_loaded_node_class
+    if name == "_require_custom_node_class":
+        return partial(
+            _require_custom_node_class,
+            find_node_class=get_runtime().comfy.find_node_class,
+        )
+    if name == "_require_any_custom_node_class":
+        return partial(
+            _require_any_custom_node_class,
+            find_node_class=get_runtime().comfy.find_node_class,
+        )
+    if name == "_encode_with_comfy_clip":
+        return partial(
+            _encode_with_comfy_clip,
+            find_node_class=get_runtime().comfy.find_node_class,
+        )
+    return fallback(name)
+
+
+__all__ = ()

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -20,30 +20,46 @@ def resolve_comfy_host_helper(
 ) -> Any:
     """Resolve the seven E-07 host seams without importing the root shim."""
 
+    if name not in (
+        "_comfy_max_resolution",
+        "_find_comfy_node_class",
+        "_find_comfy_node_mapping_class",
+        "_find_loaded_node_class",
+        "_require_custom_node_class",
+        "_require_any_custom_node_class",
+        "_encode_with_comfy_clip",
+    ):
+        return fallback(name)
+
+    try:
+        provider = get_runtime().comfy
+    except RuntimeError:
+        # Flat ``nodes`` imports used by local tooling do not execute package
+        # bootstrap. Preserve their existing root resolver until B-11 moves it.
+        return fallback(name)
+
     if name == "_comfy_max_resolution":
-        return get_runtime().comfy.max_resolution
+        return provider.max_resolution
     if name == "_find_comfy_node_class":
-        return get_runtime().comfy.find_node_class
+        return provider.find_node_class
     if name == "_find_comfy_node_mapping_class":
-        return get_runtime().comfy.find_node_mapping_class
+        return provider.find_node_mapping_class
     if name == "_find_loaded_node_class":
-        return get_runtime().comfy.find_loaded_node_class
+        return provider.find_loaded_node_class
     if name == "_require_custom_node_class":
         return partial(
             _require_custom_node_class,
-            find_node_class=get_runtime().comfy.find_node_class,
+            find_node_class=provider.find_node_class,
         )
     if name == "_require_any_custom_node_class":
         return partial(
             _require_any_custom_node_class,
-            find_node_class=get_runtime().comfy.find_node_class,
+            find_node_class=provider.find_node_class,
         )
-    if name == "_encode_with_comfy_clip":
-        return partial(
-            _encode_with_comfy_clip,
-            find_node_class=get_runtime().comfy.find_node_class,
-        )
-    return fallback(name)
+    return partial(
+        _encode_with_comfy_clip,
+        find_node_class=provider.find_node_class,
+    )
 
 
 __all__ = ()

--- a/nodes.py
+++ b/nodes.py
@@ -424,6 +424,9 @@ try:
         _encode_with_comfy_clip as _adapter_encode_with_comfy_clip,
         _node_output_tuple as _node_output_tuple,
     )
+    from .easyuse_anima.infrastructure.comfy.wiring import (
+        resolve_comfy_host_helper as _resolve_comfy_host_helper,
+    )
     from .easyuse_anima.infrastructure.comfy.resources import (
         # B-10b1 deliberately omits the retired root _comfy_checkpoint_names alias.
         _comfy_clip_loader_types as _adapter_comfy_clip_loader_types,
@@ -984,6 +987,9 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _common_upscale_image as _common_upscale_image,
         _encode_with_comfy_clip as _adapter_encode_with_comfy_clip,
         _node_output_tuple as _node_output_tuple,
+    )
+    from easyuse_anima.infrastructure.comfy.wiring import (
+        resolve_comfy_host_helper as _resolve_comfy_host_helper,
     )
     from easyuse_anima.infrastructure.comfy.resources import (
         # B-10b1 deliberately omits the retired root _comfy_checkpoint_names alias.
@@ -1761,10 +1767,16 @@ _bind_aio_first_pass_cache_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_aio_legacy_generation_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_aio_generation_normalization_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_aio_usdu_planning_runtime(
     resolve_helper=lambda name: globals()[name],
@@ -1773,37 +1785,67 @@ _bind_aio_postprocess_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_aio_resource_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_aio_model_preparation_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_aio_sampling_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_aio_preview_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_aio_output_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_aio_conditioning_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_sam3_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_impact_detailer_node_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_sam3_node_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_regional_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_regional_node_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
     flexible_optional_input_type=_FlexibleOptionalInputType,
 )
 _bind_advanced_runtime(
@@ -1817,14 +1859,23 @@ _bind_aio_node_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_conditioning_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
     resolve_logger=lambda: logger,
 )
 _bind_artist_mix_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_prompt_data_node_runtime(
-    resolve_helper=lambda name: globals()[name],
+    resolve_helper=lambda name: _resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: globals()[fallback_name],
+    ),
 )
 _bind_prompt_fields_runtime(
     resolve_helper=lambda name: globals()[name],

--- a/tests/comfy_host_fakes.py
+++ b/tests/comfy_host_fakes.py
@@ -1,0 +1,126 @@
+"""Test-only Comfy host providers for E-07 wiring coverage."""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from unittest.mock import DEFAULT, Mock, patch
+
+
+class FakeComfyHostProvider:
+    def __init__(
+        self,
+        *,
+        max_resolution: int = 16384,
+        node_classes: dict[str, object] | None = None,
+        mapping_classes: dict[str, object] | None = None,
+        loaded_classes: dict[str, object] | None = None,
+    ) -> None:
+        self.max_resolution_value = max_resolution
+        self.node_classes = dict(node_classes or {})
+        self.mapping_classes = dict(mapping_classes or {})
+        self.loaded_classes = dict(loaded_classes or {})
+
+    def max_resolution(self) -> int:
+        return self.max_resolution_value
+
+    def find_node_class(self, node_id: str):
+        return self.node_classes.get(node_id)
+
+    def find_node_mapping_class(self, node_id: str):
+        return self.mapping_classes.get(node_id)
+
+    def find_loaded_node_class(self, node_id: str):
+        return self.loaded_classes.get(node_id)
+
+
+class _LayeredFakeComfyHostProvider:
+    def __init__(self, base, symbol: str, replacement) -> None:
+        self._base = base
+        self._symbol = symbol
+        self._replacement = replacement
+
+    def max_resolution(self) -> int:
+        if self._symbol == "_comfy_max_resolution":
+            return self._replacement()
+        return self._base.max_resolution()
+
+    def find_node_class(self, node_id: str):
+        if self._symbol in {
+            "_find_comfy_node_class",
+            "_require_custom_node_class",
+            "_require_any_custom_node_class",
+        }:
+            return self._replacement(node_id)
+        if (
+            self._symbol == "_encode_with_comfy_clip"
+            and node_id == "CLIPTextEncode"
+        ):
+            replacement = self._replacement
+
+            class ClipTextEncode:
+                def encode(self, clip, text):
+                    return (replacement(clip, text),)
+
+            return ClipTextEncode
+        return self._base.find_node_class(node_id)
+
+    def find_node_mapping_class(self, node_id: str):
+        if self._symbol == "_find_comfy_node_mapping_class":
+            return self._replacement(node_id)
+        return self._base.find_node_mapping_class(node_id)
+
+    def find_loaded_node_class(self, node_id: str):
+        if self._symbol == "_find_loaded_node_class":
+            return self._replacement(node_id)
+        return self._base.find_loaded_node_class(node_id)
+
+
+def _runtime_module_for(root_module):
+    package = root_module.__package__
+    module_name = (
+        f"{package}.easyuse_anima.runtime"
+        if package
+        else "easyuse_anima.runtime"
+    )
+    runtime_module = sys.modules.get(module_name)
+    if runtime_module is None:
+        raise AssertionError(f"Runtime module is not loaded: {module_name}")
+    return runtime_module
+
+
+@contextmanager
+def use_fake_comfy_host(root_module, provider):
+    runtime_module = _runtime_module_for(root_module)
+    runtime = runtime_module.RuntimeServices(comfy=provider)
+    with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
+        yield provider
+
+
+@contextmanager
+def patch_comfy_helper(
+    root_module,
+    symbol: str,
+    new=DEFAULT,
+    **mock_kwargs,
+):
+    """Replace an E-07 root-test seam through a layered fake provider."""
+
+    if new is DEFAULT:
+        replacement = Mock(**mock_kwargs)
+    else:
+        if mock_kwargs:
+            raise TypeError("mock options are invalid when an explicit replacement is used")
+        replacement = new
+
+    runtime_module = _runtime_module_for(root_module)
+    installed = runtime_module._RUNTIME_SERVICES
+    base = (
+        installed.comfy
+        if installed is not None
+        else FakeComfyHostProvider()
+    )
+    provider = _LayeredFakeComfyHostProvider(base, symbol, replacement)
+    runtime = runtime_module.RuntimeServices(comfy=provider)
+    with patch.object(runtime_module, "_RUNTIME_SERVICES", runtime):
+        yield replacement

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -613,6 +613,28 @@
         "lookup cache or snapshot",
         "feature migration"
       ]
+    },
+    "E-07b": {
+      "type": "Contract/gate",
+      "production_files": [
+        "nodes.py",
+        "easyuse_anima/infrastructure/comfy/wiring.py"
+      ],
+      "production_symbols": [
+        "resolve_comfy_host_helper(name: str, fallback: Callable[[str], Any]) -> Callable[..., Any]"
+      ],
+      "test_files": [
+        "tests/comfy_host_fakes.py",
+        "tests/test_comfy_host_wiring.py",
+        "tests/test_python_compatibility_surface.py"
+      ],
+      "forbidden": [
+        "root wrapper move, removal, or behavior change",
+        "host lookup cache or snapshot",
+        "canonical import of root nodes.py",
+        "feature or domain RuntimeServices access",
+        "seed, stage, cache, node schema, workflow, or route behavior change"
+      ]
     }
   }
 }

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -16,7 +16,7 @@
   "expected_counts": {
     "production_consumer_slots": 22,
     "unique_production_modules": 15,
-    "root_monkeypatch_test_files": 13,
+    "root_monkeypatch_test_files": 16,
     "canonical_monkeypatch_test_files": 2
   },
   "external_evidence": {
@@ -70,7 +70,10 @@
       ],
       "repository_monkeypatch_consumers": {
         "root": [
-          "tests/test_aio_schema_contract.py"
+          "tests/test_aio_generation_migrations.py",
+          "tests/test_aio_generation_settings.py",
+          "tests/test_aio_schema_contract.py",
+          "tests/test_node_contracts.py"
         ],
         "canonical": [
           "tests/test_node_contracts.py",
@@ -165,6 +168,7 @@
       "repository_monkeypatch_consumers": {
         "root": [
           "tests/test_aio_conditioning.py",
+          "tests/test_aio_legacy_generation.py",
           "tests/test_aio_nodes.py",
           "tests/test_prompt_corrector.py",
           "tests/test_prompt_studio_regional.py",

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -16,7 +16,7 @@
   "expected_counts": {
     "production_consumer_slots": 22,
     "unique_production_modules": 15,
-    "root_monkeypatch_test_files": 16,
+    "root_monkeypatch_test_files": 0,
     "canonical_monkeypatch_test_files": 2
   },
   "external_evidence": {
@@ -69,12 +69,7 @@
         }
       ],
       "repository_monkeypatch_consumers": {
-        "root": [
-          "tests/test_aio_generation_migrations.py",
-          "tests/test_aio_generation_settings.py",
-          "tests/test_aio_schema_contract.py",
-          "tests/test_node_contracts.py"
-        ],
+        "root": [],
         "canonical": [
           "tests/test_node_contracts.py",
           "tests/test_sam3_nodes.py"
@@ -100,7 +95,7 @@
       "compatibility_classification": "provider_owned",
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
-      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
       "root_removal_gate": "E-07b provider parity and repository root-patch migration, then #184 B-11c29a",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29a"
@@ -166,14 +161,7 @@
         }
       ],
       "repository_monkeypatch_consumers": {
-        "root": [
-          "tests/test_aio_conditioning.py",
-          "tests/test_aio_legacy_generation.py",
-          "tests/test_aio_nodes.py",
-          "tests/test_prompt_corrector.py",
-          "tests/test_prompt_studio_regional.py",
-          "tests/test_sam3_nodes.py"
-        ],
+        "root": [],
         "canonical": []
       },
       "confirmed_external_consumers": [],
@@ -198,7 +186,7 @@
       "compatibility_classification": "pure_helper_with_provider_input",
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
-      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
       "root_removal_gate": "E-07b injected provider lookup parity and repository root-patch migration, then #184 B-11c29d",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29d"
@@ -257,18 +245,7 @@
         }
       ],
       "repository_monkeypatch_consumers": {
-        "root": [
-          "tests/test_aio_model_preparation.py",
-          "tests/test_aio_nodes.py",
-          "tests/test_aio_output.py",
-          "tests/test_aio_preview.py",
-          "tests/test_aio_resources.py",
-          "tests/test_aio_sampling.py",
-          "tests/test_comfy_adapters.py",
-          "tests/test_node_contracts.py",
-          "tests/test_prompt_corrector.py",
-          "tests/test_sam3_nodes.py"
-        ],
+        "root": [],
         "canonical": []
       },
       "confirmed_external_consumers": [],
@@ -292,7 +269,7 @@
       "compatibility_classification": "provider_owned",
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
-      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
       "root_removal_gate": "E-07b fake-provider migration and lookup-order parity, then #184 B-11c29b",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29b"
@@ -321,9 +298,7 @@
         }
       ],
       "repository_monkeypatch_consumers": {
-        "root": [
-          "tests/test_sam3_nodes.py"
-        ],
+        "root": [],
         "canonical": []
       },
       "confirmed_external_consumers": [],
@@ -344,7 +319,7 @@
       "compatibility_classification": "provider_owned",
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
-      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
       "root_removal_gate": "E-07b direct-mapping parity and SAM3 test injection, then #184 B-11c29b",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29b"
@@ -401,7 +376,7 @@
       "compatibility_classification": "provider_owned",
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
-      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
       "root_removal_gate": "E-07b provider parity with no new root-patch dependency, then #184 B-11c29b",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29b"
@@ -448,9 +423,7 @@
         }
       ],
       "repository_monkeypatch_consumers": {
-        "root": [
-          "tests/test_aio_model_preparation.py"
-        ],
+        "root": [],
         "canonical": []
       },
       "confirmed_external_consumers": [],
@@ -473,7 +446,7 @@
       "compatibility_classification": "pure_helper_with_provider_input",
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
-      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
       "root_removal_gate": "E-07b injected lookup and exact error parity, then #184 B-11c29c",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29c"
@@ -535,12 +508,7 @@
         }
       ],
       "repository_monkeypatch_consumers": {
-        "root": [
-          "tests/test_aio_model_preparation.py",
-          "tests/test_aio_nodes.py",
-          "tests/test_aio_output.py",
-          "tests/test_aio_sampling.py"
-        ],
+        "root": [],
         "canonical": []
       },
       "confirmed_external_consumers": [],
@@ -561,7 +529,7 @@
       "compatibility_classification": "pure_helper_with_provider_input",
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
-      "replacement_mechanism": "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+      "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
       "root_removal_gate": "E-07b injected lookup and exact error parity, then #184 B-11c29c",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29c"
@@ -625,7 +593,7 @@
         "easyuse_anima/infrastructure/comfy/wiring.py"
       ],
       "production_symbols": [
-        "resolve_comfy_host_helper(name: str, fallback: Callable[[str], Any]) -> Callable[..., Any]"
+        "resolve_comfy_host_helper(name: str, fallback: Callable[[str], Any]) -> Any"
       ],
       "test_files": [
         "tests/comfy_host_fakes.py",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -39433,9 +39433,9 @@
       },
       {
         "is_package": false,
-        "loc": 49,
+        "loc": 65,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
-        "normalized_git_blob_sha1": "65aa1bf32681dd112005b034f308973e024ea912",
+        "normalized_git_blob_sha1": "e967ae92154c7a44c35a9a1b64c1dfdca056779e",
         "path": "easyuse_anima/infrastructure/comfy/wiring.py",
         "top_level": {
           "class_count": 0,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8258,6 +8258,146 @@
         "requested": "__future__",
         "role": "ordinary",
         "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Callable",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "name": "Callable",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "partial",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "functools:partial",
+        "kind": "static_from",
+        "line": 6,
+        "name": "partial",
+        "optional": false,
+        "requested": "functools",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Any",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 7,
+        "name": "Any",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "get_runtime",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "...runtime:get_runtime",
+        "kind": "static_from",
+        "line": 9,
+        "name": "get_runtime",
+        "optional": false,
+        "requested": "...runtime",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "target": "easyuse_anima/runtime.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_require_any_custom_node_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".capabilities:_require_any_custom_node_class",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_require_any_custom_node_class",
+        "optional": false,
+        "requested": ".capabilities",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_require_custom_node_class",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".capabilities:_require_custom_node_class",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_require_custom_node_class",
+        "optional": false,
+        "requested": ".capabilities",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_encode_with_comfy_clip",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".invocation:_encode_with_comfy_clip",
+        "kind": "static_from",
+        "line": 14,
+        "name": "_encode_with_comfy_clip",
+        "optional": false,
+        "requested": ".invocation",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
         "source": "easyuse_anima/lora/metadata.py"
       },
       {
@@ -22161,6 +22301,37 @@
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
       },
       {
+        "alias": "_resolve_comfy_host_helper",
+        "bound_name": "_resolve_comfy_host_helper",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_comfy_host_helper",
+          "target": "easyuse_anima/infrastructure/comfy/wiring.py",
+          "try_line": 9
+        },
+        "conditional": true,
+        "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 427,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": ".easyuse_anima.infrastructure.comfy.wiring",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
         "alias": "_adapter_comfy_clip_loader_types",
         "bound_name": "_adapter_comfy_clip_loader_types",
         "branch_context": [
@@ -22182,7 +22353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 427,
+        "line": 430,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22213,7 +22384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 430,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22244,7 +22415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 430,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22275,7 +22446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 430,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22306,7 +22477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 427,
+        "line": 430,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22337,7 +22508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 435,
+        "line": 438,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22368,7 +22539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 435,
+        "line": 438,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22399,7 +22570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 439,
+        "line": 442,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22430,7 +22601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 443,
+        "line": 446,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22461,7 +22632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 443,
+        "line": 446,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22492,7 +22663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 443,
+        "line": 446,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22523,7 +22694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 448,
+        "line": 451,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22554,7 +22725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 448,
+        "line": 451,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22585,7 +22756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 448,
+        "line": 451,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22616,7 +22787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 448,
+        "line": 451,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22647,7 +22818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 448,
+        "line": 451,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22678,7 +22849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 455,
+        "line": 458,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22709,7 +22880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 455,
+        "line": 458,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22740,7 +22911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 455,
+        "line": 458,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22771,7 +22942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 460,
+        "line": 463,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22802,7 +22973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 460,
+        "line": 463,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22833,7 +23004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 460,
+        "line": 463,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22864,7 +23035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22895,7 +23066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22926,7 +23097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22957,7 +23128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22988,7 +23159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 478,
+        "line": 481,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23019,7 +23190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 501,
+        "line": 504,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23050,7 +23221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 501,
+        "line": 504,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23081,7 +23252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 505,
+        "line": 508,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23112,7 +23283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 505,
+        "line": 508,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23143,7 +23314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23174,7 +23345,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23205,7 +23376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23236,7 +23407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23267,7 +23438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23298,7 +23469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23329,7 +23500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23360,7 +23531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23391,7 +23562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23422,7 +23593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23453,7 +23624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23484,7 +23655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23515,7 +23686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23546,7 +23717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23577,7 +23748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 510,
+        "line": 513,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23608,7 +23779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23639,7 +23810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23670,7 +23841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23701,7 +23872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23732,7 +23903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23763,7 +23934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23794,7 +23965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23825,7 +23996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 527,
+        "line": 530,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23856,7 +24027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23887,7 +24058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 537,
+        "line": 540,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23918,7 +24089,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 541,
+        "line": 544,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23949,7 +24120,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 541,
+        "line": 544,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23980,7 +24151,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 542,
+        "line": 545,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24011,7 +24182,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 543,
+        "line": 546,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24042,7 +24213,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 543,
+        "line": 546,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24073,7 +24244,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 543,
+        "line": 546,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24104,7 +24275,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 548,
+        "line": 551,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24135,7 +24306,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 548,
+        "line": 551,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24166,7 +24337,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24197,7 +24368,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24228,7 +24399,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24259,7 +24430,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24290,7 +24461,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24321,7 +24492,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24352,7 +24523,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24383,7 +24554,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24414,7 +24585,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24445,7 +24616,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24476,7 +24647,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24507,7 +24678,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24538,7 +24709,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24569,7 +24740,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24600,7 +24771,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24631,7 +24802,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24662,7 +24833,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24693,7 +24864,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24724,7 +24895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 549,
+        "line": 552,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24743,7 +24914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24758,7 +24929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24777,7 +24948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24792,7 +24963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24811,7 +24982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24826,7 +24997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24845,7 +25016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24860,7 +25031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24879,7 +25050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24894,7 +25065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24913,7 +25084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24928,7 +25099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24947,7 +25118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24962,7 +25133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24981,7 +25152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -24996,7 +25167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25015,7 +25186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25030,7 +25201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25049,7 +25220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25064,7 +25235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25083,7 +25254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25098,7 +25269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25117,7 +25288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25132,7 +25303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25151,7 +25322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25166,7 +25337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25185,7 +25356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25200,7 +25371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25219,7 +25390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25234,7 +25405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25253,7 +25424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25268,7 +25439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25287,7 +25458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25302,7 +25473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25321,7 +25492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25336,7 +25507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25355,7 +25526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25370,7 +25541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25389,7 +25560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25404,7 +25575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25423,7 +25594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25438,7 +25609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25457,7 +25628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25472,7 +25643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25491,7 +25662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25506,7 +25677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25525,7 +25696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25540,7 +25711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25559,7 +25730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25574,7 +25745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25593,7 +25764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25608,7 +25779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25627,7 +25798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25642,7 +25813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25661,7 +25832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25676,7 +25847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25695,7 +25866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25710,7 +25881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25729,7 +25900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25744,7 +25915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25763,7 +25934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25778,7 +25949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25797,7 +25968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25812,7 +25983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25831,7 +26002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25846,7 +26017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 610,
+        "line": 613,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25865,7 +26036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25880,7 +26051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 613,
+        "line": 616,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25899,7 +26070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25914,7 +26085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 613,
+        "line": 616,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25933,7 +26104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25948,7 +26119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 616,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25967,7 +26138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -25982,7 +26153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26001,7 +26172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26016,7 +26187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26035,7 +26206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26050,7 +26221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26069,7 +26240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26084,7 +26255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26103,7 +26274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26118,7 +26289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26137,7 +26308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26152,7 +26323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26171,7 +26342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26186,7 +26357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26205,7 +26376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26220,7 +26391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26239,7 +26410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26254,7 +26425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26273,7 +26444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26288,7 +26459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26307,7 +26478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26322,7 +26493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26341,7 +26512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26356,7 +26527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26375,7 +26546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26390,7 +26561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26409,7 +26580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26424,7 +26595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26443,7 +26614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26458,7 +26629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26477,7 +26648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26492,7 +26663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26511,7 +26682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26526,7 +26697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26545,7 +26716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26560,7 +26731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26579,7 +26750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26594,7 +26765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26613,7 +26784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26628,7 +26799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26647,7 +26818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26662,7 +26833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26681,7 +26852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26696,7 +26867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26715,7 +26886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26730,7 +26901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26749,7 +26920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26764,7 +26935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26783,7 +26954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26798,7 +26969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26817,7 +26988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26832,7 +27003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26851,7 +27022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26866,7 +27037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26885,7 +27056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26900,7 +27071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26919,7 +27090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26934,7 +27105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26953,7 +27124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -26968,7 +27139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26987,7 +27158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27002,7 +27173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27021,7 +27192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27036,7 +27207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27055,7 +27226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27070,7 +27241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27089,7 +27260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27104,7 +27275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27123,7 +27294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27138,7 +27309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27157,7 +27328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27172,7 +27343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27191,7 +27362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27206,7 +27377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27225,7 +27396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27240,7 +27411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27259,7 +27430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27274,7 +27445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27293,7 +27464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27308,7 +27479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27327,7 +27498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27342,7 +27513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27361,7 +27532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27376,7 +27547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27395,7 +27566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27410,7 +27581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27429,7 +27600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27444,7 +27615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27463,7 +27634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27478,7 +27649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27497,7 +27668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27512,7 +27683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27531,7 +27702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27546,7 +27717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27565,7 +27736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27580,7 +27751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27599,7 +27770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27614,7 +27785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27633,7 +27804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27648,7 +27819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27667,7 +27838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27682,7 +27853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27701,7 +27872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27716,7 +27887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27735,7 +27906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27750,7 +27921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27769,7 +27940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27784,7 +27955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27803,7 +27974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27818,7 +27989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27837,7 +28008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27852,7 +28023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27871,7 +28042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27886,7 +28057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27905,7 +28076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27920,7 +28091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27939,7 +28110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27954,7 +28125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27973,7 +28144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -27988,7 +28159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28007,7 +28178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28022,7 +28193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28041,7 +28212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28056,7 +28227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28075,7 +28246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28090,7 +28261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28109,7 +28280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28124,7 +28295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28143,7 +28314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28158,7 +28329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28177,7 +28348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28192,7 +28363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28211,7 +28382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28226,7 +28397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28245,7 +28416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28260,7 +28431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28279,7 +28450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28294,7 +28465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28313,7 +28484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28328,7 +28499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28347,7 +28518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28362,7 +28533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 702,
+        "line": 705,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28381,7 +28552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28396,7 +28567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 702,
+        "line": 705,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28415,7 +28586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28430,7 +28601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 705,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28449,7 +28620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28464,7 +28635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28483,7 +28654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28498,7 +28669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28517,7 +28688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28532,7 +28703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28551,7 +28722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28566,7 +28737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28585,7 +28756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28600,7 +28771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28619,7 +28790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28634,7 +28805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 714,
+        "line": 717,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28653,7 +28824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28668,7 +28839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28687,7 +28858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28702,7 +28873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28721,7 +28892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28736,7 +28907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28755,7 +28926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28770,7 +28941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28789,7 +28960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28804,7 +28975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28823,7 +28994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28838,7 +29009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28857,7 +29028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28872,7 +29043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28891,7 +29062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28906,7 +29077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28925,7 +29096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28940,7 +29111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28959,7 +29130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -28974,7 +29145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28993,7 +29164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29008,7 +29179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29027,7 +29198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29042,7 +29213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29061,7 +29232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29076,7 +29247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29095,7 +29266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29110,7 +29281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29129,7 +29300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29144,7 +29315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29163,7 +29334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29178,7 +29349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29197,7 +29368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29212,7 +29383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29231,7 +29402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29246,7 +29417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29265,7 +29436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29280,7 +29451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29299,7 +29470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29314,7 +29485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29333,7 +29504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29348,7 +29519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29367,7 +29538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29382,7 +29553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29401,7 +29572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29416,7 +29587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29435,7 +29606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29450,7 +29621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29469,7 +29640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29484,7 +29655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29503,7 +29674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29518,7 +29689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29537,7 +29708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29552,7 +29723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29571,7 +29742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29586,7 +29757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29605,7 +29776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29620,7 +29791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29639,7 +29810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29654,7 +29825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29673,7 +29844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29688,7 +29859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29707,7 +29878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29722,7 +29893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29741,7 +29912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29756,7 +29927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29775,7 +29946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29790,7 +29961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29809,7 +29980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29824,7 +29995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29843,7 +30014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29858,7 +30029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29877,7 +30048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29892,7 +30063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29911,7 +30082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29926,7 +30097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29945,7 +30116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29960,7 +30131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29979,7 +30150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -29994,7 +30165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30013,7 +30184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30028,7 +30199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30047,7 +30218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30062,7 +30233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30081,7 +30252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30096,7 +30267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30115,7 +30286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30130,7 +30301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30149,7 +30320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30164,7 +30335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30183,7 +30354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30198,7 +30369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30217,7 +30388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30232,7 +30403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30251,7 +30422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30266,7 +30437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30285,7 +30456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30300,7 +30471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30319,7 +30490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30334,7 +30505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30353,7 +30524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30368,7 +30539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30387,7 +30558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30402,7 +30573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30421,7 +30592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30436,7 +30607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30455,7 +30626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30470,7 +30641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30489,7 +30660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30504,7 +30675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30523,7 +30694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30538,7 +30709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30557,7 +30728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30572,7 +30743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30591,7 +30762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30606,7 +30777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30625,7 +30796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30640,7 +30811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30659,7 +30830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30674,7 +30845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30693,7 +30864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30708,7 +30879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30727,7 +30898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30742,7 +30913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30761,7 +30932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30776,7 +30947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30795,7 +30966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30810,7 +30981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30829,7 +31000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30844,7 +31015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30863,7 +31034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30878,7 +31049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30897,7 +31068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30912,7 +31083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30931,7 +31102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30946,7 +31117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30965,7 +31136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -30980,7 +31151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30999,7 +31170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31014,7 +31185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31033,7 +31204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31048,7 +31219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31067,7 +31238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31082,7 +31253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31101,7 +31272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31116,7 +31287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31135,7 +31306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31150,7 +31321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31169,7 +31340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31184,7 +31355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31203,7 +31374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31218,7 +31389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31237,7 +31408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31252,7 +31423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31271,7 +31442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31286,7 +31457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31305,7 +31476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31320,7 +31491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31339,7 +31510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31354,7 +31525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31373,7 +31544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31388,7 +31559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31407,7 +31578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31422,7 +31593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31441,7 +31612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31456,7 +31627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31475,7 +31646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31490,7 +31661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31509,7 +31680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31524,7 +31695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31543,7 +31714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31558,7 +31729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31577,7 +31748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31592,7 +31763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31611,7 +31782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31626,7 +31797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31645,7 +31816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31660,7 +31831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31679,7 +31850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31694,7 +31865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31713,7 +31884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31728,7 +31899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31747,7 +31918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31762,7 +31933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31781,7 +31952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31796,7 +31967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31815,7 +31986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31830,7 +32001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31849,7 +32020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31864,7 +32035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31883,7 +32054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31898,7 +32069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 919,
+        "line": 922,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31917,7 +32088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31932,7 +32103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 919,
+        "line": 922,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31951,7 +32122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -31966,7 +32137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 919,
+        "line": 922,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31985,7 +32156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32000,7 +32171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 924,
+        "line": 927,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32019,7 +32190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32034,7 +32205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 924,
+        "line": 927,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32053,7 +32224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32068,7 +32239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 924,
+        "line": 927,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32087,7 +32258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32102,7 +32273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32121,7 +32292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32136,7 +32307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32155,7 +32326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32170,7 +32341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32189,7 +32360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32204,7 +32375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32223,7 +32394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32238,7 +32409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32257,7 +32428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32272,7 +32443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32291,7 +32462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32306,7 +32477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32325,7 +32496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32340,7 +32511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 939,
+        "line": 942,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32359,7 +32530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32374,7 +32545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 939,
+        "line": 942,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32393,7 +32564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32408,7 +32579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 939,
+        "line": 942,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32427,7 +32598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32442,7 +32613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32461,7 +32632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32476,7 +32647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32495,7 +32666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32510,7 +32681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32529,7 +32700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32544,7 +32715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32563,7 +32734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32578,7 +32749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 963,
+        "line": 966,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32597,7 +32768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32612,7 +32783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 963,
+        "line": 966,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32631,7 +32802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32646,7 +32817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_comfy_max_resolution",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32665,7 +32836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32680,7 +32851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32699,7 +32870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32714,7 +32885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32733,7 +32904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32748,7 +32919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32767,7 +32938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32782,7 +32953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32801,7 +32972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32816,7 +32987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32835,7 +33006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32850,7 +33021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32869,7 +33040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32884,7 +33055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32903,7 +33074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32918,7 +33089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32937,7 +33108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32952,7 +33123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32971,7 +33142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -32986,7 +33157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33005,7 +33176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33020,7 +33191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33028,6 +33199,40 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": "_resolve_comfy_host_helper",
+        "bound_name": "_resolve_comfy_host_helper",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 573,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "_resolve_comfy_host_helper",
+          "target": "easyuse_anima/infrastructure/comfy/wiring.py",
+          "try_line": 9
+        },
+        "conditional": true,
+        "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 991,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "easyuse_anima.infrastructure.comfy.wiring",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "alias": "_adapter_comfy_clip_loader_types",
@@ -33039,7 +33244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33054,7 +33259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33073,7 +33278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33088,7 +33293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33107,7 +33312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33122,7 +33327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33141,7 +33346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33156,7 +33361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33175,7 +33380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33190,7 +33395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33209,7 +33414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33224,7 +33429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 996,
+        "line": 1002,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33243,7 +33448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33258,7 +33463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 996,
+        "line": 1002,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33277,7 +33482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33292,7 +33497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1006,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33311,7 +33516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33326,7 +33531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33345,7 +33550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33360,7 +33565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33379,7 +33584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33394,7 +33599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33413,7 +33618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33428,7 +33633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33447,7 +33652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33462,7 +33667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33481,7 +33686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33496,7 +33701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33515,7 +33720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33530,7 +33735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33549,7 +33754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33564,7 +33769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33583,7 +33788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33598,7 +33803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1022,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33617,7 +33822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33632,7 +33837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1022,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33651,7 +33856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33666,7 +33871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1022,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33685,7 +33890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33700,7 +33905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1027,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33719,7 +33924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33734,7 +33939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1027,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33753,7 +33958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33768,7 +33973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1027,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33787,7 +33992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33802,7 +34007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33821,7 +34026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33836,7 +34041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33855,7 +34060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33870,7 +34075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33889,7 +34094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33904,7 +34109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33923,7 +34128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33938,7 +34143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33957,7 +34162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -33972,7 +34177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1068,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33991,7 +34196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34006,7 +34211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1068,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34025,7 +34230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34040,7 +34245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1072,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34059,7 +34264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34074,7 +34279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1072,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34093,7 +34298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34108,7 +34313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34127,7 +34332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34142,7 +34347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34161,7 +34366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34176,7 +34381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34195,7 +34400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34210,7 +34415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34229,7 +34434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34244,7 +34449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34263,7 +34468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34278,7 +34483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34297,7 +34502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34312,7 +34517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34331,7 +34536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34346,7 +34551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34365,7 +34570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34380,7 +34585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34399,7 +34604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34414,7 +34619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34433,7 +34638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34448,7 +34653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34467,7 +34672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34482,7 +34687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34501,7 +34706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34516,7 +34721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34535,7 +34740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34550,7 +34755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34569,7 +34774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34584,7 +34789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34603,7 +34808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34618,7 +34823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34637,7 +34842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34652,7 +34857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34671,7 +34876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34686,7 +34891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34705,7 +34910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34720,7 +34925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34739,7 +34944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34754,7 +34959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34773,7 +34978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34788,7 +34993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34807,7 +35012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34822,7 +35027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34841,7 +35046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34856,7 +35061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34875,7 +35080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34890,7 +35095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1104,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34909,7 +35114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34924,7 +35129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1104,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34943,7 +35148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34958,7 +35163,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1108,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34977,7 +35182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -34992,7 +35197,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1108,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -35011,7 +35216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35026,7 +35231,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1109,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -35045,7 +35250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35060,7 +35265,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1110,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -35079,7 +35284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35094,7 +35299,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1110,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35113,7 +35318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35128,7 +35333,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1110,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35147,7 +35352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35162,7 +35367,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1115,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35181,7 +35386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35196,7 +35401,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1115,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35215,7 +35420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35230,7 +35435,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35249,7 +35454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35264,7 +35469,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35283,7 +35488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35298,7 +35503,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35317,7 +35522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35332,7 +35537,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35351,7 +35556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35366,7 +35571,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35385,7 +35590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35400,7 +35605,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35419,7 +35624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35434,7 +35639,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35453,7 +35658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35468,7 +35673,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35487,7 +35692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35502,7 +35707,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35521,7 +35726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35536,7 +35741,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35555,7 +35760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35570,7 +35775,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35589,7 +35794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35604,7 +35809,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35623,7 +35828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35638,7 +35843,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35657,7 +35862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35672,7 +35877,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35691,7 +35896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35706,7 +35911,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35725,7 +35930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35740,7 +35945,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35759,7 +35964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35774,7 +35979,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35793,7 +35998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35808,7 +36013,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35827,7 +36032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -35842,7 +36047,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35860,7 +36065,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1627
+            "line": 1633
           }
         ],
         "classification": "external",
@@ -35868,7 +36073,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1628,
+        "line": 1634,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35885,7 +36090,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1635
+            "line": 1641
           }
         ],
         "classification": "external",
@@ -35893,7 +36098,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1636,
+        "line": 1642,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -35910,7 +36115,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1643
+            "line": 1649
           }
         ],
         "classification": "external",
@@ -35918,7 +36123,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1644,
+        "line": 1650,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -37612,6 +37817,18 @@
         "to": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
+        "from": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "to": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "from": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "to": "easyuse_anima/runtime.py"
+      },
+      {
         "from": "easyuse_anima/lora/preset.py",
         "to": "easyuse_anima/common/values.py"
       },
@@ -37982,6 +38199,10 @@
       {
         "from": "nodes.py",
         "to": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "from": "nodes.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "nodes.py",
@@ -38410,6 +38631,12 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/infrastructure/comfy/wiring.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/lora/__init__.py"
         ]
       },
@@ -38638,7 +38865,7 @@
     ]
   },
   "inventory": {
-    "module_count": 85,
+    "module_count": 86,
     "modules": [
       {
         "is_package": true,
@@ -39205,6 +39432,18 @@
         }
       },
       {
+        "is_package": false,
+        "loc": 49,
+        "module": "easyuse_anima.infrastructure.comfy.wiring",
+        "normalized_git_blob_sha1": "65aa1bf32681dd112005b034f308973e024ea912",
+        "path": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 1,
+          "global_count": 1
+        }
+      },
+      {
         "is_package": true,
         "loc": 3,
         "module": "easyuse_anima.lora",
@@ -39602,9 +39841,9 @@
       },
       {
         "is_package": false,
-        "loc": 1864,
+        "loc": 1915,
         "module": "nodes",
-        "normalized_git_blob_sha1": "ddc55db1b1676a9aacd858dd36596ff2cd11f897",
+        "normalized_git_blob_sha1": "237571d35c003e7b9d9cc2a6fec8dcdf08aca61a",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -40968,7 +41207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -40977,7 +41216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40991,7 +41230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41000,7 +41239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41014,7 +41253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41023,7 +41262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41037,7 +41276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41046,7 +41285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41060,7 +41299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41069,7 +41308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41083,7 +41322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41092,7 +41331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41106,7 +41345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41115,7 +41354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41129,7 +41368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41138,7 +41377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 571,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41152,7 +41391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41161,7 +41400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41175,7 +41414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41184,7 +41423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41198,7 +41437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41207,7 +41446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41221,7 +41460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41230,7 +41469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41244,7 +41483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41253,7 +41492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41267,7 +41506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41276,7 +41515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41290,7 +41529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41299,7 +41538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41313,7 +41552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41322,7 +41561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 582,
+        "line": 585,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41336,7 +41575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41345,7 +41584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41359,7 +41598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41368,7 +41607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41382,7 +41621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41391,7 +41630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41405,7 +41644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41414,7 +41653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41428,7 +41667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41437,7 +41676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41451,7 +41690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41460,7 +41699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41474,7 +41713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41483,7 +41722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41497,7 +41736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41506,7 +41745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41520,7 +41759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41529,7 +41768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41543,7 +41782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41552,7 +41791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41566,7 +41805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41575,7 +41814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41589,7 +41828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41598,7 +41837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41612,7 +41851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41621,7 +41860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41635,7 +41874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41644,7 +41883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41658,7 +41897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41667,7 +41906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41681,7 +41920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41690,7 +41929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41704,7 +41943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41713,7 +41952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 610,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41727,7 +41966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41736,7 +41975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 613,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41750,7 +41989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41759,7 +41998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 613,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41773,7 +42012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41782,7 +42021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41796,7 +42035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41805,7 +42044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41819,7 +42058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41828,7 +42067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41842,7 +42081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41851,7 +42090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41865,7 +42104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41874,7 +42113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41888,7 +42127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41897,7 +42136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 618,
+        "line": 621,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41911,7 +42150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41920,7 +42159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41934,7 +42173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41943,7 +42182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41957,7 +42196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41966,7 +42205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41980,7 +42219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -41989,7 +42228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 625,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42003,7 +42242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42012,7 +42251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42026,7 +42265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42035,7 +42274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42049,7 +42288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42058,7 +42297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42072,7 +42311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42081,7 +42320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42095,7 +42334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42104,7 +42343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42118,7 +42357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42127,7 +42366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42141,7 +42380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42150,7 +42389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42164,7 +42403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42173,7 +42412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42187,7 +42426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42196,7 +42435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42210,7 +42449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42219,7 +42458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42233,7 +42472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42242,7 +42481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42256,7 +42495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42265,7 +42504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42279,7 +42518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42288,7 +42527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 631,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42302,7 +42541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42311,7 +42550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42325,7 +42564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42334,7 +42573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42348,7 +42587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42357,7 +42596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42371,7 +42610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42380,7 +42619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42394,7 +42633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42403,7 +42642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42417,7 +42656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42426,7 +42665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42440,7 +42679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42449,7 +42688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42463,7 +42702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42472,7 +42711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42486,7 +42725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42495,7 +42734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42509,7 +42748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42518,7 +42757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42532,7 +42771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42541,7 +42780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42555,7 +42794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42564,7 +42803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 646,
+        "line": 649,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42578,7 +42817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42587,7 +42826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42601,7 +42840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42610,7 +42849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42624,7 +42863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42633,7 +42872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42647,7 +42886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42656,7 +42895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42670,7 +42909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42679,7 +42918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42693,7 +42932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42702,7 +42941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42716,7 +42955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42725,7 +42964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42739,7 +42978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42748,7 +42987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42762,7 +43001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42771,7 +43010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42785,7 +43024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42794,7 +43033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 660,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42808,7 +43047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42817,7 +43056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42831,7 +43070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42840,7 +43079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42854,7 +43093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42863,7 +43102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42877,7 +43116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42886,7 +43125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42900,7 +43139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42909,7 +43148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42923,7 +43162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42932,7 +43171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42946,7 +43185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42955,7 +43194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42969,7 +43208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -42978,7 +43217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42992,7 +43231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43001,7 +43240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43015,7 +43254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43024,7 +43263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 672,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43038,7 +43277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43047,7 +43286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43061,7 +43300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43070,7 +43309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43084,7 +43323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43093,7 +43332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43107,7 +43346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43116,7 +43355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43130,7 +43369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43139,7 +43378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43153,7 +43392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43162,7 +43401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43176,7 +43415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43185,7 +43424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43199,7 +43438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43208,7 +43447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43222,7 +43461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43231,7 +43470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43245,7 +43484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43254,7 +43493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43268,7 +43507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43277,7 +43516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43291,7 +43530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43300,7 +43539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43314,7 +43553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43323,7 +43562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43337,7 +43576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43346,7 +43585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43360,7 +43599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43369,7 +43608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43383,7 +43622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43392,7 +43631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 684,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43406,7 +43645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43415,7 +43654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 702,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43429,7 +43668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43438,7 +43677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 702,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43452,7 +43691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43461,7 +43700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43475,7 +43714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43484,7 +43723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43498,7 +43737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43507,7 +43746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43521,7 +43760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43530,7 +43769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43544,7 +43783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43553,7 +43792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43567,7 +43806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43576,7 +43815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 707,
+        "line": 710,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43590,7 +43829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43599,7 +43838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 714,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43613,7 +43852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43622,7 +43861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43636,7 +43875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43645,7 +43884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43659,7 +43898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43668,7 +43907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43682,7 +43921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43691,7 +43930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 715,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43705,7 +43944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43714,7 +43953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43728,7 +43967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43737,7 +43976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43751,7 +43990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43760,7 +43999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43774,7 +44013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43783,7 +44022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43797,7 +44036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43806,7 +44045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43820,7 +44059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43829,7 +44068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43843,7 +44082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43852,7 +44091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43866,7 +44105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43875,7 +44114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43889,7 +44128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43898,7 +44137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43912,7 +44151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43921,7 +44160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 721,
+        "line": 724,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43935,7 +44174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43944,7 +44183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43958,7 +44197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43967,7 +44206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43981,7 +44220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -43990,7 +44229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44004,7 +44243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44013,7 +44252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44027,7 +44266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44036,7 +44275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44050,7 +44289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44059,7 +44298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44073,7 +44312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44082,7 +44321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 735,
+        "line": 738,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44096,7 +44335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44105,7 +44344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44119,7 +44358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44128,7 +44367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44142,7 +44381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44151,7 +44390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44165,7 +44404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44174,7 +44413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44188,7 +44427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44197,7 +44436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44211,7 +44450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44220,7 +44459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44234,7 +44473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44243,7 +44482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44257,7 +44496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44266,7 +44505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44280,7 +44519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44289,7 +44528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44303,7 +44542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44312,7 +44551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44326,7 +44565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44335,7 +44574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44349,7 +44588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44358,7 +44597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44372,7 +44611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44381,7 +44620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44395,7 +44634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44404,7 +44643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44418,7 +44657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44427,7 +44666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44441,7 +44680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44450,7 +44689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44464,7 +44703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44473,7 +44712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44487,7 +44726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44496,7 +44735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44510,7 +44749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44519,7 +44758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44533,7 +44772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44542,7 +44781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44556,7 +44795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44565,7 +44804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44579,7 +44818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44588,7 +44827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 753,
+        "line": 756,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44602,7 +44841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44611,7 +44850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44625,7 +44864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44634,7 +44873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44648,7 +44887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44657,7 +44896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44671,7 +44910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44680,7 +44919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44694,7 +44933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44703,7 +44942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44717,7 +44956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44726,7 +44965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44740,7 +44979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44749,7 +44988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44763,7 +45002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44772,7 +45011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44786,7 +45025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44795,7 +45034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44809,7 +45048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44818,7 +45057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44832,7 +45071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44841,7 +45080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44855,7 +45094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44864,7 +45103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44878,7 +45117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44887,7 +45126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44901,7 +45140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44910,7 +45149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 789,
+        "line": 792,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44924,7 +45163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44933,7 +45172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44947,7 +45186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44956,7 +45195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44970,7 +45209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -44979,7 +45218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44993,7 +45232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45002,7 +45241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45016,7 +45255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45025,7 +45264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45039,7 +45278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45048,7 +45287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45062,7 +45301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45071,7 +45310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45085,7 +45324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45094,7 +45333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45108,7 +45347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45117,7 +45356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 817,
+        "line": 820,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45131,7 +45370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45140,7 +45379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45154,7 +45393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45163,7 +45402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45177,7 +45416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45186,7 +45425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45200,7 +45439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45209,7 +45448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45223,7 +45462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45232,7 +45471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45246,7 +45485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45255,7 +45494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45269,7 +45508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45278,7 +45517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45292,7 +45531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45301,7 +45540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45315,7 +45554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45324,7 +45563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45338,7 +45577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45347,7 +45586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45361,7 +45600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45370,7 +45609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45384,7 +45623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45393,7 +45632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45407,7 +45646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45416,7 +45655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45430,7 +45669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45439,7 +45678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45453,7 +45692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45462,7 +45701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45476,7 +45715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45485,7 +45724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45499,7 +45738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45508,7 +45747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45522,7 +45761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45531,7 +45770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45545,7 +45784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45554,7 +45793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45568,7 +45807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45577,7 +45816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45591,7 +45830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45600,7 +45839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45614,7 +45853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45623,7 +45862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45637,7 +45876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45646,7 +45885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45660,7 +45899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45669,7 +45908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45683,7 +45922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45692,7 +45931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 833,
+        "line": 836,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45706,7 +45945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45715,7 +45954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45729,7 +45968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45738,7 +45977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45752,7 +45991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45761,7 +46000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45775,7 +46014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45784,7 +46023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 913,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45798,7 +46037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45807,7 +46046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 919,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45821,7 +46060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45830,7 +46069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 919,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45844,7 +46083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45853,7 +46092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 919,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45867,7 +46106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45876,7 +46115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 924,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45890,7 +46129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45899,7 +46138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 924,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45913,7 +46152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45922,7 +46161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 924,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45936,7 +46175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45945,7 +46184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45959,7 +46198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45968,7 +46207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45982,7 +46221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -45991,7 +46230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46005,7 +46244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46014,7 +46253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46028,7 +46267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46037,7 +46276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46051,7 +46290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46060,7 +46299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46074,7 +46313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46083,7 +46322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 930,
+        "line": 933,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46097,7 +46336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46106,7 +46345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 939,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46120,7 +46359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46129,7 +46368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 939,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46143,7 +46382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46152,7 +46391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 939,
+        "line": 942,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46166,7 +46405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46175,7 +46414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46189,7 +46428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46198,7 +46437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46212,7 +46451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46221,7 +46460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46235,7 +46474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46244,7 +46483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 950,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46258,7 +46497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46267,7 +46506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 963,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46281,7 +46520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46290,7 +46529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 963,
+        "line": 966,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46304,7 +46543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46313,7 +46552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46327,7 +46566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46336,7 +46575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46350,7 +46589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46359,7 +46598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46373,7 +46612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46382,7 +46621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46396,7 +46635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46405,7 +46644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46419,7 +46658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46428,7 +46667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46442,7 +46681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46451,7 +46690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46465,7 +46704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46474,7 +46713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 971,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46488,7 +46727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46497,7 +46736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46511,7 +46750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46520,7 +46759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46534,7 +46773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46543,7 +46782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46557,7 +46796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46566,7 +46805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 982,
+        "line": 985,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46580,7 +46819,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
+            "kind": "try",
+            "line": 9
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 991,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46589,7 +46851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46603,7 +46865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46612,7 +46874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46626,7 +46888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46635,7 +46897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46649,7 +46911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46658,7 +46920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46672,7 +46934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46681,7 +46943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 988,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46695,7 +46957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46704,7 +46966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 996,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46718,7 +46980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46727,7 +46989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 996,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46741,7 +47003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46750,7 +47012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1000,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46764,7 +47026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46773,7 +47035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46787,7 +47049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46796,7 +47058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46810,7 +47072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46819,7 +47081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46833,7 +47095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46842,7 +47104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46856,7 +47118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46865,7 +47127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46879,7 +47141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46888,7 +47150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46902,7 +47164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46911,7 +47173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46925,7 +47187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46934,7 +47196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1009,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46948,7 +47210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46957,7 +47219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46971,7 +47233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -46980,7 +47242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46994,7 +47256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47003,7 +47265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1016,
+        "line": 1022,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47017,7 +47279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47026,7 +47288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47040,7 +47302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47049,7 +47311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47063,7 +47325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47072,7 +47334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1027,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47086,7 +47348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47095,7 +47357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47109,7 +47371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47118,7 +47380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47132,7 +47394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47141,7 +47403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47155,7 +47417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47164,7 +47426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47178,7 +47440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47187,7 +47449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1039,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47201,7 +47463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47210,7 +47472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47224,7 +47486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47233,7 +47495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47247,7 +47509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47256,7 +47518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47270,7 +47532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47279,7 +47541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1072,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47293,7 +47555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47302,7 +47564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47316,7 +47578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47325,7 +47587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47339,7 +47601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47348,7 +47610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47362,7 +47624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47371,7 +47633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47385,7 +47647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47394,7 +47656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47408,7 +47670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47417,7 +47679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47431,7 +47693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47440,7 +47702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47454,7 +47716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47463,7 +47725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47477,7 +47739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47486,7 +47748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47500,7 +47762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47509,7 +47771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47523,7 +47785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47532,7 +47794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47546,7 +47808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47555,7 +47817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47569,7 +47831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47578,7 +47840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47592,7 +47854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47601,7 +47863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47615,7 +47877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47624,7 +47886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1071,
+        "line": 1077,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47638,7 +47900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47647,7 +47909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47661,7 +47923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47670,7 +47932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47684,7 +47946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47693,7 +47955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47707,7 +47969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47716,7 +47978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47730,7 +47992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47739,7 +48001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47753,7 +48015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47762,7 +48024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47776,7 +48038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47785,7 +48047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47799,7 +48061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47808,7 +48070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1088,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47822,7 +48084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47831,7 +48093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47845,7 +48107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47854,7 +48116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47868,7 +48130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47877,7 +48139,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47891,7 +48153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47900,7 +48162,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47914,7 +48176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47923,7 +48185,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1109,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47937,7 +48199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47946,7 +48208,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47960,7 +48222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47969,7 +48231,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47983,7 +48245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -47992,7 +48254,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1110,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48006,7 +48268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48015,7 +48277,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48029,7 +48291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48038,7 +48300,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1115,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48052,7 +48314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48061,7 +48323,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48075,7 +48337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48084,7 +48346,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48098,7 +48360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48107,7 +48369,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48121,7 +48383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48130,7 +48392,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48144,7 +48406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48153,7 +48415,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48167,7 +48429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48176,7 +48438,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48190,7 +48452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48199,7 +48461,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48213,7 +48475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48222,7 +48484,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48236,7 +48498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48245,7 +48507,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48259,7 +48521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48268,7 +48530,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48282,7 +48544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48291,7 +48553,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48305,7 +48567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48314,7 +48576,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48328,7 +48590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48337,7 +48599,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48351,7 +48613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48360,7 +48622,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48374,7 +48636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48383,7 +48645,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48397,7 +48659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48406,7 +48668,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48420,7 +48682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48429,7 +48691,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48443,7 +48705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48452,7 +48714,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48466,7 +48728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 570,
+            "handler_line": 573,
             "kind": "try",
             "line": 9
           }
@@ -48475,7 +48737,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1116,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51177,6 +51439,50 @@
         "line": 3,
         "optional": false,
         "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Callable",
+        "kind": "static_from",
+        "line": 5,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "functools:partial",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Any",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 3,
+        "optional": false,
+        "role": "ordinary",
         "source": "easyuse_anima/lora/metadata.py"
       },
       {
@@ -52376,14 +52682,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1627
+            "line": 1633
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1628,
+        "line": 1634,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52395,14 +52701,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1635
+            "line": 1641
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1636,
+        "line": 1642,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52414,14 +52720,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1643
+            "line": 1649
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1644,
+        "line": 1650,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53815,14 +54121,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1627
+            "line": 1633
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1628,
+        "line": 1634,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53834,14 +54140,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1635
+            "line": 1641
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1636,
+        "line": 1642,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53853,14 +54159,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1643
+            "line": 1649
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1644,
+        "line": 1650,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54010,6 +54316,7 @@
       "easyuse_anima/infrastructure/comfy/invocation.py",
       "easyuse_anima/infrastructure/comfy/provider.py",
       "easyuse_anima/infrastructure/comfy/resources.py",
+      "easyuse_anima/infrastructure/comfy/wiring.py",
       "easyuse_anima/lora/__init__.py",
       "easyuse_anima/lora/metadata.py",
       "easyuse_anima/lora/preset.py",
@@ -54097,6 +54404,7 @@
       "easyuse_anima/infrastructure/comfy/invocation.py",
       "easyuse_anima/infrastructure/comfy/provider.py",
       "easyuse_anima/infrastructure/comfy/resources.py",
+      "easyuse_anima/infrastructure/comfy/wiring.py",
       "easyuse_anima/lora/__init__.py",
       "easyuse_anima/lora/metadata.py",
       "easyuse_anima/lora/preset.py",
@@ -55334,7 +55642,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1132,
+        "line": 1138,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55343,7 +55651,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1760,
+        "line": 1766,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55352,7 +55660,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1763,
+        "line": 1769,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55361,7 +55669,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1766,
+        "line": 1775,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55370,7 +55678,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1769,
+        "line": 1781,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55379,7 +55687,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1772,
+        "line": 1784,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55388,7 +55696,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1775,
+        "line": 1787,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55397,7 +55705,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1778,
+        "line": 1793,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55406,7 +55714,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1781,
+        "line": 1799,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55415,7 +55723,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1784,
+        "line": 1805,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55424,7 +55732,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1787,
+        "line": 1811,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55433,7 +55741,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1790,
+        "line": 1817,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55442,7 +55750,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1793,
+        "line": 1823,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55451,7 +55759,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1796,
+        "line": 1829,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55460,7 +55768,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1799,
+        "line": 1835,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55469,7 +55777,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1802,
+        "line": 1841,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55478,7 +55786,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1805,
+        "line": 1844,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55487,7 +55795,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1809,
+        "line": 1851,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55496,7 +55804,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1812,
+        "line": 1854,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55505,7 +55813,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1816,
+        "line": 1858,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55514,7 +55822,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1819,
+        "line": 1861,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55523,7 +55831,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1823,
+        "line": 1868,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55532,7 +55840,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1826,
+        "line": 1874,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55541,7 +55849,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1829,
+        "line": 1880,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55550,7 +55858,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1832,
+        "line": 1883,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55559,7 +55867,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1835,
+        "line": 1886,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55568,7 +55876,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1838,
+        "line": 1889,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55577,7 +55885,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1845,
+        "line": 1896,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55586,7 +55894,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1851,
+        "line": 1902,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55595,7 +55903,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1856,
+        "line": 1907,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55604,7 +55912,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1860,
+        "line": 1911,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56118,13 +56426,13 @@
       },
       {
         "kind": "dict",
-        "line": 1194,
+        "line": 1200,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1183,
+        "line": 1189,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -2806,6 +2806,34 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.wiring:transitional_private_seam",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_resolve_comfy_host_helper": "resolve_comfy_host_helper"
+      },
+      "classification": "transitional_private_seam",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.infrastructure.comfy.wiring",
+      "target_state": "canonical",
+      "identity_requirement": "required",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.infrastructure.comfy.wiring",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "nodes.py residual runtime"
+      ],
+      "evidence": [
+        "AST:nodes.py direct runtime load"
+      ],
+      "removal_gates": [
+        "canonical production consumer migration",
+        "focused monkeypatch and identity contract review",
+        "separate B-10b or B-11 rollback unit"
+      ],
+      "lifecycle_state": "transitional"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.lora.metadata:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -93,7 +93,7 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 300,
+    "nodes_canonical_bindings": 301,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,

--- a/tests/test_aio_conditioning.py
+++ b/tests/test_aio_conditioning.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import nodes
 from easyuse_anima.aio import conditioning
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class AIOConditioningMoveTests(unittest.TestCase):
@@ -20,7 +21,7 @@ class AIOConditioningMoveTests(unittest.TestCase):
     def test_full_mode_preserves_original_conditioning_identity(self):
         positive = object()
         negative = object()
-        with patch.object(nodes, "_encode_with_comfy_clip") as encode:
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip") as encode:
             result = conditioning._aio_usdu_conditioning(
                 "clip",
                 positive,
@@ -74,7 +75,11 @@ class AIOConditioningMoveTests(unittest.TestCase):
             encoded.append(text)
             return f"encoded:{text}"
 
-        with patch.object(nodes, "_encode_with_comfy_clip", side_effect=encode):
+        with patch_comfy_helper(
+            nodes,
+            "_encode_with_comfy_clip",
+            side_effect=encode,
+        ):
             result = conditioning._aio_usdu_conditioning(
                 "clip",
                 "original-positive",
@@ -104,12 +109,16 @@ class AIOConditioningMoveTests(unittest.TestCase):
 
         def first_encode(_clip, text):
             calls.append(("first", text))
-            nodes._encode_with_comfy_clip = replacement_encode
+            encode.side_effect = replacement_encode
             return f"first:{text}"
 
         with (
             patch.object(nodes, "_aio_usdu_prompt_without_general", return_value=("", False)),
-            patch.object(nodes, "_encode_with_comfy_clip", side_effect=first_encode),
+            patch_comfy_helper(
+                nodes,
+                "_encode_with_comfy_clip",
+                side_effect=first_encode,
+            ) as encode,
         ):
             result = conditioning._aio_usdu_conditioning(
                 "clip",

--- a/tests/test_aio_generation_migrations.py
+++ b/tests/test_aio_generation_migrations.py
@@ -19,6 +19,7 @@ from easyuse_anima.aio.generation_migrations import (
 from easyuse_anima.aio.generation_settings import (
     migrate_normalize_and_round_trip_aio_generation_settings,
 )
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 def _payload(version: int = 1) -> dict[str, object]:
@@ -161,9 +162,15 @@ class AIOGenerationMigrationTests(unittest.TestCase):
             "_comfy_sampler_names": lambda: ["euler"],
             "_comfy_scheduler_names": lambda: ["simple"],
             "_impact_scheduler_names": lambda: ["sgm_uniform"],
-            "_comfy_max_resolution": lambda: 16384,
         }
-        with patch.multiple(nodes, **capabilities):
+        with (
+            patch.multiple(nodes, **capabilities),
+            patch_comfy_helper(
+                nodes,
+                "_comfy_max_resolution",
+                return_value=16384,
+            ),
+        ):
             expected = nodes._normalize_aio_generation_settings(legacy)
             actual = migrate_normalize_and_round_trip_aio_generation_settings(
                 legacy,
@@ -173,7 +180,14 @@ class AIOGenerationMigrationTests(unittest.TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(legacy, legacy_before)
 
-        with patch.multiple(nodes, **capabilities):
+        with (
+            patch.multiple(nodes, **capabilities),
+            patch_comfy_helper(
+                nodes,
+                "_comfy_max_resolution",
+                return_value=16384,
+            ),
+        ):
             current_runtime = nodes._normalize_aio_generation_settings(
                 {"schema": AIO_GENERATION_SETTINGS_SCHEMA, "version": 2}
             )

--- a/tests/test_aio_generation_settings.py
+++ b/tests/test_aio_generation_settings.py
@@ -22,6 +22,7 @@ from easyuse_anima.aio.generation_settings import (
     _aio_generation_config_from_dict,
     _aio_generation_config_to_dict,
 )
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,12 +37,18 @@ def _deterministic_capabilities(
     impact_schedulers=("sgm_uniform",),
     max_resolution=16384,
 ):
-    with patch.multiple(
-        nodes,
-        _comfy_sampler_names=lambda: list(samplers),
-        _comfy_scheduler_names=lambda: list(schedulers),
-        _impact_scheduler_names=lambda: list(impact_schedulers),
-        _comfy_max_resolution=lambda: max_resolution,
+    with (
+        patch.multiple(
+            nodes,
+            _comfy_sampler_names=lambda: list(samplers),
+            _comfy_scheduler_names=lambda: list(schedulers),
+            _impact_scheduler_names=lambda: list(impact_schedulers),
+        ),
+        patch_comfy_helper(
+            nodes,
+            "_comfy_max_resolution",
+            return_value=max_resolution,
+        ),
     ):
         yield
 

--- a/tests/test_aio_legacy_generation.py
+++ b/tests/test_aio_legacy_generation.py
@@ -10,10 +10,18 @@ from unittest.mock import patch
 
 import nodes
 from easyuse_anima.aio import legacy_generation
+from tests.comfy_host_fakes import patch_comfy_helper
 from tests.test_node_contracts import _loaded_package_entrypoint
 
 ROOT = Path(__file__).resolve().parents[1]
 TRACE_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "aio_legacy_execution_trace.v1.json"
+
+
+def _production_resolver(name):
+    return nodes._resolve_comfy_host_helper(
+        name,
+        lambda fallback_name: getattr(nodes, fallback_name),
+    )
 
 
 class _Token:
@@ -122,7 +130,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], base_latent)
@@ -273,7 +281,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertEqual(
@@ -373,7 +381,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertEqual(
@@ -426,7 +434,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 )
             finally:
                 legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=lambda name: getattr(nodes, name)
+                    resolve_helper=_production_resolver
                 )
             return result, trace
 
@@ -561,7 +569,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], face_image)
@@ -640,7 +648,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 )
             finally:
                 legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=lambda name: getattr(nodes, name)
+                    resolve_helper=_production_resolver
                 )
             return trace
 
@@ -742,7 +750,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], image)
@@ -882,7 +890,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], detailed_image)
@@ -1038,7 +1046,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 )
             finally:
                 legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=lambda name: getattr(nodes, name)
+                    resolve_helper=_production_resolver
                 )
 
         planner_trace = []
@@ -1299,7 +1307,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], output)
@@ -1473,7 +1481,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 )
             finally:
                 legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=lambda name: getattr(nodes, name)
+                    resolve_helper=_production_resolver
                 )
 
         patch_trace = []
@@ -1638,7 +1646,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
             )
         finally:
             legacy_generation._bind_aio_legacy_generation_runtime(
-                resolve_helper=lambda name: getattr(nodes, name)
+                resolve_helper=_production_resolver
             )
 
         self.assertIs(result[0], output)
@@ -1713,7 +1721,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 )
             finally:
                 legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=lambda name: getattr(nodes, name)
+                    resolve_helper=_production_resolver
                 )
 
         first_provider_trace = []
@@ -1885,7 +1893,7 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
                 )
             finally:
                 legacy_generation._bind_aio_legacy_generation_runtime(
-                    resolve_helper=lambda name: getattr(nodes, name)
+                    resolve_helper=_production_resolver
                 )
 
         disabled_trace = []
@@ -2307,53 +2315,65 @@ class AIOGeneratorLegacyMoveTests(unittest.TestCase):
         def unexpected(*args, **kwargs):
             self.fail("standalone Mod Guidance must remain lazy for the fixture cases")
 
-        with patch.multiple(
-            nodes,
-            _require_easy_use_anima_input=require,
-            _normalize_aio_generation_settings=normalize_settings,
-            _resolve_aio_runtime_seed=resolve_seed,
-            _load_aio_resources_from_input_context=load_resources,
-            _apply_aio_lora_stack=apply_lora,
-            _apply_aio_model_patches=apply_model_patches,
-            _normalize_prompt_data=phase("normalize_prompt", context["prompt_data"]),
-            _advanced_outputs_from_prompt_data=advanced_outputs,
-            _encode_prompt_data_positive_conditioning=phase(
-                "encode_positive", "positive-conditioning"
+        with (
+            patch.multiple(
+                nodes,
+                _require_easy_use_anima_input=require,
+                _normalize_aio_generation_settings=normalize_settings,
+                _resolve_aio_runtime_seed=resolve_seed,
+                _load_aio_resources_from_input_context=load_resources,
+                _apply_aio_lora_stack=apply_lora,
+                _apply_aio_model_patches=apply_model_patches,
+                _normalize_prompt_data=phase(
+                    "normalize_prompt",
+                    context["prompt_data"],
+                ),
+                _advanced_outputs_from_prompt_data=advanced_outputs,
+                _encode_prompt_data_positive_conditioning=phase(
+                    "encode_positive",
+                    "positive-conditioning",
+                ),
+                _as_bool=lambda value, default: bool(value),
+                _aio_detailer_has_enabled_targets=phase("detailer_enabled", False),
+                _normalize_anima_mod_guidance_profile=phase("normalize_profile", "off"),
+                _resolve_anima_mod_guidance_enabled=phase("resolve_guidance", False),
+                _aio_highres_effective_backend=phase(
+                    "resolve_highres_backend",
+                    "comfy_ksampler",
+                ),
+                _apply_spectrum_anima_mod_guidance=unexpected,
+                _apply_aio_spectrum_model_patches_for_comfy_sampler=apply_spectrum_model,
+                _single_value=lambda value: value,
+                random=_Random,
+                _aio_first_pass_cache_key=cache_key,
+                _get_aio_first_pass_cache=phase("get_cache", None),
+                _generate_empty_latent_with_comfy=phase("empty_latent", "empty-latent"),
+                _sample_latent_with_aio_backend=phase("sample", "sampled-latent"),
+                _decode_latent_with_comfy=phase("decode", "decoded-image"),
+                _resize_image_to_size_if_needed=phase(
+                    "resize_first_pass",
+                    ("decoded-image", False),
+                ),
+                _put_aio_first_pass_cache=phase("put_cache", None),
+                _run_aio_highres_stage=run_highres,
+                _run_aio_detailer_stage=run_detailer,
+                _run_aio_upscale_stage=run_upscale,
+                _image_tensor_size=image_size,
+                _encode_image_with_comfy_vae=encode_image,
+                _run_aio_postprocess_stage=run_postprocess,
+                _cleanup_aio_ephemeral_model=cleanup,
+                _save_aio_temp_preview_image=save_temp,
+                _send_aio_preview_event=send_preview,
+                _aio_save_filename_prefix=save_prefix,
+                _save_image_with_comfy=save_comfy,
+                _tag_aio_preview_images=tag_images,
+                _prompt_data_json_safe=copy.deepcopy,
             ),
-            _encode_with_comfy_clip=phase("encode_negative", "negative-conditioning"),
-            _as_bool=lambda value, default: bool(value),
-            _aio_detailer_has_enabled_targets=phase("detailer_enabled", False),
-            _normalize_anima_mod_guidance_profile=phase("normalize_profile", "off"),
-            _resolve_anima_mod_guidance_enabled=phase("resolve_guidance", False),
-            _aio_highres_effective_backend=phase(
-                "resolve_highres_backend", "comfy_ksampler"
+            patch_comfy_helper(
+                nodes,
+                "_encode_with_comfy_clip",
+                phase("encode_negative", "negative-conditioning"),
             ),
-            _apply_spectrum_anima_mod_guidance=unexpected,
-            _apply_aio_spectrum_model_patches_for_comfy_sampler=apply_spectrum_model,
-            _single_value=lambda value: value,
-            random=_Random,
-            _aio_first_pass_cache_key=cache_key,
-            _get_aio_first_pass_cache=phase("get_cache", None),
-            _generate_empty_latent_with_comfy=phase("empty_latent", "empty-latent"),
-            _sample_latent_with_aio_backend=phase("sample", "sampled-latent"),
-            _decode_latent_with_comfy=phase("decode", "decoded-image"),
-            _resize_image_to_size_if_needed=phase(
-                "resize_first_pass", ("decoded-image", False)
-            ),
-            _put_aio_first_pass_cache=phase("put_cache", None),
-            _run_aio_highres_stage=run_highres,
-            _run_aio_detailer_stage=run_detailer,
-            _run_aio_upscale_stage=run_upscale,
-            _image_tensor_size=image_size,
-            _encode_image_with_comfy_vae=encode_image,
-            _run_aio_postprocess_stage=run_postprocess,
-            _cleanup_aio_ephemeral_model=cleanup,
-            _save_aio_temp_preview_image=save_temp,
-            _send_aio_preview_event=send_preview,
-            _aio_save_filename_prefix=save_prefix,
-            _save_image_with_comfy=save_comfy,
-            _tag_aio_preview_images=tag_images,
-            _prompt_data_json_safe=copy.deepcopy,
         ):
             output = generator.generate(
                 context,

--- a/tests/test_aio_model_preparation.py
+++ b/tests/test_aio_model_preparation.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import nodes
 from easyuse_anima.aio import model_preparation
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class AIOModelPreparationMoveTests(unittest.TestCase):
@@ -52,7 +53,11 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
                 calls.append((model, clip, name, model_strength, clip_strength))
                 return f"{model}>{name}", f"{clip}>{name}"
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=LoraLoader):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=LoraLoader,
+        ):
             model, clip, applied = model_preparation._apply_aio_lora_stack(
                 "model", "clip", stack
             )
@@ -145,7 +150,11 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
             "PathchSageAttentionKJ": SageAttention,
             "TorchCompileModelAdvanced": TorchCompile,
         }
-        with patch.object(nodes, "_require_custom_node_class", side_effect=lambda node_id, *_: classes[node_id]):
+        with patch_comfy_helper(
+            nodes,
+            "_require_custom_node_class",
+            side_effect=lambda node_id: classes[node_id],
+        ):
             result = model_preparation._apply_aio_kj_model_patches(
                 "base",
                 {
@@ -284,8 +293,14 @@ class AIOModelPreparationMoveTests(unittest.TestCase):
     def test_disabled_spectrum_variants_preserve_model_identity(self):
         model = object()
         with (
-            patch.object(nodes, "_require_custom_node_class") as require_correction,
-            patch.object(nodes, "_require_any_custom_node_class") as require_forecast,
+            patch_comfy_helper(
+                nodes,
+                "_require_custom_node_class",
+            ) as require_correction,
+            patch_comfy_helper(
+                nodes,
+                "_require_any_custom_node_class",
+            ) as require_forecast,
         ):
             self.assertIs(
                 model_preparation._apply_aio_spectrum_correction_patch_for_comfy_sampler(

--- a/tests/test_aio_nodes.py
+++ b/tests/test_aio_nodes.py
@@ -8,7 +8,23 @@ from unittest.mock import patch
 import nodes
 from easyuse_anima.aio import first_pass_cache
 from easyuse_anima.nodes import aio_nodes
+from tests.comfy_host_fakes import (
+    FakeComfyHostProvider,
+    patch_comfy_helper,
+    use_fake_comfy_host,
+)
 from tests.test_node_contracts import _loaded_package_entrypoint
+
+
+_DEFAULT_COMFY_HOST = use_fake_comfy_host(nodes, FakeComfyHostProvider())
+
+
+def setUpModule():
+    _DEFAULT_COMFY_HOST.__enter__()
+
+
+def tearDownModule():
+    _DEFAULT_COMFY_HOST.__exit__(None, None, None)
 
 
 class AIONodeContractTests(unittest.TestCase):
@@ -876,7 +892,7 @@ class AIOSettingsStorageTests(unittest.TestCase):
 
 class AIOImageSaverDependencyTests(unittest.TestCase):
     def test_missing_image_saver_dependency_names_required_node_pack(self):
-        with patch.object(nodes, "_find_comfy_node_class", return_value=None):
+        with patch_comfy_helper(nodes, "_find_comfy_node_class", return_value=None):
             with self.assertRaisesRegex(RuntimeError, "ComfyUI-Image-Saver"):
                 nodes._save_image_with_image_saver(
                     images=None,
@@ -899,7 +915,11 @@ class AIOImageSaverDependencyTests(unittest.TestCase):
                 fetch_calls.append((username, model_name, version))
                 return ("ABCDEF1234",)
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=FakeCivitaiHashFetcher):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=FakeCivitaiHashFetcher,
+        ):
             result = nodes._aio_image_saver_additional_hashes({
                 "additional_hashes": "Base:AAAAAAAA",
                 "additional_hash_bundles": [
@@ -927,7 +947,11 @@ class AIOImageSaverDependencyTests(unittest.TestCase):
             def get_autov3_hash(self, username, model_name, version=""):
                 return ("Error: API request failed with status 503",)
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=FakeCivitaiHashFetcher):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=FakeCivitaiHashFetcher,
+        ):
             with self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING") as logs:
                 result = nodes._aio_image_saver_additional_hashes({
                     "additional_hashes": "Base:AAAAAAAA",
@@ -949,7 +973,11 @@ class AIOImageSaverDependencyTests(unittest.TestCase):
             def get_autov3_hash(self, username, model_name, version=""):
                 raise RuntimeError("temporary upstream failure")
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=FakeCivitaiHashFetcher):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=FakeCivitaiHashFetcher,
+        ):
             with self.assertLogs("ComfyUI-EasyUseAnima", level="WARNING") as logs:
                 result = nodes._aio_image_saver_additional_hashes({
                     "additional_hashes": "Base:AAAAAAAA",
@@ -1010,7 +1038,11 @@ class AIOImageSaverDependencyTests(unittest.TestCase):
                 "Civitai Hash Fetcher (Image Saver)": FakeCivitaiHashFetcher,
             }.get(node_id)
 
-        with patch.object(nodes, "_find_comfy_node_class", side_effect=fake_find):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            side_effect=fake_find,
+        ):
             result = nodes._save_image_with_image_saver(
                 images="images",
                 save_settings=settings["save"],
@@ -1048,7 +1080,11 @@ class AIOImageSaverDependencyTests(unittest.TestCase):
                 calls.append(kwargs)
                 return {"ui": {"images": [{"filename": "preview.webp"}]}}
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=FakeImageSaver):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=FakeImageSaver,
+        ):
             nodes._save_image_with_image_saver(
                 images="images",
                 save_settings=nodes._normalize_aio_generation_settings("{}")["save"],
@@ -1085,7 +1121,11 @@ class AIOImageSaverDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=FakeImageSaver):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=FakeImageSaver,
+        ):
             nodes._save_image_with_image_saver(
                 images="images",
                 save_settings=settings["save"],
@@ -1129,7 +1169,11 @@ class AIOLoraStackTests(unittest.TestCase):
                 calls.append((model, clip, lora_name, strength_model, strength_clip))
                 return (f"{model}>{lora_name}", f"{clip}>{lora_name}")
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=FakeLoraLoader):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=FakeLoraLoader,
+        ):
             model, clip, applied = nodes._apply_aio_lora_stack(
                 "model",
                 "clip",
@@ -1185,7 +1229,11 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_find_comfy_node_class", side_effect=fake_find):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            side_effect=fake_find,
+        ):
             result = nodes._apply_aio_spectrum_model_patches_for_comfy_sampler(
                 "base_model",
                 "clip",
@@ -1224,7 +1272,11 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_find_comfy_node_class", side_effect=fake_find):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            side_effect=fake_find,
+        ):
             result = nodes._apply_aio_spectrum_model_patches_for_comfy_sampler(
                 "base_model",
                 "clip",
@@ -1248,7 +1300,7 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=None):
+        with patch_comfy_helper(nodes, "_find_comfy_node_class", return_value=None):
             with self.assertRaisesRegex(RuntimeError, "ComfyUI-Spectrum-KSampler"):
                 nodes._apply_aio_spectrum_model_patches_for_comfy_sampler(
                     "base_model",
@@ -1264,7 +1316,7 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=None):
+        with patch_comfy_helper(nodes, "_find_comfy_node_class", return_value=None):
             with self.assertRaisesRegex(RuntimeError, "ComfyUI-Spectrum-KSampler"):
                 nodes._sample_latent_with_aio_backend(
                     model=None,
@@ -1320,7 +1372,11 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_require_custom_node_class", return_value=LegacySpectrumAdvanced):
+        with patch_comfy_helper(
+            nodes,
+            "_require_custom_node_class",
+            return_value=LegacySpectrumAdvanced,
+        ):
             result = nodes._sample_latent_with_spectrum_mod_guidance_advanced(
                 "model",
                 "clip",
@@ -1392,7 +1448,11 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_require_custom_node_class", return_value=FakeSpectrumSPDKSampler):
+        with patch_comfy_helper(
+            nodes,
+            "_require_custom_node_class",
+            return_value=FakeSpectrumSPDKSampler,
+        ):
             result = nodes._sample_latent_with_spectrum_spd(
                 model="model",
                 sampler_settings=settings["sampler"],
@@ -1437,7 +1497,11 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_require_custom_node_class", return_value=LegacySpd):
+        with patch_comfy_helper(
+            nodes,
+            "_require_custom_node_class",
+            return_value=LegacySpd,
+        ):
             result = nodes._sample_latent_with_spectrum_spd(
                 "model",
                 settings["sampler"],
@@ -1470,7 +1534,11 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_require_custom_node_class", return_value=FakeAnimaDAVE):
+        with patch_comfy_helper(
+            nodes,
+            "_require_custom_node_class",
+            return_value=FakeAnimaDAVE,
+        ):
             result = nodes._apply_aio_anima_dave_patch("base_model", settings["model_patches"]["dave"])
 
         self.assertEqual(result, "dave_model")
@@ -1500,7 +1568,11 @@ class AIOSamplerDependencyTests(unittest.TestCase):
             },
         }))
 
-        with patch.object(nodes, "_require_custom_node_class", return_value=FakeAnimaSafePAG):
+        with patch_comfy_helper(
+            nodes,
+            "_require_custom_node_class",
+            return_value=FakeAnimaSafePAG,
+        ):
             result = nodes._apply_aio_safe_pag_patch("base_model", settings["model_patches"]["safe_pag"])
 
         self.assertEqual(result, "safe_pag_model")
@@ -2175,9 +2247,17 @@ class AIOFinalUpscaleStageTests(unittest.TestCase):
                 return (AIOFinalUpscaleStageTests._Image(1024, 1536),)
 
         with (
-            patch.object(nodes, "_require_custom_node_class", return_value=FakeUSDU) as require,
+            patch_comfy_helper(
+                nodes,
+                "_require_custom_node_class",
+                return_value=FakeUSDU,
+            ) as require,
             patch.object(nodes, "_load_upscale_model_with_comfy", return_value="upscale_model") as load_upscale,
-            patch.object(nodes, "_encode_with_comfy_clip", side_effect=lambda clip, prompt: f"encoded:{prompt}") as encode,
+            patch_comfy_helper(
+                nodes,
+                "_encode_with_comfy_clip",
+                side_effect=lambda clip, prompt: f"encoded:{prompt}",
+            ) as encode,
             patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="stage_model") as patch_stage,
             patch.object(nodes, "_cleanup_aio_ephemeral_model") as cleanup,
             self.assertLogs("ComfyUI-EasyUseAnima", level="INFO") as logs,
@@ -2265,7 +2345,11 @@ class AIOFinalUpscaleStageTests(unittest.TestCase):
 
         input_image = self._Image(512, 768)
         with (
-            patch.object(nodes, "_require_custom_node_class", side_effect=fake_require) as require,
+            patch_comfy_helper(
+                nodes,
+                "_require_custom_node_class",
+                side_effect=fake_require,
+            ) as require,
             patch.object(nodes, "_load_upscale_model_with_comfy") as load_upscale,
             patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as patch_stage,
         ):
@@ -2317,7 +2401,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
             patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
@@ -2344,7 +2428,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
             patch.object(nodes, "_decode_latent_with_comfy", return_value="undersized_image"),
@@ -2387,7 +2471,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
                     patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
                     patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
                     patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-                    patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+                    patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
                     patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
                     patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
                     patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="sampler_patch_model") as comfy_patch,
@@ -2434,7 +2518,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
             patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
@@ -2475,7 +2559,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", True, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model") as standalone_mod,
             patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler") as comfy_patch,
@@ -2544,7 +2628,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
             patch.object(nodes, "_decode_latent_with_comfy", return_value="first_image"),
@@ -2612,7 +2696,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
             patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
@@ -2680,7 +2764,11 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
                 ),
             ),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive") as encode_positive,
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative") as encode_negative,
+            patch_comfy_helper(
+                nodes,
+                "_encode_with_comfy_clip",
+                return_value="negative",
+            ) as encode_negative,
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_apply_spectrum_anima_mod_guidance", return_value="mod_guidance_model"),
             patch.object(nodes, "_apply_aio_spectrum_model_patches_for_comfy_sampler", return_value="sampler_patch_model"),
@@ -2725,7 +2813,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image") as empty_latent,
             patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent") as sample,
             patch.object(nodes, "_decode_latent_with_comfy", return_value="image") as decode,
@@ -2780,7 +2868,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
             patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),
@@ -2845,7 +2933,7 @@ class AIOGeneratorRuntimeTests(unittest.TestCase):
             patch.object(nodes, "_apply_aio_model_patches", return_value="patched_model"),
             patch.object(nodes, "_advanced_outputs_from_prompt_data", return_value=("p", "n", "q", "qn", False, False, "", "", 512, 768)),
             patch.object(nodes, "_encode_prompt_data_positive_conditioning", return_value="positive"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="negative"),
+            patch_comfy_helper(nodes, "_encode_with_comfy_clip", return_value="negative"),
             patch.object(nodes, "_generate_empty_latent_with_comfy", return_value="latent_image"),
             patch.object(nodes, "_sample_latent_with_aio_backend", return_value="latent"),
             patch.object(nodes, "_decode_latent_with_comfy", return_value="image"),

--- a/tests/test_aio_output.py
+++ b/tests/test_aio_output.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import nodes
 from easyuse_anima.aio import output
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class AIOOutputMoveTests(unittest.TestCase):
@@ -77,7 +78,11 @@ class AIOOutputMoveTests(unittest.TestCase):
             ]
         }
         with (
-            patch.object(nodes, "_require_custom_node_class", return_value=Fetcher) as require,
+            patch_comfy_helper(
+                nodes,
+                "_require_custom_node_class",
+                return_value=Fetcher,
+            ) as require,
             patch.object(nodes.logger, "warning") as warning,
         ):
             result = output._aio_image_saver_civitai_hash_fetcher_entries(settings)
@@ -92,7 +97,7 @@ class AIOOutputMoveTests(unittest.TestCase):
 
     def test_civitai_empty_and_hard_error_paths_keep_dependency_boundaries(self):
         require = Mock(side_effect=AssertionError("must not resolve dependency"))
-        with patch.object(nodes, "_require_custom_node_class", require):
+        with patch_comfy_helper(nodes, "_require_custom_node_class", require):
             self.assertEqual(
                 output._aio_image_saver_civitai_hash_fetcher_entries(
                     {"civitai_hash_fetchers": [{"enabled": False, "username": "u", "model_name": "m"}]}
@@ -105,7 +110,11 @@ class AIOOutputMoveTests(unittest.TestCase):
             def get_autov3_hash(self, *_args):
                 return ("unused",)
 
-        with patch.object(nodes, "_require_custom_node_class", return_value=Fetcher):
+        with patch_comfy_helper(
+            nodes,
+            "_require_custom_node_class",
+            return_value=Fetcher,
+        ):
             with self.assertRaisesRegex(RuntimeError, "both username and model_name"):
                 output._aio_image_saver_civitai_hash_fetcher_entries(
                     {"civitai_hash_fetchers": [{"enabled": True, "username": "u", "version": "v"}]}
@@ -148,7 +157,11 @@ class AIOOutputMoveTests(unittest.TestCase):
                 calls.append((args, kwargs))
                 return {"ui": {"images": ["saved"]}}
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=SaveImage) as find:
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=SaveImage,
+        ) as find:
             result = output._save_image_with_comfy(
                 "images", "", workflow_prompt="prompt", extra_pnginfo={"workflow": True}
             )
@@ -191,7 +204,11 @@ class AIOOutputMoveTests(unittest.TestCase):
         }
         seed = Mock(return_value=987654321)
         with (
-            patch.object(nodes, "_require_custom_node_class", return_value=ImageSaver),
+            patch_comfy_helper(
+                nodes,
+                "_require_custom_node_class",
+                return_value=ImageSaver,
+            ),
             patch.object(nodes, "_resolve_aio_runtime_seed", seed),
             patch.object(nodes, "_aio_prompt_with_lora_metadata", return_value="positive <lora:x:1>"),
             patch.object(nodes, "_aio_image_saver_additional_hashes", return_value="Base:A,Model:B"),

--- a/tests/test_aio_preview.py
+++ b/tests/test_aio_preview.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import nodes
 from easyuse_anima.aio import preview
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class AIOPreviewMoveTests(unittest.TestCase):
@@ -215,7 +216,11 @@ class AIOPreviewMoveTests(unittest.TestCase):
         with (
             patch.dict(sys.modules, {"folder_paths": None}),
             patch.object(nodes, "_image_tensor_size", return_value=(512, 768)),
-            patch.object(nodes, "_find_comfy_node_class", return_value=PreviewImage),
+            patch_comfy_helper(
+                nodes,
+                "_find_comfy_node_class",
+                return_value=PreviewImage,
+            ),
             patch.object(nodes, "_tag_aio_preview_images", tag),
             patch.object(nodes.logger, "warning") as warning,
         ):

--- a/tests/test_aio_resources.py
+++ b/tests/test_aio_resources.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import nodes
 from easyuse_anima.aio import resources as aio_resources
 from easyuse_anima.infrastructure.comfy import capabilities
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class AIOResourceMoveTests(unittest.TestCase):
@@ -84,7 +85,11 @@ class AIOResourceMoveTests(unittest.TestCase):
             "CLIPLoader": CLIPLoader,
         }
         with (
-            patch.object(nodes, "_find_comfy_node_class", side_effect=classes.get),
+            patch_comfy_helper(
+                nodes,
+                "_find_comfy_node_class",
+                side_effect=classes.get,
+            ),
             patch.object(nodes, "_node_output_tuple", side_effect=lambda value: tuple(value)) as output_tuple,
         ):
             self.assertEqual(
@@ -113,7 +118,11 @@ class AIOResourceMoveTests(unittest.TestCase):
         self.assertEqual(output_tuple.call_count, 3)
 
     def test_missing_loader_error_text_is_preserved(self):
-        with patch.object(nodes, "_find_comfy_node_class", return_value=None):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=None,
+        ):
             with self.assertRaisesRegex(
                 RuntimeError,
                 r"^\[EasyUseAnima\] Could not find ComfyUI UNETLoader\.$",
@@ -130,7 +139,11 @@ class AIOResourceMoveTests(unittest.TestCase):
         load_model = Mock(return_value=("upscale-model",))
         loader_cls = type("UpscaleModelLoader", (), {"load_model": load_model})
         with (
-            patch.object(nodes, "_find_comfy_node_class", return_value=loader_cls),
+            patch_comfy_helper(
+                nodes,
+                "_find_comfy_node_class",
+                return_value=loader_cls,
+            ),
             patch.object(nodes, "_node_output_tuple", side_effect=lambda value: tuple(value)),
         ):
             self.assertEqual(

--- a/tests/test_aio_sampling.py
+++ b/tests/test_aio_sampling.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import nodes
 from easyuse_anima.aio import sampling
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class AIOSamplingMoveTests(unittest.TestCase):
@@ -89,7 +90,11 @@ class AIOSamplingMoveTests(unittest.TestCase):
             "VAEEncode": VAEEncode,
         }
         with (
-            patch.object(nodes, "_find_comfy_node_class", side_effect=classes.get),
+            patch_comfy_helper(
+                nodes,
+                "_find_comfy_node_class",
+                side_effect=classes.get,
+            ),
             patch.object(nodes, "_resolve_aio_runtime_seed", return_value=987),
         ):
             empty = sampling._generate_empty_latent_with_comfy(8, 20)
@@ -127,14 +132,22 @@ class AIOSamplingMoveTests(unittest.TestCase):
         class MissingAPI:
             pass
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=None):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=None,
+        ):
             with self.assertRaisesRegex(
                 RuntimeError, "Could not find ComfyUI KSampler"
             ):
                 sampling._sample_latent_with_comfy(
                     None, 0, 1, 1.0, "euler", "normal", None, None, None, 1.0
                 )
-        with patch.object(nodes, "_find_comfy_node_class", return_value=MissingAPI):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=MissingAPI,
+        ):
             with self.assertRaisesRegex(
                 RuntimeError, r"VAEEncode does not expose encode\(\)"
             ):
@@ -144,8 +157,10 @@ class AIOSamplingMoveTests(unittest.TestCase):
             def generate(self, *_args):
                 return ()
 
-        with patch.object(
-            nodes, "_find_comfy_node_class", return_value=EmptyLatentImage
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=EmptyLatentImage,
         ):
             with self.assertRaisesRegex(
                 RuntimeError, "EmptyLatentImage returned no LATENT"
@@ -178,7 +193,7 @@ class AIOSamplingMoveTests(unittest.TestCase):
             "spectrum_extra": {"quality_tags": "must-not-win", "custom": 9},
         }
         with (
-            patch.object(
+            patch_comfy_helper(
                 nodes,
                 "_require_custom_node_class",
                 return_value=SpectrumKSamplerAdvanced,
@@ -218,8 +233,10 @@ class AIOSamplingMoveTests(unittest.TestCase):
                 return {"result": ("spd-latent",)}
 
         with (
-            patch.object(
-                nodes, "_require_custom_node_class", return_value=SpectrumSPDKSampler
+            patch_comfy_helper(
+                nodes,
+                "_require_custom_node_class",
+                return_value=SpectrumSPDKSampler,
             ),
             patch.object(nodes, "_resolve_aio_runtime_seed", return_value=55),
         ):

--- a/tests/test_aio_schema_contract.py
+++ b/tests/test_aio_schema_contract.py
@@ -16,6 +16,11 @@ from easyuse_anima.aio.generation_settings import (
     _aio_generation_config_from_dict,
 )
 from easyuse_anima.prompt.conditioning import ANIMA_MOD_GUIDANCE_PROFILES
+from tests.comfy_host_fakes import (
+    FakeComfyHostProvider,
+    patch_comfy_helper,
+    use_fake_comfy_host,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -34,6 +39,16 @@ REQUIRED_SETTING_SURFACES = (
     "ui",
     "documentation",
 )
+
+_DEFAULT_COMFY_HOST = use_fake_comfy_host(nodes, FakeComfyHostProvider())
+
+
+def setUpModule():
+    _DEFAULT_COMFY_HOST.__enter__()
+
+
+def tearDownModule():
+    _DEFAULT_COMFY_HOST.__exit__(None, None, None)
 
 
 def _manifest() -> dict:
@@ -353,12 +368,18 @@ def _deterministic_capabilities(
     schedulers=("simple",),
     impact_schedulers=("sgm_uniform",),
 ):
-    with patch.multiple(
-        nodes,
-        _comfy_sampler_names=lambda: list(samplers),
-        _comfy_scheduler_names=lambda: list(schedulers),
-        _impact_scheduler_names=lambda: list(impact_schedulers),
-        _comfy_max_resolution=lambda: 16384,
+    with (
+        patch.multiple(
+            nodes,
+            _comfy_sampler_names=lambda: list(samplers),
+            _comfy_scheduler_names=lambda: list(schedulers),
+            _impact_scheduler_names=lambda: list(impact_schedulers),
+        ),
+        patch_comfy_helper(
+            nodes,
+            "_comfy_max_resolution",
+            return_value=16384,
+        ),
     ):
         yield
 
@@ -588,7 +609,7 @@ class AIOGenerationSettingsManifestTests(unittest.TestCase):
             schedulers=tuple(capabilities["schedulers"]),
             impact_schedulers=tuple(capabilities["impact_schedulers"]),
         ):
-            with patch.object(
+            with patch_comfy_helper(
                 nodes,
                 "_comfy_max_resolution",
                 return_value=capabilities["max_resolution"],

--- a/tests/test_comfy_adapters.py
+++ b/tests/test_comfy_adapters.py
@@ -391,9 +391,13 @@ class ComfyRootCompatibilityTests(unittest.TestCase):
             def encode(self, clip, text):
                 return (f"{clip}:{text}",)
 
-        with patch.object(nodes, "_find_comfy_node_class", return_value=ClipTextEncode) as finder:
+        with patch.object(
+            nodes,
+            "NODE_CLASS_MAPPINGS",
+            {"CLIPTextEncode": ClipTextEncode},
+            create=True,
+        ):
             self.assertEqual(nodes._encode_with_comfy_clip("clip", "prompt"), "clip:prompt")
-        finder.assert_called_once_with("CLIPTextEncode")
 
     def test_adapter_modules_remain_below_production_module_loc_guidance(self):
         for path in (

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -49,15 +49,16 @@ class ComfyHostWiringTests(unittest.TestCase):
             },
         )
 
-    def test_known_helper_is_lazy_until_call_time_resolution(self):
-        with self.assertRaisesRegex(
-            RuntimeError,
-            r"^\[EasyUseAnima\] RuntimeServices has not been installed\.$",
-        ):
-            resolve_comfy_host_helper(
-                "_find_comfy_node_class",
-                self._fallback,
-            )
+    def test_known_helper_uses_flat_import_fallback_before_runtime_install(self):
+        helper = resolve_comfy_host_helper(
+            "_find_comfy_node_class",
+            self._fallback,
+        )
+
+        self.assertEqual(
+            helper("Example"),
+            ("_find_comfy_node_class", ("Example",)),
+        )
 
     def test_provider_owned_helpers_delegate_to_narrow_methods(self):
         direct = object()

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from easyuse_anima import runtime as runtime_module
+from easyuse_anima.infrastructure.comfy.wiring import resolve_comfy_host_helper
+from easyuse_anima.runtime import RuntimeServices
+from tests.comfy_host_fakes import FakeComfyHostProvider
+
+
+class ClipTextEncode:
+    def encode(self, clip, text):
+        return (f"{clip}:{text}",)
+
+
+class ComfyHostWiringTests(unittest.TestCase):
+    def setUp(self):
+        self.runtime_state = patch.object(runtime_module, "_RUNTIME_SERVICES", None)
+        self.runtime_state.start()
+
+    def tearDown(self):
+        self.runtime_state.stop()
+
+    @staticmethod
+    def _fallback(name: str):
+        return lambda *args: (name, args)
+
+    def test_unknown_helper_uses_fallback_without_installed_runtime(self):
+        helper = resolve_comfy_host_helper("_other_helper", self._fallback)
+
+        self.assertEqual(helper(1, 2), ("_other_helper", (1, 2)))
+
+    def test_runtime_access_stays_in_runtime_and_comfy_wiring_adapter(self):
+        package_root = Path(__file__).resolve().parents[1] / "easyuse_anima"
+        access_files = {
+            path.relative_to(package_root.parent).as_posix()
+            for path in package_root.rglob("*.py")
+            if re.search(r"\bget_runtime\b", path.read_text(encoding="utf-8"))
+        }
+
+        self.assertEqual(
+            access_files,
+            {
+                "easyuse_anima/infrastructure/comfy/wiring.py",
+                "easyuse_anima/runtime.py",
+            },
+        )
+
+    def test_known_helper_is_lazy_until_call_time_resolution(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^\[EasyUseAnima\] RuntimeServices has not been installed\.$",
+        ):
+            resolve_comfy_host_helper(
+                "_find_comfy_node_class",
+                self._fallback,
+            )
+
+    def test_provider_owned_helpers_delegate_to_narrow_methods(self):
+        direct = object()
+        mapping = object()
+        loaded = object()
+        provider = FakeComfyHostProvider(
+            max_resolution=8192,
+            node_classes={"Direct": direct},
+            mapping_classes={"Mapping": mapping},
+            loaded_classes={"Loaded": loaded},
+        )
+        runtime_module._RUNTIME_SERVICES = RuntimeServices(comfy=provider)
+
+        self.assertEqual(
+            resolve_comfy_host_helper(
+                "_comfy_max_resolution",
+                self._fallback,
+            )(),
+            8192,
+        )
+        self.assertIs(
+            resolve_comfy_host_helper(
+                "_find_comfy_node_class",
+                self._fallback,
+            )("Direct"),
+            direct,
+        )
+        self.assertIs(
+            resolve_comfy_host_helper(
+                "_find_comfy_node_mapping_class",
+                self._fallback,
+            )("Mapping"),
+            mapping,
+        )
+        self.assertIs(
+            resolve_comfy_host_helper(
+                "_find_loaded_node_class",
+                self._fallback,
+            )("Loaded"),
+            loaded,
+        )
+
+    def test_pure_helpers_receive_only_provider_node_lookup(self):
+        custom = object()
+        other = object()
+        provider = FakeComfyHostProvider(
+            node_classes={
+                "Custom": custom,
+                "Other": other,
+                "CLIPTextEncode": ClipTextEncode,
+            },
+        )
+        runtime_module._RUNTIME_SERVICES = RuntimeServices(comfy=provider)
+
+        require = resolve_comfy_host_helper(
+            "_require_custom_node_class",
+            self._fallback,
+        )
+        require_any = resolve_comfy_host_helper(
+            "_require_any_custom_node_class",
+            self._fallback,
+        )
+        encode = resolve_comfy_host_helper(
+            "_encode_with_comfy_clip",
+            self._fallback,
+        )
+
+        self.assertIs(require("Custom", "Pack", "Hint"), custom)
+        self.assertEqual(
+            require_any(("Missing", "Other"), "Pack", "Hint"),
+            ("Other", other),
+        )
+        self.assertEqual(encode("clip", "prompt"), "clip:prompt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -53,6 +53,7 @@ from easyuse_anima.nodes import (
     sam3_nodes,
     wildcard_nodes,
 )
+from tests.comfy_host_fakes import patch_comfy_helper
 from easyuse_anima.prompt import artist_mix as prompt_artist_mix
 from easyuse_anima.prompt import advanced as prompt_advanced
 from easyuse_anima.prompt import conditioning as prompt_conditioning
@@ -190,7 +191,6 @@ def _input_spec(spec) -> dict:
 @contextmanager
 def _deterministic_comfy_inputs():
     replacements = {
-        "_comfy_max_resolution": lambda: 16384,
         "_comfy_sampler_names": lambda: ["contract_sampler_a", "contract_sampler_b"],
         "_comfy_scheduler_names": lambda: ["contract_scheduler_a", "contract_scheduler_b"],
         "_comfy_diffusion_model_names": lambda: ["contract/diffusion_model.safetensors"],
@@ -213,10 +213,18 @@ def _deterministic_comfy_inputs():
             "allow_remote_api": False,
         },
     }
-    with patch.multiple(nodes, **replacements), patch.object(
-        sam3_nodes,
-        "_comfy_checkpoint_names",
-        return_value=["contract/checkpoint.safetensors"],
+    with (
+        patch.multiple(nodes, **replacements),
+        patch_comfy_helper(
+            nodes,
+            "_comfy_max_resolution",
+            return_value=16384,
+        ),
+        patch.object(
+            sam3_nodes,
+            "_comfy_checkpoint_names",
+            return_value=["contract/checkpoint.safetensors"],
+        ),
     ):
         yield
 
@@ -1689,8 +1697,10 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
         candidates = ("preferred.vae", "fallback.vae")
         returned = ["runtime.vae"]
         events = []
+        find_calls = []
 
-        def find_node_class(_node_id):
+        def find_node_class(node_id):
+            find_calls.append(node_id)
             return None
 
         def folder_names(_folder, _fallback):
@@ -1698,18 +1708,36 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
 
         def adapter(candidate_values, node_finder, folder_lookup):
             events.append(
-                ("adapter_call", candidate_values, node_finder, folder_lookup)
+                (
+                    "adapter_call",
+                    candidate_values,
+                    node_finder("ContractProbe"),
+                    folder_lookup,
+                )
             )
             return returned
 
         def resolver(name):
             events.append(name)
-            return getattr(root_module, name)
+            return root_module._resolve_comfy_host_helper(
+                name,
+                lambda fallback_name: getattr(root_module, fallback_name),
+            )
+
+        def production_resolver(name):
+            return root_module._resolve_comfy_host_helper(
+                name,
+                lambda fallback_name: getattr(root_module, fallback_name),
+            )
 
         with (
             patch.object(root_module, "ANIMA_DEFAULT_VAE_CANDIDATES", candidates),
             patch.object(root_module, "_adapter_comfy_vae_names", adapter),
-            patch.object(root_module, "_find_comfy_node_class", find_node_class),
+            patch_comfy_helper(
+                root_module,
+                "_find_comfy_node_class",
+                find_node_class,
+            ),
             patch.object(root_module, "_folder_path_names", folder_names),
         ):
             canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
@@ -1717,7 +1745,7 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
                 result = canonical_module._comfy_vae_names()
             finally:
                 canonical_module._bind_aio_resource_runtime(
-                    resolve_helper=lambda name: getattr(root_module, name)
+                    resolve_helper=production_resolver
                 )
 
         self.assertIs(result, returned)
@@ -1731,11 +1759,12 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
                 (
                     "adapter_call",
                     candidates,
-                    find_node_class,
+                    None,
                     folder_names,
                 ),
             ],
         )
+        self.assertEqual(find_calls, ["ContractProbe"])
 
     def test_vae_root_alias_and_call_time_dependencies(self):
         self._assert_vae_contract(nodes, aio_resources)
@@ -1757,17 +1786,30 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
         candidates = ("qwen_image", "stable_diffusion")
         returned = ["runtime_clip_type"]
         events = []
+        find_calls = []
 
-        def find_node_class(_node_id):
+        def find_node_class(node_id):
+            find_calls.append(node_id)
             return None
 
         def adapter(candidate_values, node_finder):
-            events.append(("adapter_call", candidate_values, node_finder))
+            events.append(
+                ("adapter_call", candidate_values, node_finder("ContractProbe"))
+            )
             return returned
 
         def resolver(name):
             events.append(name)
-            return getattr(root_module, name)
+            return root_module._resolve_comfy_host_helper(
+                name,
+                lambda fallback_name: getattr(root_module, fallback_name),
+            )
+
+        def production_resolver(name):
+            return root_module._resolve_comfy_host_helper(
+                name,
+                lambda fallback_name: getattr(root_module, fallback_name),
+            )
 
         with (
             patch.object(root_module, "ANIMA_CLIP_TYPES", candidates),
@@ -1776,14 +1818,18 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
                 "_adapter_comfy_clip_loader_types",
                 adapter,
             ),
-            patch.object(root_module, "_find_comfy_node_class", find_node_class),
+            patch_comfy_helper(
+                root_module,
+                "_find_comfy_node_class",
+                find_node_class,
+            ),
         ):
             canonical_module._bind_aio_resource_runtime(resolve_helper=resolver)
             try:
                 result = canonical_module._comfy_clip_loader_types()
             finally:
                 canonical_module._bind_aio_resource_runtime(
-                    resolve_helper=lambda name: getattr(root_module, name)
+                    resolve_helper=production_resolver
                 )
 
         self.assertIs(result, returned)
@@ -1793,9 +1839,10 @@ class AioResourceNameMoveContractTests(unittest.TestCase):
                 "_adapter_comfy_clip_loader_types",
                 "ANIMA_CLIP_TYPES",
                 "_find_comfy_node_class",
-                ("adapter_call", candidates, find_node_class),
+                ("adapter_call", candidates, None),
             ],
         )
+        self.assertEqual(find_calls, ["ContractProbe"])
 
     def test_clip_loader_type_root_alias_and_call_time_dependencies(self):
         self._assert_clip_loader_type_contract(nodes, aio_resources)

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "ddc55db1b1676a9aacd858dd36596ff2cd11f897")
-        # Issue #184 B-11c28 moves only the shared AiO image resize helper to
-        # its canonical postprocess owner.
+        self.assertEqual(report["git_blob_sha1"], "237571d35c003e7b9d9cc2a6fec8dcdf08aca61a")
+        # E-07b changes imports and binder composition only; the root
+        # executable-symbol counts remain at the B-11c28 boundary.
         self.assertEqual(report["top_level"]["function_count"], 8)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_864)
+        self.assertEqual(report["line_count"], 1_915)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import autocomplete_dataset
+import nodes
 import settings as easyuse_settings
 from easyuse_anima.naia.client import _clean_prompt
 from easyuse_anima.naia.resolution import ADVANCED_RESOLUTION_BUCKETS
@@ -85,6 +86,7 @@ from settings import (
     resolve_prompt_studio_font_size,
 )
 from wildcard_engine import expand_wildcards
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class PromptCorrectorTests(unittest.TestCase):
@@ -592,7 +594,7 @@ class PromptBuilderTests(unittest.TestCase):
             encoded_texts.append(text)
             return [[f"cond:{text}", {"encoded_text": text}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch("nodes._correct_builder_prompt", return_value="corrected prompt") as correct_mock:
                 positive = EasyUseAnimaArtistMixConditioning().encode(
                     object(),
@@ -606,7 +608,7 @@ class PromptBuilderTests(unittest.TestCase):
         correct_mock.assert_called_once_with("1girl, artist_a", artist_overrides="artist_a")
 
         encoded_texts.clear()
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch("nodes._correct_builder_prompt") as correct_mock:
                 front_positive = EasyUseAnimaArtistMixConditioning().encode(
                     object(),
@@ -634,7 +636,7 @@ class PromptBuilderTests(unittest.TestCase):
             encoded_texts.append(text)
             return [[f"cond:{text}", {"encoded_text": text}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             positive = EasyUseAnimaArtistMixConditioning().encode(
                 object(),
                 prompt="1girl",
@@ -655,7 +657,7 @@ class PromptBuilderTests(unittest.TestCase):
             encoded_texts.append(text)
             return [[f"cond:{text}", {"encoded_text": text}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             positive = EasyUseAnimaArtistMixConditioning().encode(
                 object(),
                 prompt="1girl",
@@ -677,7 +679,7 @@ class PromptBuilderTests(unittest.TestCase):
             encoded_texts.append(text)
             return [[f"cond:{text}", {"encoded_text": text}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             EasyUseAnimaArtistMixConditioning().encode(
                 object(),
                 prompt="1girl",
@@ -696,7 +698,15 @@ class PromptBuilderTests(unittest.TestCase):
                 calls.append((width, height, batch_size))
                 return ({"samples": "latent"},)
 
-        with patch("nodes._find_comfy_node_class", lambda node_id: FakeEmptyLatentImage if node_id == "EmptyLatentImage" else None):
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            lambda node_id: (
+                FakeEmptyLatentImage
+                if node_id == "EmptyLatentImage"
+                else None
+            ),
+        ):
             latent = _generate_empty_latent_with_comfy(832, 1216)
 
         self.assertEqual(latent, {"samples": "latent"})
@@ -714,7 +724,11 @@ class PromptBuilderTests(unittest.TestCase):
             },
         }
 
-        with patch("nodes._encode_with_comfy_clip", lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]]):
+        with patch_comfy_helper(
+            nodes,
+            "_encode_with_comfy_clip",
+            lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
+        ):
             with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                 patched_model, positive, negative, latent_image = EasyUseAnimaPromptDataConditioning().apply(
                     model,
@@ -764,7 +778,11 @@ class PromptBuilderTests(unittest.TestCase):
         }
 
         _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED.clear()
-        with patch("nodes._encode_with_comfy_clip", lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]]):
+        with patch_comfy_helper(
+            nodes,
+            "_encode_with_comfy_clip",
+            lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
+        ):
             with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                 with patch("nodes._find_spectrum_anima_mod_guidance_class", lambda: FakeAnimaModGuidance):
                     with patch("nodes.logger.warning") as warning_mock:
@@ -820,7 +838,11 @@ class PromptBuilderTests(unittest.TestCase):
         }
 
         _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED.clear()
-        with patch("nodes._encode_with_comfy_clip", lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]]):
+        with patch_comfy_helper(
+            nodes,
+            "_encode_with_comfy_clip",
+            lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
+        ):
             with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                 with patch("nodes._find_spectrum_anima_mod_guidance_class", lambda: FakeAnimaModGuidance):
                     with patch("nodes.logger.warning") as warning_mock:
@@ -897,7 +919,7 @@ class PromptBuilderTests(unittest.TestCase):
                 },
             ]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch("nodes._blend_conditionings", fake_blend):
                 with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                     _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
@@ -935,7 +957,7 @@ class PromptBuilderTests(unittest.TestCase):
             encoded_texts.append(text)
             return [[f"cond:{text}", {"encoded_text": text}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                 _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                     object(),
@@ -971,7 +993,7 @@ class PromptBuilderTests(unittest.TestCase):
             encoded_texts.append(text)
             return [[f"cond:{text}", {"encoded_text": text}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                 _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                     object(),
@@ -1005,7 +1027,7 @@ class PromptBuilderTests(unittest.TestCase):
             delta_calls.append((artists, list(weights or []), kwargs))
             return [["tail", {"strength": kwargs.get("branch_strength")}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch("nodes._encode_artist_delta_rms", fake_delta):
                 with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                     _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
@@ -1051,7 +1073,7 @@ class PromptBuilderTests(unittest.TestCase):
             calls.append(("clustered", kwargs))
             return [["clustered", {}]]
 
-        with patch("nodes._encode_with_comfy_clip", fake_encode):
+        with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch("nodes._encode_artist_delta_rms", fake_delta):
                 with patch("nodes._encode_artist_clustered", fake_clustered):
                     with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):

--- a/tests/test_prompt_studio_regional.py
+++ b/tests/test_prompt_studio_regional.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import nodes as easy_nodes
 from easyuse_anima.nodes import regional_nodes
 from easyuse_anima.prompt import regional as regional_service
+from tests.comfy_host_fakes import patch_comfy_helper
 from nodes import (
     EasyUseAnimaRegionalConditioning,
     EasyUseAnimaPromptStudioRegional,
@@ -208,18 +209,17 @@ class PromptStudioRegionalTests(unittest.TestCase):
                 }
             ],
         }
-        original_encode = easy_nodes._encode_with_comfy_clip
-        try:
-            easy_nodes._encode_with_comfy_clip = lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]]
-
+        with patch_comfy_helper(
+            easy_nodes,
+            "_encode_with_comfy_clip",
+            lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
+        ):
             positive, negative = EasyUseAnimaRegionalConditioning().encode(
                 payload,
                 clip=object(),
                 mask_strength=0.75,
                 set_cond_area="mask bounds",
             )
-        finally:
-            easy_nodes._encode_with_comfy_clip = original_encode
 
         self.assertEqual(positive[0][1]["encoded_text"], "masterpiece")
         self.assertEqual(positive[1][1]["encoded_text"], "red dress")

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 85)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 85)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 85)
+        self.assertEqual(report["inventory"]["module_count"], 86)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 86)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 86)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -2100,7 +2100,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
 
     def test_next_contracts_have_exact_signatures_and_allowed_boundaries(self):
         contracts = self.ledger["next_contracts"]
-        self.assertEqual(set(contracts), {"E-02a", "E-07a"})
+        self.assertEqual(set(contracts), {"E-02a", "E-07a", "E-07b"})
         self.assertEqual(
             contracts["E-02a"]["production_files"],
             [
@@ -2135,6 +2135,23 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
                 "DefaultComfyHostProvider.find_node_class(self, node_id: str)",
                 "DefaultComfyHostProvider.find_node_mapping_class(self, node_id: str)",
                 "DefaultComfyHostProvider.find_loaded_node_class(self, node_id: str)",
+            ],
+        )
+        self.assertEqual(
+            contracts["E-07b"]["production_files"],
+            [
+                "nodes.py",
+                "easyuse_anima/infrastructure/comfy/wiring.py",
+            ],
+        )
+        self.assertEqual(
+            contracts["E-07b"]["production_symbols"],
+            [
+                (
+                    "resolve_comfy_host_helper("
+                    "name: str, fallback: Callable[[str], Any]"
+                    ") -> Callable[..., Any]"
+                ),
             ],
         )
         for contract in contracts.values():

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1163,7 +1163,33 @@ def _comfy_host_runtime_consumers(
     return result
 
 
-def _patch_call_target(node: ast.Call) -> tuple[str, str] | None:
+def _literal_dict_symbol_assignments(tree: ast.Module) -> dict[str, set[str]]:
+    assignments: dict[str, set[str]] = defaultdict(set)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not isinstance(node.value, ast.Dict):
+            continue
+        symbols = {
+            key.value
+            for key in node.value.keys
+            if (
+                isinstance(key, ast.Constant)
+                and isinstance(key.value, str)
+                and key.value in COMFY_HOST_WRAPPERS
+            )
+        }
+        for target in targets:
+            if isinstance(target, ast.Name):
+                assignments[target.id].update(symbols)
+    return assignments
+
+
+def _patch_call_targets(
+    node: ast.Call,
+    literal_dict_symbols: dict[str, set[str]],
+) -> list[tuple[str, str]]:
     if (
         isinstance(node.func, ast.Name)
         and node.func.id == "patch"
@@ -1174,7 +1200,7 @@ def _patch_call_target(node: ast.Call) -> tuple[str, str] | None:
         target = node.args[0].value
         symbol = target.rsplit(".", 1)[-1]
         if target.startswith("nodes.") and symbol in COMFY_HOST_WRAPPERS:
-            return "root", symbol
+            return [("root", symbol)]
     if (
         isinstance(node.func, ast.Attribute)
         and node.func.attr == "object"
@@ -1186,8 +1212,38 @@ def _patch_call_target(node: ast.Call) -> tuple[str, str] | None:
     ):
         owner = ast.unparse(node.args[0])
         scope = "root" if owner in COMFY_HOST_ROOT_TEST_ALIASES else "canonical"
-        return scope, node.args[1].value
-    return None
+        return [(scope, node.args[1].value)]
+    if (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "multiple"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "patch"
+        and node.args
+    ):
+        owner = ast.unparse(node.args[0])
+        scope = "root" if owner in COMFY_HOST_ROOT_TEST_ALIASES else "canonical"
+        symbols = {
+            keyword.arg
+            for keyword in node.keywords
+            if keyword.arg in COMFY_HOST_WRAPPERS
+        }
+        for keyword in node.keywords:
+            if keyword.arg is not None:
+                continue
+            if isinstance(keyword.value, ast.Dict):
+                symbols.update(
+                    key.value
+                    for key in keyword.value.keys
+                    if (
+                        isinstance(key, ast.Constant)
+                        and isinstance(key.value, str)
+                        and key.value in COMFY_HOST_WRAPPERS
+                    )
+                )
+            elif isinstance(keyword.value, ast.Name):
+                symbols.update(literal_dict_symbols.get(keyword.value.id, set()))
+        return [(scope, symbol) for symbol in sorted(symbols)]
+    return []
 
 
 def _comfy_host_monkeypatch_consumers() -> dict[str, dict[str, list[str]]]:
@@ -1197,11 +1253,11 @@ def _comfy_host_monkeypatch_consumers() -> dict[str, dict[str, list[str]]]:
     }
     for path in sorted((ROOT / "tests").glob("test_*.py")):
         tree = _read_tree(path)
+        literal_dict_symbols = _literal_dict_symbol_assignments(tree)
         relative = path.relative_to(ROOT).as_posix()
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
-                target = _patch_call_target(node)
-                if target is not None:
+                for target in _patch_call_targets(node, literal_dict_symbols):
                     scope, symbol = target
                     consumers[symbol][scope].add(relative)
             if not isinstance(node, (ast.Assign, ast.AnnAssign)):

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -2127,7 +2127,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             )
             self.assertEqual(
                 entry["replacement_mechanism"],
-                "migrate_repository_tests_to_fake_provider_or_explicit_lookup_in_E-07b",
+                "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
             )
             self.assertTrue(entry["root_removal_gate"])
             self.assertTrue(entry["host_lookup_order"])
@@ -2206,7 +2206,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
                 (
                     "resolve_comfy_host_helper("
                     "name: str, fallback: Callable[[str], Any]"
-                    ") -> Callable[..., Any]"
+                    ") -> Any"
                 ),
             ],
         )

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1677,7 +1677,7 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 300,
+            "nodes_canonical_bindings": 301,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,

--- a/tests/test_sam3_nodes.py
+++ b/tests/test_sam3_nodes.py
@@ -8,6 +8,7 @@ import nodes
 from easyuse_anima.image import sam3 as sam3_service
 from easyuse_anima.nodes import impact_detailer_nodes
 from easyuse_anima.nodes import sam3_nodes
+from tests.comfy_host_fakes import patch_comfy_helper
 
 
 class SAM3MoveTests(unittest.TestCase):
@@ -113,13 +114,21 @@ class SAM3MoveTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "SAM3 detect prompt is empty"):
             sam3_service._format_sam3_detection_prompt("  ", 1)
 
-    def test_sam3_lookup_keeps_call_time_root_resolver(self):
+    def test_sam3_lookup_uses_call_time_provider(self):
         sentinel = object()
-        with patch.object(nodes, "_find_comfy_node_class", return_value=sentinel) as find:
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_class",
+            return_value=sentinel,
+        ) as find:
             self.assertIs(sam3_service._find_sam3_detect_class(), sentinel)
         find.assert_called_once_with("SAM3_Detect")
 
-        with patch.object(nodes, "_find_comfy_node_mapping_class", return_value=sentinel) as find:
+        with patch_comfy_helper(
+            nodes,
+            "_find_comfy_node_mapping_class",
+            return_value=sentinel,
+        ) as find:
             self.assertIs(sam3_service._find_impact_detailer_class(), sentinel)
         find.assert_called_once_with("DetailerForEach")
 
@@ -163,7 +172,11 @@ class SAM3MoveTests(unittest.TestCase):
         with (
             patch.object(sam3_nodes, "_empty_mask_for_image", return_value="empty-mask"),
             patch.object(sam3_nodes, "_empty_segs_for_image", return_value="empty-segs"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="conditioning") as encode,
+            patch_comfy_helper(
+                nodes,
+                "_encode_with_comfy_clip",
+                return_value="conditioning",
+            ) as encode,
             patch.object(sam3_nodes, "_find_sam3_detect_class", return_value=sam3_detect),
             patch.object(sam3_nodes, "_find_impact_mask_to_segs_class", return_value=mask_to_segs),
             patch.object(
@@ -196,7 +209,11 @@ class SAM3MoveTests(unittest.TestCase):
         with (
             patch.object(sam3_nodes, "_empty_mask_for_image", return_value="empty-mask"),
             patch.object(sam3_nodes, "_empty_segs_for_image", return_value="empty-segs"),
-            patch.object(nodes, "_encode_with_comfy_clip", return_value="conditioning"),
+            patch_comfy_helper(
+                nodes,
+                "_encode_with_comfy_clip",
+                return_value="conditioning",
+            ),
             patch.object(sam3_nodes, "_find_sam3_detect_class", return_value=sam3_detect),
             patch.object(sam3_nodes, "_find_impact_mask_to_segs_class", return_value=mask_to_segs),
             patch.object(sam3_nodes._EasyUseAnimaImpactDetailerDelegate, "doit") as detail,


### PR DESCRIPTION
## 분류

- Task: E-07b
- Owner: #323 / parent #187, gate #188
- Type: Contract/gate
- Base: `dev@c1fc22114ba068d4cc7c6cc2494c871f38615246`
- Head: `80d41760fbd4f73526b30116e3b10a9d224ab9d4`
- Move/Behavior: 포함하지 않음

## 작업 전 inventory

- root 구현: `nodes.py`의 7개 wrapper 유지
- production consumer: 22 slots / 15 canonical modules
- caller contract: 기존 binder/resolver가 22개 host helper를 호출 시점에 해석
- alias/compatibility: 7개 root underscore seam 모두 `unsupported_test_only`
- repository tests: root replacement 16개 파일, canonical monkeypatch 2개 파일
- global state: 설치된 `RuntimeServices(comfy)` 1개만 사용하며 새 override registry를 추가하지 않음
- init ordering: package entrypoint가 `nodes.py`를 먼저 import하고 bootstrap에서 runtime을 설치하므로 binder setup에서는 provider를 조회하지 않음

E-01a detector는 `patch.multiple` keyword/dict expansion을 읽지 못해 root test 수를 13개로 과소 집계했습니다. E-07b 구현 전에 detector를 보강했고 누락된 3개 파일을 포함해 16개로 ledger를 바로잡았습니다.

## 변경

- 새 Comfy wiring adapter가 설치된 `ComfyHostProvider`의 4개 narrow method를 사용
- requirement helper 2개와 CLIP invocation helper 1개에는 provider의 `find_node_class`만 주입
- 15개 canonical consumer 파일은 수정하지 않고 기존 call-time binder 계약 재사용
- unrelated helper와 pre-bootstrap flat `nodes` import는 기존 root fallback 유지
- repository-only root replacement 16개 파일을 fake provider 또는 명시적 canonical lookup으로 이관
- root replacement 0개, 의도된 canonical `_comfy_max_resolution` replacement 2개를 gate로 고정
- `get_runtime()` 접근은 `runtime.py`와 Comfy wiring adapter로 제한
- backend/package/compatibility analyzer fixture 갱신

## 주요 파일

- `nodes.py`
- `easyuse_anima/infrastructure/comfy/wiring.py`
- `tests/comfy_host_fakes.py`
- `tests/test_comfy_host_wiring.py`
- `tests/fixtures/comfy_host_compatibility.v1.json`
- 관련 root-replacement 테스트 16개
- backend/package compatibility analyzer fixture와 gate
- `docs/architecture/comfy-host-provider-bridge.md`

## 검증

- focused provider wiring, compatibility ledger, backend analyzer, import-boundary tests 통과
- repository root replacement detector: 0개
- `tools/check_project.ps1 -Profile full`
  - Python unittest: 957/957
  - frontend: 114 JavaScript files
  - TypeScript: 6.0.3
  - Pyright baseline ratchet 통과
  - G-03 import boundary: 6 groups / 0 violations
  - `git diff --check` 통과
- `comfy node validate` 통과
- actual `comfy node pack`
  - 218 entries / Python 86개
  - analyzer의 shipped Python 86개와 missing 0 / extra 0
  - 새 `easyuse_anima/infrastructure/comfy/wiring.py` 포함
- ComfyUI Codex test instance: API/module smoke
  - ComfyUI 0.27.0 / frontend 1.45.20
  - `/object_info` HTTP 200
  - 대표 EasyUse Anima 노드 4/4 등록
  - AiO Input provider resource lookup 완료

Ruff 113건은 기존 G-01 report-only debt이며 실행·설정 오류는 없었습니다. 테스트 인스턴스의 다른 optional node pack에서 기존 누락 의존성 경고가 있었지만 EasyUse Anima import/runtime 오류는 없었습니다.

## 경계와 위험

- 7개 root wrapper 구현은 이동·삭제·변경하지 않음
- lookup order, fallback, error text, schema, route, seed, stage, cache behavior 변경 없음
- provider cache/snapshot/override registry 없음
- flat import fallback은 B-11 wrapper Move 전까지 의도적으로 유지

## 롤백

이 PR의 wiring module, root binder composition, fake-provider test migration, analyzer/ledger 상태만 되돌리면 됩니다. 7개 root implementation과 feature behavior는 이전 상태 그대로입니다.

## 다음 단계

E-07b 완료 후 #184 B-11c29a max-resolution wrapper Move/retirement가 READY입니다.
