### PR TITLE
B-11c29a: max-resolution root wrapper retirement

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -525,13 +525,68 @@ Forbidden:
 
 ### B-11c29a — Max-resolution wrapper
 
-- **State:** READY after E-07b PR #328
+- **State:** IN PROGRESS after E-07b PR #328
 - **Owner:** #184
 - **Type:** Move or retirement according to the ledger
 
 Move or retire only `_comfy_max_resolution`. Preserve its zero-argument root
 signature when the compatibility decision requires it. Do not combine node
 lookup, requirement helpers, CLIP invocation, schema, or postprocess behavior.
+
+Pre-edit inventory at `dev@14015769634d387fe5afa6a74a5594007e86346c`:
+
+- root `nodes.py` owns one zero-argument `_comfy_max_resolution` wrapper and
+  imports `_adapter_comfy_max_resolution` in relative and flat modes;
+- the wrapper has no mutable state or import-time call and lazily resolves host
+  `nodes.MAX_RESOLUTION`, returning `16384` after missing/invalid host state;
+- three production consumers resolve the name at call time through the E-07b
+  provider wiring: AiO generation normalization, Impact Detailer inputs, and
+  SAM3 inputs;
+- repository root replacements are zero; two tests intentionally replace the
+  canonical consumer slot; external consumer evidence remains zero;
+- the ledger classifies the private root seam as `unsupported_test_only` and
+  does not require call-time root replacement; and
+- therefore this unit retires the root wrapper instead of preserving a direct
+  alias, while the wiring adapter keeps the pre-bootstrap flat-import fallback.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/infrastructure/comfy/wiring.py
+```
+
+Allowed test, fixture, and documentation files:
+
+```text
+tests/test_comfy_host_wiring.py
+tests/test_node_contracts.py
+tests/test_python_compatibility_surface.py
+tests/test_nodes_module_analyzer.py
+tests/test_python_backend_analyzer.py
+tests/fixtures/comfy_host_compatibility.v1.json
+tests/fixtures/python_compatibility_surface.v1.json
+tests/fixtures/python_backend_baseline.json
+docs/architecture/*
+```
+
+Exit:
+
+- root `_comfy_max_resolution` and both adapter imports are absent;
+- installed-runtime consumers continue to use
+  `ComfyHostProvider.max_resolution`;
+- pre-bootstrap flat import preserves delayed lookup and `16384` fallback
+  without canonical-to-root imports;
+- root and canonical replacement counts remain executable; and
+- root residual/analyzer/package closure gates pass.
+
+Forbidden:
+
+- changing `ComfyHostProvider`, the domain-neutral capability helper, lookup
+  order, default value, conversion/error behavior, schemas, or node inputs;
+- moving any node-discovery, requirement, or CLIP helper;
+- adding cache, snapshot, mutable override state, or canonical root import; and
+- changing postprocess, seed, stage, route, workflow, or persistence behavior.
 
 ### B-11c29b — Node discovery family
 
@@ -624,7 +679,7 @@ COMPLETE: E-02a minimal runtime shell / PR #327
 COMPLETE: E-07a default host provider / PR #327
 COMPLETE: E-07b wiring and compatibility gate / PR #328
 
-READY:    B-11c29a max-resolution wrapper Move/retirement
+IN PROGRESS: B-11c29a max-resolution wrapper retirement
 BLOCKED:  B-11c29b-d wrapper Moves/retirements
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -525,7 +525,7 @@ Forbidden:
 
 ### B-11c29a — Max-resolution wrapper
 
-- **State:** IN PROGRESS after E-07b PR #328
+- **State:** COMPLETE in PR #329
 - **Owner:** #184
 - **Type:** Move or retirement according to the ledger
 
@@ -590,7 +590,7 @@ Forbidden:
 
 ### B-11c29b — Node discovery family
 
-- **State:** BLOCKED by B-11c29a
+- **State:** READY after B-11c29a
 - **Owner:** #184
 - **Type:** Move/retirement, split further when the ledger requires
 
@@ -679,8 +679,9 @@ COMPLETE: E-02a minimal runtime shell / PR #327
 COMPLETE: E-07a default host provider / PR #327
 COMPLETE: E-07b wiring and compatibility gate / PR #328
 
-IN PROGRESS: B-11c29a max-resolution wrapper retirement
-BLOCKED:  B-11c29b-d wrapper Moves/retirements
+COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
+READY:    B-11c29b node-discovery wrapper Move/retirement
+BLOCKED:  B-11c29c-d wrapper Moves/retirements
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `eb0843d3e8c26c326e34e5c77dd1eb302b4a9933`
+- Integrated `dev` snapshot commit: `14015769634d387fe5afa6a74a5594007e86346c`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,10 +31,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c27 / `eb0843d`; B-11c28 shared image-resize helper Move in PR #322 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c28; B-11c29a max-resolution root retirement in PR #329 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
-| E - runtime ownership | Not started | Execute #187 after canonical feature owners exist; E-01 inventory may start earlier |
+| E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
 | G - quality ratchet | G-01, G-02a/G-02b, and G-03a complete | Extend G-03 enrollment, then continue with G-04 through G-06 |
 | H - shim retirement | Not started | Requires canonical release evidence and ADR-002 gates |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,879
-  lines after B-11c27.
-- The mechanical extraction has removed 10,784
-  lines, approximately 85.2% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,915
+  lines after E-07b.
+- The mechanical extraction has removed 10,748
+  lines, approximately 84.9% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -87,7 +87,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c25 moved only the AiO ResShift leaf in PR #319 / `5e2b335`.
   B-11c26 moved only the AiO Detailer target leaf in PR #320 / `4358ee3`.
   B-11c27 moved only the AiO USDU upscale leaf in PR #321 / `eb0843d`.
-  B-11c28 moves only the shared AiO image-resize helper in PR #322.
+  B-11c28 moved only the shared AiO image-resize helper in PR #322.
+  E-07b established provider-backed call-time host wiring in PR #328, allowing
+  B-11c29a to retire only the unsupported `_comfy_max_resolution` root wrapper
+  in PR #329 while preserving the flat pre-bootstrap fallback.
 
 ### Current quality baseline
 
@@ -329,7 +332,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS: B-11a PR #292 / `20c8b4d`; B-11b PR #293 / `f2a2ec0`; B-11c1 PR #294 / `ebeee89`; B-11c2 PR #295 / `47fef1d`; B-11c3 PR #296 / `1f18c04`; B-11c4 PR #297 / `0980530`; B-11c5 PR #298 / `617ea14`; B-11c6 PR #299 / `bbca312`; B-11c7a PR #300 / `17343eb`; B-11c7b PR #301 / `6863735`; B-11c8 PR #302 / `40e8d94`; B-11c9 PR #303 / `7222f7d`; B-11c10 PR #304 / `236a7f5`; B-11c11 PR #305 / `98812ef`; B-11c12 PR #306 / `7c2fdd5`; B-11c13 PR #307 / `21f8c97`; B-11c14 PR #308 / `5a86162`; B-11c15 PR #309 / `05beee1`; B-11c16 PR #310 / `f4ab6eb`; B-11c17 PR #311 / `82247d9`; B-11c18 PR #312 / `3d7e5d2`; B-11c19 PR #313 / `de57090`; B-11c20 PR #314 / `43c3056`; B-11c21 PR #315 / `8b3ba38`; B-11c22 PR #316 / `9250610`; B-11c23 PR #317 / `6a5fd7b`; B-11c24 PR #318 / `2abc54d`; B-11c25 PR #319 / `5e2b335`; B-11c26 PR #320 / `4358ee3`; B-11c27 PR #321 / `eb0843d`; B-11c28 shared image-resize helper Move PR #322 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29a max-resolution root retirement PR #329; next B-11c29b node discovery | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -932,9 +935,9 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     remain separate.
   - B-11c21 moves only `_run_aio_postprocess_stage` to the existing AiO
     postprocess owner in PR #315 / `8b3ba38`. Coercion, image-size, final-fit,
-    and logger dependencies remain call-time root seams. `_comfy_max_resolution` remains
-    deferred until a host-provider contract can preserve its zero-argument root
-    wrapper without importing root `nodes` from canonical code.
+    and logger dependencies remain call-time root seams. The later E-07
+    provider bridge resolves the max-resolution dependency before B-11c29a
+    retires its unsupported root wrapper.
   - B-11c22 moves only `_run_aio_highres_stage` to the existing AiO legacy-
     generation owner in PR #316 / `9250610`. Sampler planning, scaler
     construction, VAE, model-patch, sampling, cleanup, resize, and metadata
@@ -970,6 +973,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     same-size identity short-circuit, method fallback, return tuple, and raw
     exception propagation remain unchanged. Host-provider, stage, schema,
     seed-reservation, and RuntimeServices contracts remain separate.
+  - B-11c29a retires only `_comfy_max_resolution` in PR #329. The E-07b wiring
+    keeps installed-runtime consumers on `ComfyHostProvider.max_resolution`
+    and flat pre-bootstrap consumers on a fresh default provider. Lookup order,
+    integer conversion, and the `16384` fallback remain unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -3,15 +3,15 @@
 ## Registry status
 
 - Inventory baseline: `dev` commit
-  `eb0843d3e8c26c326e34e5c77dd1eb302b4a9933`
+  `14015769634d387fe5afa6a74a5594007e86346c`
 - Compatibility provenance: package/workflow version 0.5.2
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c27 are integrated through PR #321. B-11c is
-  split into residual-owner Moves and explicit private-contract cleanup before
-  the final root shim; B-11c28 shared image-resize helper Move is tracked by PR
-  #322.
+- Current state: B-11a through B-11c28 are integrated. B-11c is split into
+  residual-owner Moves and explicit private-contract cleanup before the final
+  root shim; B-11c29a retires the unsupported max-resolution root wrapper in
+  PR #329.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 300 in B-11c28
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 300 in B-11c29a
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 8 functions, 0 classes, and 26 assigned
-  globals in B-11c28 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 7 functions, 0 classes, and 26 assigned
+  globals in B-11c29a (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 291, including
+- root names reached by those canonical runtime resolvers: 290, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -590,6 +590,19 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - PR #322 does not move or change the Comfy upscale adapter, image-size helper,
   final-fit/highres/stage logic, schema/defaults, provider/RuntimeServices
   contract, wildcard seed reservation, or public `__all__`.
+
+### B-11c29a max-resolution root-wrapper retirement
+
+- `_comfy_max_resolution` is an unsupported/test-only private root seam with no
+  root monkeypatch consumer, confirmed external consumer, or call-time root
+  replacement requirement.
+- PR #329 removes the root definition and both adapter imports. Installed
+  runtime consumers continue to resolve `ComfyHostProvider.max_resolution`.
+- Flat pre-bootstrap imports resolve a fresh `DefaultComfyHostProvider` bound
+  method at call time. Host lookup order, integer conversion, and the `16384`
+  fallback remain unchanged without importing canonical code from root.
+- No provider cache, mutable override, schema change, or other host-helper Move
+  is included.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -12,6 +12,11 @@ from .capabilities import (
     _require_custom_node_class,
 )
 from .invocation import _encode_with_comfy_clip
+from .provider import DefaultComfyHostProvider
+
+
+def _default_max_resolution() -> int:
+    return DefaultComfyHostProvider().max_resolution()
 
 
 def resolve_comfy_host_helper(
@@ -35,7 +40,10 @@ def resolve_comfy_host_helper(
         provider = get_runtime().comfy
     except RuntimeError:
         # Flat ``nodes`` imports used by local tooling do not execute package
-        # bootstrap. Preserve their existing root resolver until B-11 moves it.
+        # bootstrap. Retired host seams use their canonical default provider;
+        # the remaining B-11 seams keep their existing root resolver.
+        if name == "_comfy_max_resolution":
+            return _default_max_resolution
         return fallback(name)
 
     if name == "_comfy_max_resolution":

--- a/nodes.py
+++ b/nodes.py
@@ -408,7 +408,6 @@ try:
         # The public mapped node class remains a root re-export.
     )
     from .easyuse_anima.infrastructure.comfy.capabilities import (
-        _comfy_max_resolution as _adapter_comfy_max_resolution,
         _comfy_sampler_names as _comfy_sampler_names,
         _comfy_scheduler_names as _comfy_scheduler_names,
         _find_comfy_node_class as _adapter_find_comfy_node_class,
@@ -972,7 +971,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         # The public mapped node class remains a root re-export.
     )
     from easyuse_anima.infrastructure.comfy.capabilities import (
-        _comfy_max_resolution as _adapter_comfy_max_resolution,
         _comfy_sampler_names as _comfy_sampler_names,
         _comfy_scheduler_names as _comfy_scheduler_names,
         _find_comfy_node_class as _adapter_find_comfy_node_class,
@@ -1627,14 +1625,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 
 
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
-
-
-def _comfy_max_resolution() -> int:
-    try:
-        import nodes as comfy_nodes  # type: ignore
-    except Exception:
-        comfy_nodes = None
-    return _adapter_comfy_max_resolution(comfy_nodes)
 
 
 def _find_comfy_node_class(node_id: str):

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -39,17 +39,10 @@
   "symbols": [
     {
       "symbol": "_comfy_max_resolution",
-      "root_signature": {
-        "parameters": [],
-        "return": "int"
-      },
-      "adapter_binding": {
-        "alias": "_adapter_comfy_max_resolution",
-        "target": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution"
-      },
-      "root_dependencies": [
-        "_adapter_comfy_max_resolution"
-      ],
+      "root_signature": null,
+      "adapter_binding": null,
+      "retired_adapter_alias": "_adapter_comfy_max_resolution",
+      "root_dependencies": [],
       "canonical_target": "ComfyHostProvider.max_resolution",
       "production_consumers": [
         {
@@ -96,7 +89,7 @@
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
       "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
-      "root_removal_gate": "E-07b provider parity and repository root-patch migration, then #184 B-11c29a",
+      "root_removal_gate": "completed in #184 B-11c29a / PR #329",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29a"
     },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8385,6 +8385,24 @@
       },
       {
         "alias": null,
+        "bound_name": "DefaultComfyHostProvider",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".provider:DefaultComfyHostProvider",
+        "kind": "static_from",
+        "line": 15,
+        "name": "DefaultComfyHostProvider",
+        "optional": false,
+        "requested": ".provider",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "target": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
         "classification": "external",
@@ -21929,37 +21947,6 @@
         "target": "easyuse_anima/image/scaling.py"
       },
       {
-        "alias": "_adapter_comfy_max_resolution",
-        "bound_name": "_adapter_comfy_max_resolution",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_comfy_max_resolution",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
-        "kind": "static_from",
-        "line": 410,
-        "name": "_comfy_max_resolution",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
         "alias": "_comfy_sampler_names",
         "bound_name": "_comfy_sampler_names",
         "branch_context": [
@@ -22198,7 +22185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22229,7 +22216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22260,7 +22247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22291,7 +22278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22322,7 +22309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 427,
+        "line": 426,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22353,7 +22340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 430,
+        "line": 429,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22384,7 +22371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 430,
+        "line": 429,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22415,7 +22402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 430,
+        "line": 429,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22446,7 +22433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 430,
+        "line": 429,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22477,7 +22464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 430,
+        "line": 429,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22508,7 +22495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 438,
+        "line": 437,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22539,7 +22526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 438,
+        "line": 437,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22570,7 +22557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 442,
+        "line": 441,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22601,7 +22588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22632,7 +22619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22663,7 +22650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22694,7 +22681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 451,
+        "line": 450,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22725,7 +22712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 451,
+        "line": 450,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22756,7 +22743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 451,
+        "line": 450,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22787,7 +22774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 451,
+        "line": 450,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22818,7 +22805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 451,
+        "line": 450,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22849,7 +22836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 458,
+        "line": 457,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22880,7 +22867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 458,
+        "line": 457,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22911,7 +22898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 458,
+        "line": 457,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22942,7 +22929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 463,
+        "line": 462,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22973,7 +22960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 463,
+        "line": 462,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23004,7 +22991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 463,
+        "line": 462,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23035,7 +23022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 481,
+        "line": 480,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23066,7 +23053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 481,
+        "line": 480,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23097,7 +23084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 481,
+        "line": 480,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23128,7 +23115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 481,
+        "line": 480,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23159,7 +23146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 481,
+        "line": 480,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23190,7 +23177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 504,
+        "line": 503,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23221,7 +23208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 504,
+        "line": 503,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23252,7 +23239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23283,7 +23270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23314,7 +23301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23345,7 +23332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23376,7 +23363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23407,7 +23394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23438,7 +23425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23469,7 +23456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23500,7 +23487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23531,7 +23518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23562,7 +23549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23593,7 +23580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23624,7 +23611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23655,7 +23642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23686,7 +23673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23717,7 +23704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23748,7 +23735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 513,
+        "line": 512,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23779,7 +23766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23810,7 +23797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23841,7 +23828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23872,7 +23859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23903,7 +23890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23934,7 +23921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23965,7 +23952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23996,7 +23983,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 530,
+        "line": 529,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24027,7 +24014,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 540,
+        "line": 539,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24058,7 +24045,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 540,
+        "line": 539,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24089,7 +24076,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 544,
+        "line": 543,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24120,7 +24107,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 544,
+        "line": 543,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24151,7 +24138,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24182,7 +24169,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 546,
+        "line": 545,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24213,7 +24200,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 546,
+        "line": 545,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24244,7 +24231,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 546,
+        "line": 545,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24275,7 +24262,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24306,7 +24293,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24337,7 +24324,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24368,7 +24355,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24399,7 +24386,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24430,7 +24417,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24461,7 +24448,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24492,7 +24479,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24523,7 +24510,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24554,7 +24541,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24585,7 +24572,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24616,7 +24603,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24647,7 +24634,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24678,7 +24665,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24709,7 +24696,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24740,7 +24727,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24771,7 +24758,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24802,7 +24789,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24833,7 +24820,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24864,7 +24851,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24895,7 +24882,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 552,
+        "line": 551,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24914,7 +24901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -24929,7 +24916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24948,7 +24935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -24963,7 +24950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24982,7 +24969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -24997,7 +24984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25016,7 +25003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25031,7 +25018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25050,7 +25037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25065,7 +25052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25084,7 +25071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25099,7 +25086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25118,7 +25105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25133,7 +25120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25152,7 +25139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25167,7 +25154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25186,7 +25173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25201,7 +25188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25220,7 +25207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25235,7 +25222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25254,7 +25241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25269,7 +25256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25288,7 +25275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25303,7 +25290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25322,7 +25309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25337,7 +25324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25356,7 +25343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25371,7 +25358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25390,7 +25377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25405,7 +25392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25424,7 +25411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25439,7 +25426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25458,7 +25445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25473,7 +25460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25492,7 +25479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25507,7 +25494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25526,7 +25513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25541,7 +25528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25560,7 +25547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25575,7 +25562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25594,7 +25581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25609,7 +25596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25628,7 +25615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25643,7 +25630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25662,7 +25649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25677,7 +25664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25696,7 +25683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25711,7 +25698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25730,7 +25717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25745,7 +25732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25764,7 +25751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25779,7 +25766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25798,7 +25785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25813,7 +25800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25832,7 +25819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25847,7 +25834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25866,7 +25853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25881,7 +25868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25900,7 +25887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25915,7 +25902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25934,7 +25921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25949,7 +25936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25968,7 +25955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -25983,7 +25970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26002,7 +25989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26017,7 +26004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 613,
+        "line": 612,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -26036,7 +26023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26051,7 +26038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26070,7 +26057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26085,7 +26072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26104,7 +26091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26119,7 +26106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26138,7 +26125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26153,7 +26140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26172,7 +26159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26187,7 +26174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26206,7 +26193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26221,7 +26208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26240,7 +26227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26255,7 +26242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26274,7 +26261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26289,7 +26276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26308,7 +26295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26323,7 +26310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26342,7 +26329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26357,7 +26344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26376,7 +26363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26391,7 +26378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26410,7 +26397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26425,7 +26412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26444,7 +26431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26459,7 +26446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26478,7 +26465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26493,7 +26480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26512,7 +26499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26527,7 +26514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26546,7 +26533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26561,7 +26548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26580,7 +26567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26595,7 +26582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26614,7 +26601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26629,7 +26616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26648,7 +26635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26663,7 +26650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26682,7 +26669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26697,7 +26684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26716,7 +26703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26731,7 +26718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26750,7 +26737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26765,7 +26752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26784,7 +26771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26799,7 +26786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26818,7 +26805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26833,7 +26820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26852,7 +26839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26867,7 +26854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26886,7 +26873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26901,7 +26888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26920,7 +26907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26935,7 +26922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26954,7 +26941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -26969,7 +26956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26988,7 +26975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27003,7 +26990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27022,7 +27009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27037,7 +27024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27056,7 +27043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27071,7 +27058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27090,7 +27077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27105,7 +27092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27124,7 +27111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27139,7 +27126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27158,7 +27145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27173,7 +27160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27192,7 +27179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27207,7 +27194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27226,7 +27213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27241,7 +27228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27260,7 +27247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27275,7 +27262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27294,7 +27281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27309,7 +27296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27328,7 +27315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27343,7 +27330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27362,7 +27349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27377,7 +27364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27396,7 +27383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27411,7 +27398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27430,7 +27417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27445,7 +27432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27464,7 +27451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27479,7 +27466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27498,7 +27485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27513,7 +27500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27532,7 +27519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27547,7 +27534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27566,7 +27553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27581,7 +27568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27600,7 +27587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27615,7 +27602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27634,7 +27621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27649,7 +27636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27668,7 +27655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27683,7 +27670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27702,7 +27689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27717,7 +27704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27736,7 +27723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27751,7 +27738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27770,7 +27757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27785,7 +27772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27804,7 +27791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27819,7 +27806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27838,7 +27825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27853,7 +27840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27872,7 +27859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27887,7 +27874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27906,7 +27893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27921,7 +27908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27940,7 +27927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27955,7 +27942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27974,7 +27961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -27989,7 +27976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28008,7 +27995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28023,7 +28010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28042,7 +28029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28057,7 +28044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28076,7 +28063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28091,7 +28078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28110,7 +28097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28125,7 +28112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28144,7 +28131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28159,7 +28146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28178,7 +28165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28193,7 +28180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28212,7 +28199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28227,7 +28214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28246,7 +28233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28261,7 +28248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28280,7 +28267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28295,7 +28282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28314,7 +28301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28329,7 +28316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28348,7 +28335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28363,7 +28350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28382,7 +28369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28397,7 +28384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28416,7 +28403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28431,7 +28418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28450,7 +28437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28465,7 +28452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28484,7 +28471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28499,7 +28486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28518,7 +28505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28533,7 +28520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28552,7 +28539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28567,7 +28554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28586,7 +28573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28601,7 +28588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28620,7 +28607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28635,7 +28622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28654,7 +28641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28669,7 +28656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28688,7 +28675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28703,7 +28690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28722,7 +28709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28737,7 +28724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28756,7 +28743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28771,7 +28758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28790,7 +28777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28805,7 +28792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28824,7 +28811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28839,7 +28826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28858,7 +28845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28873,7 +28860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28892,7 +28879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28907,7 +28894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28926,7 +28913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28941,7 +28928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28960,7 +28947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -28975,7 +28962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28994,7 +28981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29009,7 +28996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29028,7 +29015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29043,7 +29030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29062,7 +29049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29077,7 +29064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29096,7 +29083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29111,7 +29098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29130,7 +29117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29145,7 +29132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29164,7 +29151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29179,7 +29166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29198,7 +29185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29213,7 +29200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29232,7 +29219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29247,7 +29234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29266,7 +29253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29281,7 +29268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29300,7 +29287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29315,7 +29302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29334,7 +29321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29349,7 +29336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29368,7 +29355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29383,7 +29370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29402,7 +29389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29417,7 +29404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29436,7 +29423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29451,7 +29438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29470,7 +29457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29485,7 +29472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29504,7 +29491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29519,7 +29506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29538,7 +29525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29553,7 +29540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29572,7 +29559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29587,7 +29574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29606,7 +29593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29621,7 +29608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29640,7 +29627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29655,7 +29642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29674,7 +29661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29689,7 +29676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29708,7 +29695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29723,7 +29710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29742,7 +29729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29757,7 +29744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29776,7 +29763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29791,7 +29778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29810,7 +29797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29825,7 +29812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29844,7 +29831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29859,7 +29846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29878,7 +29865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29893,7 +29880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29912,7 +29899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29927,7 +29914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29946,7 +29933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29961,7 +29948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29980,7 +29967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -29995,7 +29982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30014,7 +30001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30029,7 +30016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30048,7 +30035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30063,7 +30050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30082,7 +30069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30097,7 +30084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30116,7 +30103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30131,7 +30118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30150,7 +30137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30165,7 +30152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30184,7 +30171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30199,7 +30186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30218,7 +30205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30233,7 +30220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30252,7 +30239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30267,7 +30254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30286,7 +30273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30301,7 +30288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30320,7 +30307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30335,7 +30322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30354,7 +30341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30369,7 +30356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30388,7 +30375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30403,7 +30390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30422,7 +30409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30437,7 +30424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30456,7 +30443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30471,7 +30458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30490,7 +30477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30505,7 +30492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30524,7 +30511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30539,7 +30526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30558,7 +30545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30573,7 +30560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30592,7 +30579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30607,7 +30594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30626,7 +30613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30641,7 +30628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30660,7 +30647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30675,7 +30662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30694,7 +30681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30709,7 +30696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30728,7 +30715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30743,7 +30730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30762,7 +30749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30777,7 +30764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30796,7 +30783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30811,7 +30798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30830,7 +30817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30845,7 +30832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30864,7 +30851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30879,7 +30866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30898,7 +30885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30913,7 +30900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30932,7 +30919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30947,7 +30934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30966,7 +30953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -30981,7 +30968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31000,7 +30987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31015,7 +31002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31034,7 +31021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31049,7 +31036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31068,7 +31055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31083,7 +31070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31102,7 +31089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31117,7 +31104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31136,7 +31123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31151,7 +31138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31170,7 +31157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31185,7 +31172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31204,7 +31191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31219,7 +31206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31238,7 +31225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31253,7 +31240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31272,7 +31259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31287,7 +31274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31306,7 +31293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31321,7 +31308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31340,7 +31327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31355,7 +31342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31374,7 +31361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31389,7 +31376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31408,7 +31395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31423,7 +31410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31442,7 +31429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31457,7 +31444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31476,7 +31463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31491,7 +31478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31510,7 +31497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31525,7 +31512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31544,7 +31531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31559,7 +31546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31578,7 +31565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31593,7 +31580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31612,7 +31599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31627,7 +31614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31646,7 +31633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31661,7 +31648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31680,7 +31667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31695,7 +31682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31714,7 +31701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31729,7 +31716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31748,7 +31735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31763,7 +31750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31782,7 +31769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31797,7 +31784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31816,7 +31803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31831,7 +31818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31850,7 +31837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31865,7 +31852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31884,7 +31871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31899,7 +31886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31918,7 +31905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31933,7 +31920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31952,7 +31939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -31967,7 +31954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31986,7 +31973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32001,7 +31988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32020,7 +32007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32035,7 +32022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32054,7 +32041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32069,7 +32056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32088,7 +32075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32103,7 +32090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32122,7 +32109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32137,7 +32124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32156,7 +32143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32171,7 +32158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 927,
+        "line": 926,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32190,7 +32177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32205,7 +32192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 927,
+        "line": 926,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32224,7 +32211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32239,7 +32226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 926,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32258,7 +32245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32273,7 +32260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32292,7 +32279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32307,7 +32294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32326,7 +32313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32341,7 +32328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32360,7 +32347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32375,7 +32362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32394,7 +32381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32409,7 +32396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32428,7 +32415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32443,7 +32430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32462,7 +32449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32477,7 +32464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32496,7 +32483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32511,7 +32498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 942,
+        "line": 941,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32530,7 +32517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32545,7 +32532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 942,
+        "line": 941,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32564,7 +32551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32579,7 +32566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 942,
+        "line": 941,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32598,7 +32585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32613,7 +32600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32632,7 +32619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32647,7 +32634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32666,7 +32653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32681,7 +32668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32700,7 +32687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32715,7 +32702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32734,7 +32721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32749,7 +32736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 966,
+        "line": 965,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32768,7 +32755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32783,7 +32770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 966,
+        "line": 965,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32791,40 +32778,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/image/scaling.py"
-      },
-      {
-        "alias": "_adapter_comfy_max_resolution",
-        "bound_name": "_adapter_comfy_max_resolution",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 573,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_comfy_max_resolution",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
-        "kind": "static_from",
-        "line": 974,
-        "name": "_comfy_max_resolution",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
         "alias": "_comfy_sampler_names",
@@ -32836,7 +32789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32851,7 +32804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32870,7 +32823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32885,7 +32838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32904,7 +32857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32919,7 +32872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32938,7 +32891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32953,7 +32906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32972,7 +32925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -32987,7 +32940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33006,7 +32959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33021,7 +32974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33040,7 +32993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33055,7 +33008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33074,7 +33027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33089,7 +33042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33108,7 +33061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33123,7 +33076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33142,7 +33095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33157,7 +33110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33176,7 +33129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33191,7 +33144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33210,7 +33163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33225,7 +33178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -33244,7 +33197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33259,7 +33212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33278,7 +33231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33293,7 +33246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33312,7 +33265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33327,7 +33280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33346,7 +33299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33361,7 +33314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33380,7 +33333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33395,7 +33348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33414,7 +33367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33429,7 +33382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33448,7 +33401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33463,7 +33416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33482,7 +33435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33497,7 +33450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1004,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33516,7 +33469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33531,7 +33484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33550,7 +33503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33565,7 +33518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33584,7 +33537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33599,7 +33552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33618,7 +33571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33633,7 +33586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33652,7 +33605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33667,7 +33620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33686,7 +33639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33701,7 +33654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33720,7 +33673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33735,7 +33688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33754,7 +33707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33769,7 +33722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33788,7 +33741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33803,7 +33756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33822,7 +33775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33837,7 +33790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33856,7 +33809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33871,7 +33824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33890,7 +33843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33905,7 +33858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1025,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33924,7 +33877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33939,7 +33892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1025,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33958,7 +33911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -33973,7 +33926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1025,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33992,7 +33945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34007,7 +33960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34026,7 +33979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34041,7 +33994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34060,7 +34013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34075,7 +34028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34094,7 +34047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34109,7 +34062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34128,7 +34081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34143,7 +34096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34162,7 +34115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34177,7 +34130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34196,7 +34149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34211,7 +34164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34230,7 +34183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34245,7 +34198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34264,7 +34217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34279,7 +34232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34298,7 +34251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34313,7 +34266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34332,7 +34285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34347,7 +34300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34366,7 +34319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34381,7 +34334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34400,7 +34353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34415,7 +34368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34434,7 +34387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34449,7 +34402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34468,7 +34421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34483,7 +34436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34502,7 +34455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34517,7 +34470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34536,7 +34489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34551,7 +34504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34570,7 +34523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34585,7 +34538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34604,7 +34557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34619,7 +34572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34638,7 +34591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34653,7 +34606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34672,7 +34625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34687,7 +34640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34706,7 +34659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34721,7 +34674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34740,7 +34693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34755,7 +34708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34774,7 +34727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34789,7 +34742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34808,7 +34761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34823,7 +34776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34842,7 +34795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34857,7 +34810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34876,7 +34829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34891,7 +34844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34910,7 +34863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34925,7 +34878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34944,7 +34897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34959,7 +34912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34978,7 +34931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -34993,7 +34946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35012,7 +34965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35027,7 +34980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35046,7 +34999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35061,7 +35014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35080,7 +35033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35095,7 +35048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1102,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -35114,7 +35067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35129,7 +35082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1102,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -35148,7 +35101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35163,7 +35116,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -35182,7 +35135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35197,7 +35150,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -35216,7 +35169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35231,7 +35184,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1107,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -35250,7 +35203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35265,7 +35218,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -35284,7 +35237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35299,7 +35252,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35318,7 +35271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35333,7 +35286,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35352,7 +35305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35367,7 +35320,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1113,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35386,7 +35339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35401,7 +35354,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1113,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35420,7 +35373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35435,7 +35388,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35454,7 +35407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35469,7 +35422,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35488,7 +35441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35503,7 +35456,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35522,7 +35475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35537,7 +35490,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35556,7 +35509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35571,7 +35524,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35590,7 +35543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35605,7 +35558,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35624,7 +35577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35639,7 +35592,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35658,7 +35611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35673,7 +35626,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35692,7 +35645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35707,7 +35660,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35726,7 +35679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35741,7 +35694,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35760,7 +35713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35775,7 +35728,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35794,7 +35747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35809,7 +35762,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35828,7 +35781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35843,7 +35796,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35862,7 +35815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35877,7 +35830,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35896,7 +35849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35911,7 +35864,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35930,7 +35883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35945,7 +35898,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35964,7 +35917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -35979,7 +35932,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35998,7 +35951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -36013,7 +35966,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36032,7 +35985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -36047,7 +36000,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36065,7 +36018,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1633
+            "line": 1631
           }
         ],
         "classification": "external",
@@ -36073,32 +36026,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1634,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_comfy_max_resolution",
-        "source": "nodes.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1641
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1642,
+        "line": 1632,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -36115,7 +36043,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1649
+            "line": 1639
           }
         ],
         "classification": "external",
@@ -36123,7 +36051,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1650,
+        "line": 1640,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -37826,6 +37754,10 @@
       },
       {
         "from": "easyuse_anima/infrastructure/comfy/wiring.py",
+        "to": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "from": "easyuse_anima/infrastructure/comfy/wiring.py",
         "to": "easyuse_anima/runtime.py"
       },
       {
@@ -39433,13 +39365,13 @@
       },
       {
         "is_package": false,
-        "loc": 65,
+        "loc": 73,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
-        "normalized_git_blob_sha1": "e967ae92154c7a44c35a9a1b64c1dfdca056779e",
+        "normalized_git_blob_sha1": "cff4535e750467eee9acd8da8e144b99f1f17094",
         "path": "easyuse_anima/infrastructure/comfy/wiring.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 1,
+          "function_count": 2,
           "global_count": 1
         }
       },
@@ -39841,13 +39773,13 @@
       },
       {
         "is_package": false,
-        "loc": 1915,
+        "loc": 1905,
         "module": "nodes",
-        "normalized_git_blob_sha1": "237571d35c003e7b9d9cc2a6fec8dcdf08aca61a",
+        "normalized_git_blob_sha1": "feb425693e6213764338a87bdda6f5c88b0ed632",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 8,
+          "function_count": 7,
           "global_count": 26
         }
       },
@@ -41207,7 +41139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41216,7 +41148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41230,7 +41162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41239,7 +41171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41253,7 +41185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41262,7 +41194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41276,7 +41208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41285,7 +41217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41299,7 +41231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41308,7 +41240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41322,7 +41254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41331,7 +41263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41345,7 +41277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41354,7 +41286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41368,7 +41300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41377,7 +41309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 574,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41391,7 +41323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41400,7 +41332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41414,7 +41346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41423,7 +41355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41437,7 +41369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41446,7 +41378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41460,7 +41392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41469,7 +41401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41483,7 +41415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41492,7 +41424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41506,7 +41438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41515,7 +41447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41529,7 +41461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41538,7 +41470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41552,7 +41484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41561,7 +41493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 585,
+        "line": 584,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41575,7 +41507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41584,7 +41516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41598,7 +41530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41607,7 +41539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41621,7 +41553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41630,7 +41562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41644,7 +41576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41653,7 +41585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41667,7 +41599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41676,7 +41608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41690,7 +41622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41699,7 +41631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41713,7 +41645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41722,7 +41654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41736,7 +41668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41745,7 +41677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41759,7 +41691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41768,7 +41700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41782,7 +41714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41791,7 +41723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41805,7 +41737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41814,7 +41746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41828,7 +41760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41837,7 +41769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41851,7 +41783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41860,7 +41792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41874,7 +41806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41883,7 +41815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41897,7 +41829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41906,7 +41838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41920,7 +41852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41929,7 +41861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 595,
+        "line": 594,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41943,7 +41875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41952,7 +41884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 613,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41966,7 +41898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41975,7 +41907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41989,7 +41921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -41998,7 +41930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42012,7 +41944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42021,7 +41953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42035,7 +41967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42044,7 +41976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42058,7 +41990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42067,7 +41999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42081,7 +42013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42090,7 +42022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42104,7 +42036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42113,7 +42045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42127,7 +42059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42136,7 +42068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 621,
+        "line": 620,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42150,7 +42082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42159,7 +42091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42173,7 +42105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42182,7 +42114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42196,7 +42128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42205,7 +42137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42219,7 +42151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42228,7 +42160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 627,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42242,7 +42174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42251,7 +42183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42265,7 +42197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42274,7 +42206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42288,7 +42220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42297,7 +42229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42311,7 +42243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42320,7 +42252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42334,7 +42266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42343,7 +42275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42357,7 +42289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42366,7 +42298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42380,7 +42312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42389,7 +42321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42403,7 +42335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42412,7 +42344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42426,7 +42358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42435,7 +42367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42449,7 +42381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42458,7 +42390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42472,7 +42404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42481,7 +42413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42495,7 +42427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42504,7 +42436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42518,7 +42450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42527,7 +42459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 634,
+        "line": 633,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42541,7 +42473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42550,7 +42482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42564,7 +42496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42573,7 +42505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42587,7 +42519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42596,7 +42528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42610,7 +42542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42619,7 +42551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42633,7 +42565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42642,7 +42574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42656,7 +42588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42665,7 +42597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42679,7 +42611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42688,7 +42620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42702,7 +42634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42711,7 +42643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42725,7 +42657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42734,7 +42666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42748,7 +42680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42757,7 +42689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42771,7 +42703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42780,7 +42712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42794,7 +42726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42803,7 +42735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 649,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42817,7 +42749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42826,7 +42758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42840,7 +42772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42849,7 +42781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42863,7 +42795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42872,7 +42804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42886,7 +42818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42895,7 +42827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42909,7 +42841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42918,7 +42850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42932,7 +42864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42941,7 +42873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42955,7 +42887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42964,7 +42896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42978,7 +42910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -42987,7 +42919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43001,7 +42933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43010,7 +42942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43024,7 +42956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43033,7 +42965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 663,
+        "line": 662,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43047,7 +42979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43056,7 +42988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43070,7 +43002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43079,7 +43011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43093,7 +43025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43102,7 +43034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43116,7 +43048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43125,7 +43057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43139,7 +43071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43148,7 +43080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43162,7 +43094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43171,7 +43103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43185,7 +43117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43194,7 +43126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43208,7 +43140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43217,7 +43149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43231,7 +43163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43240,7 +43172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43254,7 +43186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43263,7 +43195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 675,
+        "line": 674,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43277,7 +43209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43286,7 +43218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43300,7 +43232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43309,7 +43241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43323,7 +43255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43332,7 +43264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43346,7 +43278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43355,7 +43287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43369,7 +43301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43378,7 +43310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43392,7 +43324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43401,7 +43333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43415,7 +43347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43424,7 +43356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43438,7 +43370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43447,7 +43379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43461,7 +43393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43470,7 +43402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43484,7 +43416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43493,7 +43425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43507,7 +43439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43516,7 +43448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43530,7 +43462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43539,7 +43471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43553,7 +43485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43562,7 +43494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43576,7 +43508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43585,7 +43517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43599,7 +43531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43608,7 +43540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43622,7 +43554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43631,7 +43563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 687,
+        "line": 686,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43645,7 +43577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43654,7 +43586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43668,7 +43600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43677,7 +43609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43691,7 +43623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43700,7 +43632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43714,7 +43646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43723,7 +43655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43737,7 +43669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43746,7 +43678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43760,7 +43692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43769,7 +43701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43783,7 +43715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43792,7 +43724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43806,7 +43738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43815,7 +43747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 710,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43829,7 +43761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43838,7 +43770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43852,7 +43784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43861,7 +43793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43875,7 +43807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43884,7 +43816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43898,7 +43830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43907,7 +43839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43921,7 +43853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43930,7 +43862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 718,
+        "line": 717,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43944,7 +43876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43953,7 +43885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43967,7 +43899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43976,7 +43908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43990,7 +43922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -43999,7 +43931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44013,7 +43945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44022,7 +43954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44036,7 +43968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44045,7 +43977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44059,7 +43991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44068,7 +44000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44082,7 +44014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44091,7 +44023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44105,7 +44037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44114,7 +44046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44128,7 +44060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44137,7 +44069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44151,7 +44083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44160,7 +44092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 724,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44174,7 +44106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44183,7 +44115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44197,7 +44129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44206,7 +44138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44220,7 +44152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44229,7 +44161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44243,7 +44175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44252,7 +44184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44266,7 +44198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44275,7 +44207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44289,7 +44221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44298,7 +44230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44312,7 +44244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44321,7 +44253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 738,
+        "line": 737,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44335,7 +44267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44344,7 +44276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44358,7 +44290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44367,7 +44299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44381,7 +44313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44390,7 +44322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44404,7 +44336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44413,7 +44345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44427,7 +44359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44436,7 +44368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44450,7 +44382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44459,7 +44391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44473,7 +44405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44482,7 +44414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44496,7 +44428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44505,7 +44437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44519,7 +44451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44528,7 +44460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44542,7 +44474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44551,7 +44483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44565,7 +44497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44574,7 +44506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44588,7 +44520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44597,7 +44529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44611,7 +44543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44620,7 +44552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44634,7 +44566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44643,7 +44575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44657,7 +44589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44666,7 +44598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44680,7 +44612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44689,7 +44621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44703,7 +44635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44712,7 +44644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44726,7 +44658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44735,7 +44667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44749,7 +44681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44758,7 +44690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44772,7 +44704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44781,7 +44713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44795,7 +44727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44804,7 +44736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44818,7 +44750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44827,7 +44759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 756,
+        "line": 755,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44841,7 +44773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44850,7 +44782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44864,7 +44796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44873,7 +44805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44887,7 +44819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44896,7 +44828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44910,7 +44842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44919,7 +44851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44933,7 +44865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44942,7 +44874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44956,7 +44888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44965,7 +44897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44979,7 +44911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -44988,7 +44920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45002,7 +44934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45011,7 +44943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45025,7 +44957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45034,7 +44966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45048,7 +44980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45057,7 +44989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45071,7 +45003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45080,7 +45012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45094,7 +45026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45103,7 +45035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45117,7 +45049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45126,7 +45058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45140,7 +45072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45149,7 +45081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 792,
+        "line": 791,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45163,7 +45095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45172,7 +45104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45186,7 +45118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45195,7 +45127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45209,7 +45141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45218,7 +45150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45232,7 +45164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45241,7 +45173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45255,7 +45187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45264,7 +45196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45278,7 +45210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45287,7 +45219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45301,7 +45233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45310,7 +45242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45324,7 +45256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45333,7 +45265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45347,7 +45279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45356,7 +45288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 820,
+        "line": 819,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45370,7 +45302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45379,7 +45311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45393,7 +45325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45402,7 +45334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45416,7 +45348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45425,7 +45357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45439,7 +45371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45448,7 +45380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45462,7 +45394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45471,7 +45403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45485,7 +45417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45494,7 +45426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45508,7 +45440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45517,7 +45449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45531,7 +45463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45540,7 +45472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45554,7 +45486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45563,7 +45495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45577,7 +45509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45586,7 +45518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45600,7 +45532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45609,7 +45541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45623,7 +45555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45632,7 +45564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45646,7 +45578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45655,7 +45587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45669,7 +45601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45678,7 +45610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45692,7 +45624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45701,7 +45633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45715,7 +45647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45724,7 +45656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45738,7 +45670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45747,7 +45679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45761,7 +45693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45770,7 +45702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45784,7 +45716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45793,7 +45725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45807,7 +45739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45816,7 +45748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45830,7 +45762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45839,7 +45771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45853,7 +45785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45862,7 +45794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45876,7 +45808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45885,7 +45817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45899,7 +45831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45908,7 +45840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45922,7 +45854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45931,7 +45863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 836,
+        "line": 835,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45945,7 +45877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45954,7 +45886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45968,7 +45900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -45977,7 +45909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45991,7 +45923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46000,7 +45932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46014,7 +45946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46023,7 +45955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 916,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46037,7 +45969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46046,7 +45978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46060,7 +45992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46069,7 +46001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46083,7 +46015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46092,7 +46024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46106,7 +46038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46115,7 +46047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 927,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46129,7 +46061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46138,7 +46070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 927,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46152,7 +46084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46161,7 +46093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46175,7 +46107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46184,7 +46116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46198,7 +46130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46207,7 +46139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46221,7 +46153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46230,7 +46162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46244,7 +46176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46253,7 +46185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46267,7 +46199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46276,7 +46208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46290,7 +46222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46299,7 +46231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46313,7 +46245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46322,7 +46254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 933,
+        "line": 932,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46336,7 +46268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46345,7 +46277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 942,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46359,7 +46291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46368,7 +46300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 942,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46382,7 +46314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46391,7 +46323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 942,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46405,7 +46337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46414,7 +46346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46428,7 +46360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46437,7 +46369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46451,7 +46383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46460,7 +46392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46474,7 +46406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46483,7 +46415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 953,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46497,7 +46429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46506,7 +46438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 966,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46520,7 +46452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46529,7 +46461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 966,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46543,30 +46475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_max_resolution",
-        "kind": "static_from",
-        "line": 974,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46575,7 +46484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46589,7 +46498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46598,7 +46507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46612,7 +46521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46621,7 +46530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46635,7 +46544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46644,7 +46553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46658,7 +46567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46667,7 +46576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46681,7 +46590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46690,7 +46599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46704,7 +46613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46713,7 +46622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 974,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46727,7 +46636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46736,7 +46645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46750,7 +46659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46759,7 +46668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46773,7 +46682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46782,7 +46691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46796,7 +46705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46805,7 +46714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 985,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46819,7 +46728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46828,7 +46737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 991,
+        "line": 989,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46842,7 +46751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46851,7 +46760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46865,7 +46774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46874,7 +46783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46888,7 +46797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46897,7 +46806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46911,7 +46820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46920,7 +46829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46934,7 +46843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46943,7 +46852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46957,7 +46866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46966,7 +46875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46980,7 +46889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -46989,7 +46898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47003,7 +46912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47012,7 +46921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1004,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47026,7 +46935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47035,7 +46944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47049,7 +46958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47058,7 +46967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47072,7 +46981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47081,7 +46990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 1008,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47095,7 +47004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47104,7 +47013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47118,7 +47027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47127,7 +47036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47141,7 +47050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47150,7 +47059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47164,7 +47073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47173,7 +47082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47187,7 +47096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47196,7 +47105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1013,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47210,7 +47119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47219,7 +47128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47233,7 +47142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47242,7 +47151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47256,7 +47165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47265,7 +47174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1022,
+        "line": 1020,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47279,7 +47188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47288,7 +47197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47302,7 +47211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47311,7 +47220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47325,7 +47234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47334,7 +47243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1027,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47348,7 +47257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47357,7 +47266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47371,7 +47280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47380,7 +47289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47394,7 +47303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47403,7 +47312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47417,7 +47326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47426,7 +47335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47440,7 +47349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47449,7 +47358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1043,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47463,7 +47372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47472,7 +47381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47486,7 +47395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47495,7 +47404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47509,7 +47418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47518,7 +47427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47532,7 +47441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47541,7 +47450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1072,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47555,7 +47464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47564,7 +47473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47578,7 +47487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47587,7 +47496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47601,7 +47510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47610,7 +47519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47624,7 +47533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47633,7 +47542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47647,7 +47556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47656,7 +47565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47670,7 +47579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47679,7 +47588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47693,7 +47602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47702,7 +47611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47716,7 +47625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47725,7 +47634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47739,7 +47648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47748,7 +47657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47762,7 +47671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47771,7 +47680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47785,7 +47694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47794,7 +47703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47808,7 +47717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47817,7 +47726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47831,7 +47740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47840,7 +47749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47854,7 +47763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47863,7 +47772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47877,7 +47786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47886,7 +47795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1077,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47900,7 +47809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47909,7 +47818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47923,7 +47832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47932,7 +47841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47946,7 +47855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47955,7 +47864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47969,7 +47878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -47978,7 +47887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47992,7 +47901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48001,7 +47910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48015,7 +47924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48024,7 +47933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48038,7 +47947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48047,7 +47956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48061,7 +47970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48070,7 +47979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48084,7 +47993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48093,7 +48002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48107,7 +48016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48116,7 +48025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48130,7 +48039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48139,7 +48048,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48153,7 +48062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48162,7 +48071,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48176,7 +48085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48185,7 +48094,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1109,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48199,7 +48108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48208,7 +48117,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48222,7 +48131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48231,7 +48140,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48245,7 +48154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48254,7 +48163,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1110,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48268,7 +48177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48277,7 +48186,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1113,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48291,7 +48200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48300,7 +48209,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1115,
+        "line": 1113,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48314,7 +48223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48323,7 +48232,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48337,7 +48246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48346,7 +48255,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48360,7 +48269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48369,7 +48278,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48383,7 +48292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48392,7 +48301,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48406,7 +48315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48415,7 +48324,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48429,7 +48338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48438,7 +48347,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48452,7 +48361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48461,7 +48370,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48475,7 +48384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48484,7 +48393,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48498,7 +48407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48507,7 +48416,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48521,7 +48430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48530,7 +48439,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48544,7 +48453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48553,7 +48462,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48567,7 +48476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48576,7 +48485,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48590,7 +48499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48599,7 +48508,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48613,7 +48522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48622,7 +48531,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48636,7 +48545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48645,7 +48554,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48659,7 +48568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48668,7 +48577,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48682,7 +48591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48691,7 +48600,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48705,7 +48614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48714,7 +48623,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48728,7 +48637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 573,
+            "handler_line": 572,
             "kind": "try",
             "line": 9
           }
@@ -48737,7 +48646,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1116,
+        "line": 1114,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52682,14 +52591,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1633
+            "line": 1631
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1634,
+        "line": 1632,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -52701,33 +52610,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1641
+            "line": 1639
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1642,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1649
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1650,
+        "line": 1640,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54121,14 +54011,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1633
+            "line": 1631
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1634,
+        "line": 1632,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -54140,33 +54030,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1641
+            "line": 1639
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1642,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1649
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1650,
+        "line": 1640,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55642,7 +55513,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1138,
+        "line": 1136,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55651,7 +55522,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1766,
+        "line": 1756,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55660,7 +55531,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1769,
+        "line": 1759,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55669,7 +55540,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1775,
+        "line": 1765,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55678,7 +55549,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1781,
+        "line": 1771,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55687,7 +55558,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1784,
+        "line": 1774,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55696,7 +55567,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1787,
+        "line": 1777,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55705,7 +55576,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1793,
+        "line": 1783,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55714,7 +55585,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1799,
+        "line": 1789,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55723,7 +55594,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1805,
+        "line": 1795,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55732,7 +55603,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1811,
+        "line": 1801,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55741,7 +55612,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1817,
+        "line": 1807,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55750,7 +55621,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1823,
+        "line": 1813,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55759,7 +55630,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1829,
+        "line": 1819,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55768,7 +55639,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1835,
+        "line": 1825,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55777,7 +55648,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1841,
+        "line": 1831,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55786,7 +55657,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1844,
+        "line": 1834,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55795,7 +55666,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1851,
+        "line": 1841,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55804,7 +55675,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1854,
+        "line": 1844,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55813,7 +55684,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1858,
+        "line": 1848,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55822,7 +55693,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1861,
+        "line": 1851,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55831,7 +55702,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1868,
+        "line": 1858,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55840,7 +55711,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1874,
+        "line": 1864,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55849,7 +55720,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1880,
+        "line": 1870,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55858,7 +55729,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1883,
+        "line": 1873,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55867,7 +55738,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1886,
+        "line": 1876,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55876,7 +55747,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1889,
+        "line": 1879,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55885,7 +55756,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1896,
+        "line": 1886,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55894,7 +55765,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1902,
+        "line": 1892,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55903,7 +55774,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1907,
+        "line": 1897,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55912,7 +55783,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1911,
+        "line": 1901,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56426,13 +56297,13 @@
       },
       {
         "kind": "dict",
-        "line": 1200,
+        "line": 1198,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1189,
+        "line": 1187,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -58,7 +58,8 @@
       "B-11c25",
       "B-11c26",
       "B-11c27",
-      "B-11c28"
+      "B-11c28",
+      "B-11c29a"
     ]
   },
   "enums": {
@@ -93,11 +94,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 301,
+    "nodes_canonical_bindings": 300,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 8,
+    "root_residual_functions": 7,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -642,11 +643,6 @@
     ],
     "_comfy_diffusion_model_names": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_comfy_max_resolution": [
-      "easyuse_anima.aio.generation_normalization",
-      "easyuse_anima.nodes.impact_detailer_nodes",
-      "easyuse_anima.nodes.sam3_nodes"
     ],
     "_comfy_sampler_names": [
       "easyuse_anima.aio.generation_normalization"
@@ -2697,7 +2693,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.capabilities:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_adapter_comfy_max_resolution": "_comfy_max_resolution",
         "_adapter_find_comfy_node_class": "_find_comfy_node_class",
         "_adapter_find_loaded_node_class": "_find_loaded_node_class",
         "_adapter_require_any_custom_node_class": "_require_any_custom_node_class",
@@ -4253,7 +4248,6 @@
       "surface": "nodes_root_residuals",
       "kind": "functions",
       "symbols": {
-        "_comfy_max_resolution": "_comfy_max_resolution",
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
         "_encode_with_comfy_clip": "_encode_with_comfy_clip",
         "_find_comfy_node_class": "_find_comfy_node_class",

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import sys
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -59,6 +61,21 @@ class ComfyHostWiringTests(unittest.TestCase):
             helper("Example"),
             ("_find_comfy_node_class", ("Example",)),
         )
+
+    def test_retired_max_resolution_uses_default_provider_before_runtime_install(self):
+        comfy_nodes = types.ModuleType("nodes")
+        comfy_nodes.MAX_RESOLUTION = "8192"
+
+        def unexpected_fallback(name: str):
+            self.fail(f"retired helper reached root fallback: {name}")
+
+        with patch.dict(sys.modules, {"nodes": comfy_nodes}):
+            helper = resolve_comfy_host_helper(
+                "_comfy_max_resolution",
+                unexpected_fallback,
+            )
+
+            self.assertEqual(helper(), 8192)
 
     def test_provider_owned_helpers_delegate_to_narrow_methods(self):
         direct = object()

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2149,6 +2149,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
     )
 
     def test_root_nodes_comfy_aliases_are_canonical_objects(self):
+        self.assertFalse(hasattr(nodes, "_comfy_max_resolution"))
         for canonical_module, helper_names in self.DIRECT_HELPER_MODULES:
             for helper_name in helper_names:
                 with self.subTest(module=canonical_module.__name__, helper=helper_name):
@@ -2159,6 +2160,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
 
     def test_package_nodes_comfy_aliases_are_canonical_objects(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
+            self.assertFalse(hasattr(package_nodes, "_comfy_max_resolution"))
             self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
             self.assertFalse(hasattr(package_nodes, "_impact_core_module"))
             self.assertFalse(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "237571d35c003e7b9d9cc2a6fec8dcdf08aca61a")
-        # E-07b changes imports and binder composition only; the root
-        # executable-symbol counts remain at the B-11c28 boundary.
-        self.assertEqual(report["top_level"]["function_count"], 8)
+        self.assertEqual(report["git_blob_sha1"], "feb425693e6213764338a87bdda6f5c88b0ed632")
+        # B-11c29a retires the unsupported root max-resolution wrapper and
+        # its two adapter imports without changing the public class surface.
+        self.assertEqual(report["top_level"]["function_count"], 7)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_915)
+        self.assertEqual(report["line_count"], 1_905)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1043,6 +1043,10 @@ def _comfy_host_root_inventory(
     canonical_bindings: dict[str, str],
     ledger: dict[str, Any],
 ) -> dict[str, dict[str, Any]]:
+    entries = {
+        entry["symbol"]: entry
+        for entry in ledger["symbols"]
+    }
     adapter_aliases = {
         entry["symbol"]: entry["adapter_binding"]["alias"]
         for entry in ledger["symbols"]
@@ -1057,6 +1061,26 @@ def _comfy_host_root_inventory(
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
             and node.name == symbol
         ]
+        if entries[symbol]["root_signature"] is None:
+            retired_alias = entries[symbol].get("retired_adapter_alias")
+            if retired_alias is None:
+                raise AssertionError(
+                    f"{symbol} must record its retired adapter alias"
+                )
+            if retired_alias in canonical_bindings:
+                raise AssertionError(
+                    f"{symbol} retired adapter is still imported as {retired_alias}"
+                )
+            if definitions:
+                raise AssertionError(
+                    f"{symbol} is retired and must not have a root definition"
+                )
+            inventory[symbol] = {
+                "root_signature": None,
+                "adapter_binding": None,
+                "root_dependencies": [],
+            }
+            continue
         if len(definitions) != 1 or not isinstance(definitions[0], ast.FunctionDef):
             raise AssertionError(
                 f"{symbol} must have exactly one synchronous root definition"
@@ -1665,6 +1689,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c26",
                 "B-11c27",
                 "B-11c28",
+                "B-11c29a",
             ],
         },
         "enums": {
@@ -1677,11 +1702,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 301,
+            "nodes_canonical_bindings": 300,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 8,
+            "root_residual_functions": 7,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,
@@ -2101,6 +2126,20 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             "_find_loaded_node_class",
         }
         pure_helpers = set(COMFY_HOST_WRAPPERS) - provider_owned
+        retired = {
+            symbol
+            for symbol, entry in self.entries.items()
+            if entry["root_signature"] is None
+        }
+        self.assertEqual(retired, {"_comfy_max_resolution"})
+        self.assertEqual(
+            {
+                symbol: entry["retired_adapter_alias"]
+                for symbol, entry in self.entries.items()
+                if "retired_adapter_alias" in entry
+            },
+            {"_comfy_max_resolution": "_adapter_comfy_max_resolution"},
+        )
         for symbol, entry in self.entries.items():
             expected_classification = (
                 "provider_owned"


### PR DESCRIPTION
## 분류

- Task: B-11c29a
- Owner: #184
- Type: Move/retirement
- Base: `dev@14015769634d387fe5afa6a74a5594007e86346c`
- 검증 head: `b27baa366913f4d10fb7545aacfdca87c1cb008e`
- Contract/Behavior: 포함하지 않음

## 작업 전 inventory

- moving/retiring symbol: root `nodes._comfy_max_resolution() -> int` 하나
- current root dependency: relative/flat `_adapter_comfy_max_resolution`
- production callers: 3 slots
  - `easyuse_anima.aio.generation_normalization`
  - `easyuse_anima.nodes.impact_detailer_nodes`
  - `easyuse_anima.nodes.sam3_nodes`
- caller timing: 기존 binder/resolver를 통한 call-time resolution
- compatibility: private root seam은 `unsupported_test_only`
- root monkeypatch consumers: 0개
- canonical monkeypatch consumers: 2개
- confirmed external consumers: 0개
- global state/import-time calls: 없음
- optional host behavior: invocation 전까지 ComfyUI host optional, missing/invalid 값은 `16384`

Ledger 결정에 따라 root direct alias를 남기지 않고 retire했습니다. 설치된
runtime은 `ComfyHostProvider.max_resolution`을 계속 사용하고, pre-bootstrap
flat import는 wiring adapter의 fresh default-provider fallback으로 보존합니다.

## 변경 요약

- root `_comfy_max_resolution` 정의와 relative/flat adapter import 제거
- runtime 미설치 flat import에서만 fresh `DefaultComfyHostProvider`로 지연 조회
- retired root definition과 adapter import 재도입을 막는 수동 ledger gate 추가
- root/package 부재, provider/flat fallback, analyzer/fixture 계약 갱신
- 로드맵과 compatibility shim registry를 B-11c29a 완료/B-11c29b READY로 갱신

## 주요 파일

- `nodes.py`
- `easyuse_anima/infrastructure/comfy/wiring.py`
- `tests/test_comfy_host_wiring.py`
- `tests/test_node_contracts.py`
- `tests/test_python_compatibility_surface.py`
- analyzer/compatibility fixtures
- `docs/architecture/*`

## 검증

- focused unittest: 94개 통과
- 리뷰 보완 후 핵심 unittest: 37개 통과
- official full:
  - Python unittest 958개 통과
  - frontend 114개 JavaScript 파일 통과
  - TypeScript 6.0.3 통과
  - Pyright baseline ratchet 통과
  - G-03 import boundary 6개 그룹, 위반 0
  - git diff check 통과
- Ruff 113건은 기존 G-01 report-only baseline이며 blocking regression 없음
- `comfy node validate` 통과
- `comfy node pack`:
  - archive 218 entries
  - Python 86 files
  - analyzer shipped set과 missing/extra 0
  - `easyuse_anima/infrastructure/comfy/wiring.py` 포함

테스트 표면: ComfyUI Codex test environment의 repository full runner.
Live ComfyUI smoke는 실행하지 않았습니다.

## 남은 위험

- private unsupported root symbol을 직접 import하던 미확인 외부 코드는 더 이상
  해당 symbol을 찾지 못합니다. 공개 코드 검색상 확인된 external consumer는
  없으며 ledger 정책상 지원 대상이 아닙니다.
- 다른 6개 Comfy host root helper는 이 PR에서 이동하거나 변경하지 않았습니다.

## 롤백

root wrapper와 두 adapter import, flat fallback, ledger/analyzer 상태를 한 단위로
복원합니다.

## 다음 단계

B-11c29b node discovery family를 별도 Move/retirement 단위로 진행합니다.
