### PR TITLE
B-11c29b1: retire direct mapping node lookup

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -590,7 +590,7 @@ Forbidden:
 
 ### B-11c29b — Node discovery family
 
-- **State:** READY after B-11c29a
+- **State:** IN PROGRESS, split into B-11c29b1-b3
 - **Owner:** #184
 - **Type:** Move/retirement, split further when the ledger requires
 
@@ -604,6 +604,85 @@ _find_loaded_node_class
 
 Preserve direct mapping, attribute, and loaded-module lookup order. A new lookup
 cache is forbidden.
+
+The ledger requires three rollback units:
+
+1. **B-11c29b1:** direct mapping-only lookup,
+   `_find_comfy_node_mapping_class`;
+2. **B-11c29b2:** mapping/attribute/loaded-module lookup,
+   `_find_comfy_node_class`; and
+3. **B-11c29b3:** general lookup followed by loaded-module fallback,
+   `_find_loaded_node_class`.
+
+The first unit has one production consumer, no adapter import, no nested finder
+dependency, and no repository or confirmed external replacement consumer. The
+other two wrappers retain adapter imports and the loaded lookup depends on the
+general lookup, so combining them with B-11c29b1 would enlarge the rollback and
+compatibility boundary without need.
+
+#### B-11c29b1 — Direct mapping-only lookup
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Type:** Retirement
+
+Pre-edit inventory at `dev@0acc0152e1039d00c9387324faef43e9a7728219`:
+
+- root `nodes.py` owns one `_find_comfy_node_mapping_class(node_id: str)`
+  definition and no canonical adapter import for the symbol;
+- the wrapper has no mutable state or import-time call and performs only a
+  call-time host `nodes.NODE_CLASS_MAPPINGS.get(node_id)` lookup;
+- the one production consumer is `easyuse_anima.image.sam3`, which resolves the
+  name at call time through the E-07b provider wiring;
+- repository root replacements, canonical replacements, and confirmed external
+  consumers are all zero;
+- the ledger classifies the private root seam as `unsupported_test_only` and
+  does not require call-time root replacement; and
+- therefore this unit retires the root definition while the wiring adapter
+  preserves the runtime-missing flat-import path with a fresh default provider.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/infrastructure/comfy/wiring.py
+```
+
+Allowed test, fixture, and documentation files:
+
+```text
+tests/test_comfy_host_wiring.py
+tests/test_comfy_host_provider.py
+tests/test_node_contracts.py
+tests/test_sam3_nodes.py
+tests/test_python_compatibility_surface.py
+tests/test_nodes_module_analyzer.py
+tests/fixtures/comfy_host_compatibility.v1.json
+tests/fixtures/python_compatibility_surface.v1.json
+tests/fixtures/python_backend_baseline.json
+docs/architecture/*
+```
+
+Exit:
+
+- root `_find_comfy_node_mapping_class` is absent;
+- installed-runtime SAM3 lookup continues to use
+  `ComfyHostProvider.find_node_mapping_class`;
+- flat pre-bootstrap lookup remains delayed, mapping-only, and returns `None`
+  after missing or invalid host state;
+- retirement gates reject both a restored root definition and an undocumented
+  adapter alias; and
+- root residual/analyzer/package closure gates pass.
+
+Forbidden:
+
+- moving either general or loaded node lookup;
+- changing mapping, attribute, or loaded-module order;
+- changing `ComfyHostProvider`, the provider implementation, SAM3 feature
+  behavior, or node/workflow schemas;
+- adding cache, snapshot, mutable override state, or canonical root import; and
+- changing requirement, CLIP, seed, stage, route, persistence, or postprocess
+  behavior.
 
 ### B-11c29c — Required-node helpers
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -609,16 +609,19 @@ The ledger requires three rollback units:
 
 1. **B-11c29b1:** direct mapping-only lookup,
    `_find_comfy_node_mapping_class`;
-2. **B-11c29b2:** mapping/attribute/loaded-module lookup,
-   `_find_comfy_node_class`; and
-3. **B-11c29b3:** general lookup followed by loaded-module fallback,
-   `_find_loaded_node_class`.
+2. **B-11c29b2:** general lookup followed by loaded-module fallback,
+   `_find_loaded_node_class`; and
+3. **B-11c29b3:** mapping/attribute/loaded-module lookup,
+   `_find_comfy_node_class`.
 
 The first unit has one production consumer, no adapter import, no nested finder
 dependency, and no repository or confirmed external replacement consumer. The
-other two wrappers retain adapter imports and the loaded lookup depends on the
-general lookup, so combining them with B-11c29b1 would enlarge the rollback and
-compatibility boundary without need.
+other two wrappers retain adapter imports. The loaded wrapper can retire through
+its provider method while the general root lookup remains available to the
+root requirement and CLIP wrappers. Those wrappers must retire before the
+general lookup, so the executable order after B-11c29b2 is B-11c29c,
+B-11c29d, then B-11c29b3. Combining any of these with B-11c29b1 would enlarge
+the rollback and compatibility boundary without need.
 
 #### B-11c29b1 — Direct mapping-only lookup
 
@@ -686,7 +689,7 @@ Forbidden:
 
 ### B-11c29c — Required-node helpers
 
-- **State:** BLOCKED by B-11c29b
+- **State:** BLOCKED by B-11c29b2; precedes B-11c29b3
 - **Owner:** #184
 - **Type:** Move/retirement
 
@@ -702,7 +705,7 @@ helpers; do not expand the provider interface merely to host them.
 
 ### B-11c29d — CLIP invocation wrapper
 
-- **State:** BLOCKED by B-11c29b
+- **State:** BLOCKED by B-11c29b2; precedes B-11c29b3
 - **Owner:** #184
 - **Type:** Move/retirement
 
@@ -759,8 +762,10 @@ COMPLETE: E-07a default host provider / PR #327
 COMPLETE: E-07b wiring and compatibility gate / PR #328
 
 COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
-READY:    B-11c29b node-discovery wrapper Move/retirement
-BLOCKED:  B-11c29c-d wrapper Moves/retirements
+IN PROGRESS: B-11c29b1 direct mapping lookup retirement / PR #330
+BLOCKED:  B-11c29b2 loaded lookup retirement
+BLOCKED:  B-11c29c-d requirement and CLIP wrapper retirements
+BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -625,7 +625,7 @@ the rollback and compatibility boundary without need.
 
 #### B-11c29b1 — Direct mapping-only lookup
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE in PR #330
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -762,8 +762,8 @@ COMPLETE: E-07a default host provider / PR #327
 COMPLETE: E-07b wiring and compatibility gate / PR #328
 
 COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
-IN PROGRESS: B-11c29b1 direct mapping lookup retirement / PR #330
-BLOCKED:  B-11c29b2 loaded lookup retirement
+COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
+READY:    B-11c29b2 loaded lookup retirement
 BLOCKED:  B-11c29c-d requirement and CLIP wrapper retirements
 BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -625,7 +625,7 @@ the rollback and compatibility boundary without need.
 
 #### B-11c29b1 — Direct mapping-only lookup
 
-- **State:** COMPLETE in PR #330
+- **State:** IN PROGRESS in PR #330
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -762,8 +762,8 @@ COMPLETE: E-07a default host provider / PR #327
 COMPLETE: E-07b wiring and compatibility gate / PR #328
 
 COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
-COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
-READY:    B-11c29b2 loaded lookup retirement
+IN PROGRESS: B-11c29b1 direct mapping lookup retirement / PR #330
+BLOCKED:  B-11c29b2 loaded lookup retirement pending B-11c29b1 merge
 BLOCKED:  B-11c29c-d requirement and CLIP wrapper retirements
 BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29a / PR #329; B-11c29b1 direct mapping lookup retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29a / PR #329; B-11c29b1 direct mapping lookup retirement in PR #330 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -91,6 +91,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   E-07b established provider-backed call-time host wiring in PR #328, allowing
   B-11c29a to retire only the unsupported `_comfy_max_resolution` root wrapper
   in PR #329 while preserving the flat pre-bootstrap fallback.
+  B-11c29b1 retires only the unsupported direct mapping node lookup in PR #330;
+  loaded, requirement, CLIP, and general lookup retirements remain separate.
 
 ### Current quality baseline
 
@@ -332,7 +334,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29a / PR #329; B-11c29b split begins with mapping-only lookup retirement | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b1 direct mapping lookup retirement PR #330; next B-11c29b2 loaded lookup | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -977,6 +979,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     keeps installed-runtime consumers on `ComfyHostProvider.max_resolution`
     and flat pre-bootstrap consumers on a fresh default provider. Lookup order,
     integer conversion, and the `16384` fallback remain unchanged.
+  - B-11c29b1 retires only `_find_comfy_node_mapping_class` in PR #330.
+    Installed-runtime SAM3 consumers use the provider mapping method and flat
+    pre-bootstrap consumers use a fresh default provider. Attribute and
+    loaded-module scanning remain excluded from this lookup.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c28; B-11c29a max-resolution root retirement in PR #329 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29a / PR #329; B-11c29b1 direct mapping lookup retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -332,7 +332,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29a max-resolution root retirement PR #329; next B-11c29b node discovery | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29a / PR #329; B-11c29b split begins with mapping-only lookup retirement | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,10 +8,10 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c28 are integrated. B-11c is split into
+- Current state: B-11a through B-11c29a are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c29a retires the unsupported max-resolution root wrapper in
-  PR #329.
+  root shim; B-11c29b1 retires the unsupported direct mapping node lookup in
+  PR #330.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -85,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 7 functions, 0 classes, and 26 assigned
-  globals in B-11c29a (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 6 functions, 0 classes, and 26 assigned
+  globals in B-11c29b1 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 290, including
+- root names reached by those canonical runtime resolvers: 289, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -603,6 +603,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
   fallback remain unchanged without importing canonical code from root.
 - No provider cache, mutable override, schema change, or other host-helper Move
   is included.
+
+### B-11c29b1 direct mapping node-lookup retirement
+
+- `_find_comfy_node_mapping_class` is an unsupported/test-only private root seam
+  with one provider-wired SAM3 consumer and no repository replacement or
+  confirmed external consumer.
+- PR #330 removes only the root definition. There was no adapter alias for this
+  mapping-only wrapper.
+- Installed runtime uses `ComfyHostProvider.find_node_mapping_class`; flat
+  pre-bootstrap imports resolve a fresh default provider at call time.
+- Lookup remains limited to `NODE_CLASS_MAPPINGS.get(node_id)`. Host attributes
+  and loaded modules are not scanned, missing/invalid host state returns
+  `None`, and no cache or mutable override is added.
+- Loaded lookup, requirement helpers, CLIP invocation, and the general node
+  lookup remain separate retirement units.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -19,6 +19,10 @@ def _default_max_resolution() -> int:
     return DefaultComfyHostProvider().max_resolution()
 
 
+def _default_node_mapping_class(node_id: str):
+    return DefaultComfyHostProvider().find_node_mapping_class(node_id)
+
+
 def resolve_comfy_host_helper(
     name: str,
     fallback: Callable[[str], Any],
@@ -44,6 +48,8 @@ def resolve_comfy_host_helper(
         # the remaining B-11 seams keep their existing root resolver.
         if name == "_comfy_max_resolution":
             return _default_max_resolution
+        if name == "_find_comfy_node_mapping_class":
+            return _default_node_mapping_class
         return fallback(name)
 
     if name == "_comfy_max_resolution":

--- a/nodes.py
+++ b/nodes.py
@@ -1635,15 +1635,6 @@ def _find_comfy_node_class(node_id: str):
     return _adapter_find_comfy_node_class(node_id, comfy_nodes)
 
 
-def _find_comfy_node_mapping_class(node_id: str):
-    try:
-        import nodes as comfy_nodes  # type: ignore
-
-        return getattr(comfy_nodes, "NODE_CLASS_MAPPINGS", {}).get(node_id)
-    except Exception:
-        return None
-
-
 def _require_custom_node_class(node_id: str, node_pack: str, install_hint: str):
     return _adapter_require_custom_node_class(
         node_id,

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -269,18 +269,9 @@
     },
     {
       "symbol": "_find_comfy_node_mapping_class",
-      "root_signature": {
-        "parameters": [
-          {
-            "name": "node_id",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          }
-        ],
-        "return": null
-      },
+      "root_signature": null,
       "adapter_binding": null,
+      "retired_adapter_alias": null,
       "root_dependencies": [],
       "canonical_target": "ComfyHostProvider.find_node_mapping_class",
       "production_consumers": [
@@ -313,7 +304,7 @@
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
       "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
-      "root_removal_gate": "E-07b direct-mapping parity and SAM3 test injection, then #184 B-11c29b",
+      "root_removal_gate": "completed in #184 B-11c29b1 / PR #330",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29b"
     },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -36035,31 +36035,6 @@
         "source": "nodes.py"
       },
       {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1639
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1640,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_find_comfy_node_mapping_class",
-        "source": "nodes.py"
-      },
-      {
         "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
@@ -39365,13 +39340,13 @@
       },
       {
         "is_package": false,
-        "loc": 73,
+        "loc": 79,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
-        "normalized_git_blob_sha1": "cff4535e750467eee9acd8da8e144b99f1f17094",
+        "normalized_git_blob_sha1": "cf4fe1c276a60bbc1f5499096223d62776e84ac3",
         "path": "easyuse_anima/infrastructure/comfy/wiring.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 2,
+          "function_count": 3,
           "global_count": 1
         }
       },
@@ -39773,13 +39748,13 @@
       },
       {
         "is_package": false,
-        "loc": 1905,
+        "loc": 1896,
         "module": "nodes",
-        "normalized_git_blob_sha1": "feb425693e6213764338a87bdda6f5c88b0ed632",
+        "normalized_git_blob_sha1": "6fb2ffb410efe4658d99f17b474fbd8b296a1881",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 7,
+          "function_count": 6,
           "global_count": 26
         }
       },
@@ -52604,25 +52579,6 @@
         "source": "nodes.py"
       },
       {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1639
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1640,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
         "branch_context": [],
         "classification": "external",
         "conditional": false,
@@ -54019,25 +53975,6 @@
         "imported": "nodes",
         "kind": "static_import",
         "line": 1632,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1639
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1640,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55522,7 +55459,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1756,
+        "line": 1747,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55531,7 +55468,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1759,
+        "line": 1750,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55540,7 +55477,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1765,
+        "line": 1756,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55549,7 +55486,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1771,
+        "line": 1762,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55558,7 +55495,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1774,
+        "line": 1765,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55567,7 +55504,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1777,
+        "line": 1768,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55576,7 +55513,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1783,
+        "line": 1774,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55585,7 +55522,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1789,
+        "line": 1780,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55594,7 +55531,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1795,
+        "line": 1786,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55603,7 +55540,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1801,
+        "line": 1792,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55612,7 +55549,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1807,
+        "line": 1798,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55621,7 +55558,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1813,
+        "line": 1804,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55630,7 +55567,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1819,
+        "line": 1810,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55639,7 +55576,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1825,
+        "line": 1816,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55648,7 +55585,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1831,
+        "line": 1822,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55657,7 +55594,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1834,
+        "line": 1825,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55666,7 +55603,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1841,
+        "line": 1832,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55675,7 +55612,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1844,
+        "line": 1835,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55684,7 +55621,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1848,
+        "line": 1839,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55693,7 +55630,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1851,
+        "line": 1842,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55702,7 +55639,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1858,
+        "line": 1849,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55711,7 +55648,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1864,
+        "line": 1855,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55720,7 +55657,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1870,
+        "line": 1861,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55729,7 +55666,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1873,
+        "line": 1864,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55738,7 +55675,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1876,
+        "line": 1867,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55747,7 +55684,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1879,
+        "line": 1870,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55756,7 +55693,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1886,
+        "line": 1877,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55765,7 +55702,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1892,
+        "line": 1883,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55774,7 +55711,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1897,
+        "line": 1888,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55783,7 +55720,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1901,
+        "line": 1892,
         "module": "nodes.py",
         "scope": "<module>"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -59,7 +59,8 @@
       "B-11c26",
       "B-11c27",
       "B-11c28",
-      "B-11c29a"
+      "B-11c29a",
+      "B-11c29b1"
     ]
   },
   "enums": {
@@ -98,7 +99,7 @@
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 7,
+    "root_residual_functions": 6,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -732,9 +733,6 @@
       "easyuse_anima.aio.preview",
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
-      "easyuse_anima.image.sam3"
-    ],
-    "_find_comfy_node_mapping_class": [
       "easyuse_anima.image.sam3"
     ],
     "_find_loaded_node_class": [
@@ -4251,7 +4249,6 @@
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
         "_encode_with_comfy_clip": "_encode_with_comfy_clip",
         "_find_comfy_node_class": "_find_comfy_node_class",
-        "_find_comfy_node_mapping_class": "_find_comfy_node_mapping_class",
         "_find_loaded_node_class": "_find_loaded_node_class",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class"

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -77,6 +77,25 @@ class ComfyHostWiringTests(unittest.TestCase):
 
             self.assertEqual(helper(), 8192)
 
+    def test_retired_mapping_lookup_uses_default_provider_before_runtime_install(self):
+        mapping_class = object()
+        comfy_nodes = types.ModuleType("nodes")
+        comfy_nodes.NODE_CLASS_MAPPINGS = {"MappingOnly": mapping_class}
+        comfy_nodes.MappingOnly = object()
+
+        def unexpected_fallback(name: str):
+            self.fail(f"retired helper reached root fallback: {name}")
+
+        with patch.dict(sys.modules, {"nodes": comfy_nodes}):
+            helper = resolve_comfy_host_helper(
+                "_find_comfy_node_mapping_class",
+                unexpected_fallback,
+            )
+
+            self.assertIs(helper("MappingOnly"), mapping_class)
+            comfy_nodes.NODE_CLASS_MAPPINGS = {}
+            self.assertIsNone(helper("MappingOnly"))
+
     def test_provider_owned_helpers_delegate_to_narrow_methods(self):
         direct = object()
         mapping = object()

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -95,6 +95,8 @@ class ComfyHostWiringTests(unittest.TestCase):
             self.assertIs(helper("MappingOnly"), mapping_class)
             comfy_nodes.NODE_CLASS_MAPPINGS = {}
             self.assertIsNone(helper("MappingOnly"))
+            comfy_nodes.NODE_CLASS_MAPPINGS = object()
+            self.assertIsNone(helper("MappingOnly"))
 
     def test_provider_owned_helpers_delegate_to_narrow_methods(self):
         direct = object()

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2150,6 +2150,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
 
     def test_root_nodes_comfy_aliases_are_canonical_objects(self):
         self.assertFalse(hasattr(nodes, "_comfy_max_resolution"))
+        self.assertFalse(hasattr(nodes, "_find_comfy_node_mapping_class"))
         for canonical_module, helper_names in self.DIRECT_HELPER_MODULES:
             for helper_name in helper_names:
                 with self.subTest(module=canonical_module.__name__, helper=helper_name):
@@ -2161,6 +2162,9 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
     def test_package_nodes_comfy_aliases_are_canonical_objects(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
             self.assertFalse(hasattr(package_nodes, "_comfy_max_resolution"))
+            self.assertFalse(
+                hasattr(package_nodes, "_find_comfy_node_mapping_class")
+            )
             self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
             self.assertFalse(hasattr(package_nodes, "_impact_core_module"))
             self.assertFalse(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "feb425693e6213764338a87bdda6f5c88b0ed632")
-        # B-11c29a retires the unsupported root max-resolution wrapper and
-        # its two adapter imports without changing the public class surface.
-        self.assertEqual(report["top_level"]["function_count"], 7)
+        self.assertEqual(report["git_blob_sha1"], "6fb2ffb410efe4658d99f17b474fbd8b296a1881")
+        # B-11c29b1 retires only the unsupported direct-mapping root lookup
+        # without changing imports or the public class surface.
+        self.assertEqual(report["top_level"]["function_count"], 6)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_905)
+        self.assertEqual(report["line_count"], 1_896)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1062,12 +1062,15 @@ def _comfy_host_root_inventory(
             and node.name == symbol
         ]
         if entries[symbol]["root_signature"] is None:
-            retired_alias = entries[symbol].get("retired_adapter_alias")
-            if retired_alias is None:
+            if "retired_adapter_alias" not in entries[symbol]:
                 raise AssertionError(
                     f"{symbol} must record its retired adapter alias"
                 )
-            if retired_alias in canonical_bindings:
+            retired_alias = entries[symbol]["retired_adapter_alias"]
+            if (
+                retired_alias is not None
+                and retired_alias in canonical_bindings
+            ):
                 raise AssertionError(
                     f"{symbol} retired adapter is still imported as {retired_alias}"
                 )
@@ -1690,6 +1693,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c27",
                 "B-11c28",
                 "B-11c29a",
+                "B-11c29b1",
             ],
         },
         "enums": {
@@ -1706,7 +1710,7 @@ def _build_document() -> dict[str, Any]:
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 7,
+            "root_residual_functions": 6,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,
@@ -2131,14 +2135,23 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             for symbol, entry in self.entries.items()
             if entry["root_signature"] is None
         }
-        self.assertEqual(retired, {"_comfy_max_resolution"})
+        self.assertEqual(
+            retired,
+            {
+                "_comfy_max_resolution",
+                "_find_comfy_node_mapping_class",
+            },
+        )
         self.assertEqual(
             {
                 symbol: entry["retired_adapter_alias"]
                 for symbol, entry in self.entries.items()
                 if "retired_adapter_alias" in entry
             },
-            {"_comfy_max_resolution": "_adapter_comfy_max_resolution"},
+            {
+                "_comfy_max_resolution": "_adapter_comfy_max_resolution",
+                "_find_comfy_node_mapping_class": None,
+            },
         )
         for symbol, entry in self.entries.items():
             expected_classification = (

--- a/tests/test_sam3_nodes.py
+++ b/tests/test_sam3_nodes.py
@@ -138,7 +138,11 @@ class SAM3MoveTests(unittest.TestCase):
             patch.object(nodes, "NODE_CLASS_MAPPINGS", {}, create=True),
             patch.object(nodes, "DetailerForEach", direct_attribute, create=True),
         ):
-            self.assertIsNone(nodes._find_comfy_node_mapping_class("DetailerForEach"))
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "SAM3 Detailer requires ComfyUI Impact Pack",
+            ):
+                sam3_service._find_impact_detailer_class()
 
     def test_context_node_keeps_call_time_checkpoint_loader(self):
         with patch.object(

--- a/tests/test_sam3_nodes.py
+++ b/tests/test_sam3_nodes.py
@@ -132,18 +132,6 @@ class SAM3MoveTests(unittest.TestCase):
             self.assertIs(sam3_service._find_impact_detailer_class(), sentinel)
         find.assert_called_once_with("DetailerForEach")
 
-    def test_impact_primary_lookup_uses_mapping_only(self):
-        direct_attribute = object()
-        with (
-            patch.object(nodes, "NODE_CLASS_MAPPINGS", {}, create=True),
-            patch.object(nodes, "DetailerForEach", direct_attribute, create=True),
-        ):
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "SAM3 Detailer requires ComfyUI Impact Pack",
-            ):
-                sam3_service._find_impact_detailer_class()
-
     def test_context_node_keeps_call_time_checkpoint_loader(self):
         with patch.object(
             nodes,


### PR DESCRIPTION
## 분류

- Task: B-11c29b1
- Owner: #184
- Type: Retirement
- Base: `dev@0acc0152e1039d00c9387324faef43e9a7728219`
- 검증 head: `b068bf0cb655c3a1ba239c4abc69f06c9f09cd4e`
- Contract/Behavior: 포함하지 않음

## 작업 전 inventory와 분할 결정

B-11c29b node-discovery family는 lookup 계약과 root dependency가 달라 분할합니다.
안전한 전체 순서는 다음과 같습니다.

1. B-11c29b1 `_find_comfy_node_mapping_class`
2. B-11c29b2 `_find_loaded_node_class`
3. B-11c29c required-node helpers
4. B-11c29d CLIP invocation
5. B-11c29b3 `_find_comfy_node_class`

이번 PR은 첫 symbol만 retire합니다.

- root signature: `_find_comfy_node_mapping_class(node_id: str)`
- root adapter import: 없음
- lookup: call-time host `nodes.NODE_CLASS_MAPPINGS.get(node_id)`만 사용
- production caller: `easyuse_anima.image.sam3` 1 slot
- binder/observation: `_bind_sam3_runtime`, call-time
- root/canonical monkeypatch consumers: 0/0
- confirmed external consumers: 0
- global state/import-time calls: 없음
- ledger: `provider_owned`, `unsupported_test_only`
- call-time root replacement required: false

일반 lookup은 mapping→attribute→loaded scan 6개 consumer를 가지며 adapter import가
있습니다. 또한 아직 root requirement/CLIP/loaded wrapper의 flat/direct 호출
dependency이므로 마지막에 retire해야 합니다.

## 변경 요약

- root `_find_comfy_node_mapping_class` 정의 제거
- runtime 미설치 flat import에서 fresh `DefaultComfyHostProvider`의 mapping
  method로 지연 조회
- installed runtime의 provider method wiring 유지
- retired root definition과 명시적 null adapter history를 ledger gate로 고정
- root/package 부재, mapping-only, empty/invalid mapping fallback 계약 추가
- analyzer/compatibility fixture와 architecture 문서 갱신

## 주요 파일

- `nodes.py`
- `easyuse_anima/infrastructure/comfy/wiring.py`
- `tests/test_comfy_host_wiring.py`
- `tests/test_node_contracts.py`
- `tests/test_sam3_nodes.py`
- `tests/test_python_compatibility_surface.py`
- analyzer/compatibility fixtures
- `docs/architecture/*`

## 검증

- focused provider/wiring/SAM3/root-package/ledger/analyzer: 63개 통과
- official full:
  - Python unittest 958개 통과
  - frontend 114개 JavaScript 파일 통과
  - TypeScript 6.0.3 통과
  - Pyright baseline ratchet 통과
  - G-03 import boundary 6개 그룹, 위반 0
  - git diff check 통과
- Ruff 113건은 기존 G-01 report-only baseline이며 blocking regression 없음
- `comfy node validate` 통과
- `comfy node pack`:
  - archive 218 entries
  - Python 86 files
  - analyzer shipped set과 missing/extra 0
  - wiring module 포함

테스트 표면: ComfyUI Codex test environment의 repository full runner.
Live ComfyUI smoke는 실행하지 않았습니다.

## 리뷰 보완

- 설치된 Impact Pack 유무에 따라 흔들릴 수 있던 중복 SAM3 테스트 제거
- flat pre-bootstrap invalid mapping 객체가 `None`으로 닫히는 계약 추가
- 병합 전 문서 상태를 `IN PROGRESS`로 유지

독립 리뷰에서 production 구현 차단점은 없었습니다.

## 남은 위험

- private unsupported root symbol을 직접 import하던 미확인 외부 코드는 더 이상
  해당 symbol을 찾지 못합니다. 공개 코드 검색상 확인된 external consumer는
  없으며 ledger 정책상 지원 대상이 아닙니다.
- general/loaded lookup과 requirement/CLIP wrapper는 이번 PR에서 변경하지
  않았습니다.

## 롤백

mapping-only root definition, flat fallback, ledger/analyzer 상태를 한 단위로
복원합니다.

## 다음 단계

병합 후 B-11c29b2 loaded lookup을 별도 retirement 단위로 검토합니다.
