### PR TITLE
B-11c29b2: retire loaded node lookup

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -625,7 +625,7 @@ the rollback and compatibility boundary without need.
 
 #### B-11c29b1 — Direct mapping-only lookup
 
-- **State:** IN PROGRESS in PR #330
+- **State:** COMPLETE in PR #330 / `7eafe06`
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -686,6 +686,73 @@ Forbidden:
 - adding cache, snapshot, mutable override state, or canonical root import; and
 - changing requirement, CLIP, seed, stage, route, persistence, or postprocess
   behavior.
+
+#### B-11c29b2 — Loaded node lookup
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Type:** Retirement
+
+Pre-edit inventory at `dev@7eafe063d4b0e7b90028bbb3cdf0597543802641`:
+
+- root `nodes.py` owns one `_find_loaded_node_class(node_id: str)` definition
+  and imports `_adapter_find_loaded_node_class` in relative and flat modes;
+- the wrapper has no mutable state or import-time call. At call time it invokes
+  the general root lookup, returns a non-`None` result, otherwise scans current
+  `sys.modules` order for `NODE_CLASS_MAPPINGS[node_id]`, then returns `None`;
+- the one production consumer is `easyuse_anima.prompt.conditioning`, which
+  resolves the name at call time through the E-07b provider wiring;
+- repository root replacements, canonical replacements, and confirmed external
+  consumers are all zero;
+- the ledger classifies the seam as `provider_owned`,
+  `unsupported_test_only`, with no call-time root replacement requirement; and
+- therefore this unit retires the root definition and both adapter imports.
+  Installed runtime uses the provider method; runtime-missing flat imports use
+  a fresh default provider without removing the still-required general root
+  lookup.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/infrastructure/comfy/wiring.py
+```
+
+Allowed test, fixture, and documentation files:
+
+```text
+tests/test_comfy_host_wiring.py
+tests/test_comfy_host_provider.py
+tests/test_node_contracts.py
+tests/test_python_compatibility_surface.py
+tests/test_nodes_module_analyzer.py
+tests/fixtures/comfy_host_compatibility.v1.json
+tests/fixtures/python_compatibility_surface.v1.json
+tests/fixtures/python_backend_baseline.json
+docs/architecture/*
+```
+
+Exit:
+
+- root `_find_loaded_node_class` and both adapter imports are absent;
+- installed-runtime conditioning lookup continues to use
+  `ComfyHostProvider.find_loaded_node_class`;
+- flat pre-bootstrap lookup remains delayed, observes current host and loaded
+  modules without importing optional packs, and returns `None` when missing;
+- root general lookup remains available to requirement and CLIP wrappers;
+- retirement gates reject restored root or adapter bindings; and
+- root residual/analyzer/package closure gates pass.
+
+Forbidden:
+
+- moving the general node lookup, requirement helpers, or CLIP invocation;
+- changing mapping, attribute, loaded-module order, or exception/result
+  behavior;
+- changing `ComfyHostProvider`, provider implementation, conditioning feature
+  behavior, schemas, or workflows;
+- adding cache, snapshot, mutable override state, optional imports, or
+  canonical root import; and
+- changing seed, stage, route, persistence, or postprocess behavior.
 
 ### B-11c29c — Required-node helpers
 
@@ -762,8 +829,8 @@ COMPLETE: E-07a default host provider / PR #327
 COMPLETE: E-07b wiring and compatibility gate / PR #328
 
 COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
-IN PROGRESS: B-11c29b1 direct mapping lookup retirement / PR #330
-BLOCKED:  B-11c29b2 loaded lookup retirement pending B-11c29b1 merge
+COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
+IN PROGRESS: B-11c29b2 loaded lookup retirement
 BLOCKED:  B-11c29c-d requirement and CLIP wrapper retirements
 BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29b1 / PR #330; B-11c29b2 loaded lookup retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29b1 / PR #330; B-11c29b2 loaded lookup retirement in PR #331 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -93,6 +93,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   in PR #329 while preserving the flat pre-bootstrap fallback.
   B-11c29b1 retires only the unsupported direct mapping node lookup in PR #330;
   loaded, requirement, CLIP, and general lookup retirements remain separate.
+  B-11c29b2 retires only the unsupported loaded-node root lookup in PR #331;
+  the general root lookup remains for requirement and CLIP wrappers.
 
 ### Current quality baseline
 
@@ -334,7 +336,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b1 / PR #330; B-11c29b2 loaded lookup retirement next | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b2 loaded lookup retirement PR #331; next B-11c29c requirement helpers | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -983,6 +985,10 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     Installed-runtime SAM3 consumers use the provider mapping method and flat
     pre-bootstrap consumers use a fresh default provider. Attribute and
     loaded-module scanning remain excluded from this lookup.
+  - B-11c29b2 retires only `_find_loaded_node_class` in PR #331. Installed
+    runtime and flat pre-bootstrap consumers resolve the provider method without
+    caching or importing optional packs. General lookup and current loaded-module
+    order remain unchanged.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29a / PR #329; B-11c29b1 direct mapping lookup retirement in PR #330 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29b1 / PR #330; B-11c29b2 loaded lookup retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -334,7 +334,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b1 direct mapping lookup retirement PR #330; next B-11c29b2 loaded lookup | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b1 / PR #330; B-11c29b2 loaded lookup retirement next | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,10 +8,10 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c29a are integrated. B-11c is split into
+- Current state: B-11a through B-11c29b1 are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c29b1 retires the unsupported direct mapping node lookup in
-  PR #330.
+  root shim; B-11c29b2 retires the unsupported loaded-node root lookup in PR
+  #331.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 300 in B-11c29a
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 299 in B-11c29b2
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 6 functions, 0 classes, and 26 assigned
-  globals in B-11c29b1 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 5 functions, 0 classes, and 26 assigned
+  globals in B-11c29b2 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 289, including
+- root names reached by those canonical runtime resolvers: 288, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -618,6 +618,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
   `None`, and no cache or mutable override is added.
 - Loaded lookup, requirement helpers, CLIP invocation, and the general node
   lookup remain separate retirement units.
+
+### B-11c29b2 loaded node-lookup retirement
+
+- `_find_loaded_node_class` is an unsupported/test-only private root seam with
+  one provider-wired conditioning consumer and no repository replacement or
+  confirmed external consumer.
+- PR #331 removes the root definition and relative/flat
+  `_adapter_find_loaded_node_class` imports.
+- Installed runtime uses `ComfyHostProvider.find_loaded_node_class`; flat
+  pre-bootstrap imports resolve a fresh default provider at call time.
+- General node lookup remains first, followed by current `sys.modules` order
+  for `NODE_CLASS_MAPPINGS[node_id]`. Missing classes return `None`; optional
+  packs are not imported and no cache or mutable override is added.
+- Requirement helpers and CLIP invocation must retire before the general root
+  lookup.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -23,6 +23,10 @@ def _default_node_mapping_class(node_id: str):
     return DefaultComfyHostProvider().find_node_mapping_class(node_id)
 
 
+def _default_loaded_node_class(node_id: str):
+    return DefaultComfyHostProvider().find_loaded_node_class(node_id)
+
+
 def resolve_comfy_host_helper(
     name: str,
     fallback: Callable[[str], Any],
@@ -50,6 +54,8 @@ def resolve_comfy_host_helper(
             return _default_max_resolution
         if name == "_find_comfy_node_mapping_class":
             return _default_node_mapping_class
+        if name == "_find_loaded_node_class":
+            return _default_loaded_node_class
         return fallback(name)
 
     if name == "_comfy_max_resolution":

--- a/nodes.py
+++ b/nodes.py
@@ -411,7 +411,6 @@ try:
         _comfy_sampler_names as _comfy_sampler_names,
         _comfy_scheduler_names as _comfy_scheduler_names,
         _find_comfy_node_class as _adapter_find_comfy_node_class,
-        _find_loaded_node_class as _adapter_find_loaded_node_class,
         # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
         _require_any_custom_node_class as _adapter_require_any_custom_node_class,
@@ -974,7 +973,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _comfy_sampler_names as _comfy_sampler_names,
         _comfy_scheduler_names as _comfy_scheduler_names,
         _find_comfy_node_class as _adapter_find_comfy_node_class,
-        _find_loaded_node_class as _adapter_find_loaded_node_class,
         # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
         _require_any_custom_node_class as _adapter_require_any_custom_node_class,
@@ -1655,12 +1653,6 @@ def _require_any_custom_node_class(node_ids: tuple[str, ...], node_pack: str, in
 
 def _encode_with_comfy_clip(clip, text: str):
     return _adapter_encode_with_comfy_clip(clip, text, _find_comfy_node_class)
-
-
-def _find_loaded_node_class(node_id: str):
-    return _adapter_find_loaded_node_class(node_id, _find_comfy_node_class)
-
-
 
 
 def _consume_reserved_wildcard_next_seed(

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -310,25 +310,10 @@
     },
     {
       "symbol": "_find_loaded_node_class",
-      "root_signature": {
-        "parameters": [
-          {
-            "name": "node_id",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          }
-        ],
-        "return": null
-      },
-      "adapter_binding": {
-        "alias": "_adapter_find_loaded_node_class",
-        "target": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class"
-      },
-      "root_dependencies": [
-        "_adapter_find_loaded_node_class",
-        "_find_comfy_node_class"
-      ],
+      "root_signature": null,
+      "adapter_binding": null,
+      "retired_adapter_alias": "_adapter_find_loaded_node_class",
+      "root_dependencies": [],
       "canonical_target": "ComfyHostProvider.find_loaded_node_class",
       "production_consumers": [
         {
@@ -361,7 +346,7 @@
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
       "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
-      "root_removal_gate": "E-07b provider parity with no new root-patch dependency, then #184 B-11c29b",
+      "root_removal_gate": "completed in #184 B-11c29b2 / PR #331",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29b"
     },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -22040,37 +22040,6 @@
         "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
-        "alias": "_adapter_find_loaded_node_class",
-        "bound_name": "_adapter_find_loaded_node_class",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_find_loaded_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
-        "kind": "static_from",
-        "line": 410,
-        "name": "_find_loaded_node_class",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
         "alias": "_impact_scheduler_names",
         "bound_name": "_impact_scheduler_names",
         "branch_context": [
@@ -22185,7 +22154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22216,7 +22185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22247,7 +22216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22278,7 +22247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 420,
+        "line": 419,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22309,7 +22278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 426,
+        "line": 425,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22340,7 +22309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22371,7 +22340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22402,7 +22371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22433,7 +22402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22464,7 +22433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22495,7 +22464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 437,
+        "line": 436,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22526,7 +22495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 437,
+        "line": 436,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22557,7 +22526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 441,
+        "line": 440,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22588,7 +22557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 445,
+        "line": 444,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22619,7 +22588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 445,
+        "line": 444,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22650,7 +22619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 445,
+        "line": 444,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22681,7 +22650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 450,
+        "line": 449,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22712,7 +22681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 450,
+        "line": 449,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22743,7 +22712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 450,
+        "line": 449,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22774,7 +22743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 450,
+        "line": 449,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22805,7 +22774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 450,
+        "line": 449,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22836,7 +22805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 457,
+        "line": 456,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22867,7 +22836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 457,
+        "line": 456,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22898,7 +22867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 457,
+        "line": 456,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22929,7 +22898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 462,
+        "line": 461,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22960,7 +22929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 462,
+        "line": 461,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22991,7 +22960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 462,
+        "line": 461,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23022,7 +22991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 480,
+        "line": 479,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23053,7 +23022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 480,
+        "line": 479,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23084,7 +23053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 480,
+        "line": 479,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23115,7 +23084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 480,
+        "line": 479,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23146,7 +23115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 480,
+        "line": 479,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23177,7 +23146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 503,
+        "line": 502,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23208,7 +23177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 503,
+        "line": 502,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23239,7 +23208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 507,
+        "line": 506,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23270,7 +23239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 507,
+        "line": 506,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23301,7 +23270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23332,7 +23301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23363,7 +23332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23394,7 +23363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23425,7 +23394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23456,7 +23425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23487,7 +23456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23518,7 +23487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23549,7 +23518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23580,7 +23549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23611,7 +23580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23642,7 +23611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23673,7 +23642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23704,7 +23673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23735,7 +23704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 512,
+        "line": 511,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23766,7 +23735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23797,7 +23766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23828,7 +23797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23859,7 +23828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23890,7 +23859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23921,7 +23890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23952,7 +23921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23983,7 +23952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 529,
+        "line": 528,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24014,7 +23983,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 539,
+        "line": 538,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24045,7 +24014,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 539,
+        "line": 538,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24076,7 +24045,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 543,
+        "line": 542,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24107,7 +24076,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 543,
+        "line": 542,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24138,7 +24107,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 544,
+        "line": 543,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24169,7 +24138,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24200,7 +24169,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24231,7 +24200,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 545,
+        "line": 544,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24262,7 +24231,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 550,
+        "line": 549,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24293,7 +24262,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 550,
+        "line": 549,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24324,7 +24293,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24355,7 +24324,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24386,7 +24355,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24417,7 +24386,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24448,7 +24417,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24479,7 +24448,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24510,7 +24479,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24541,7 +24510,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24572,7 +24541,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24603,7 +24572,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24634,7 +24603,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24665,7 +24634,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24696,7 +24665,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24727,7 +24696,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24758,7 +24727,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24789,7 +24758,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24820,7 +24789,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24851,7 +24820,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24882,7 +24851,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 551,
+        "line": 550,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24901,7 +24870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -24916,7 +24885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24935,7 +24904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -24950,7 +24919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24969,7 +24938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -24984,7 +24953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25003,7 +24972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25018,7 +24987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25037,7 +25006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25052,7 +25021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25071,7 +25040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25086,7 +25055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25105,7 +25074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25120,7 +25089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25139,7 +25108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25154,7 +25123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25173,7 +25142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25188,7 +25157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25207,7 +25176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25222,7 +25191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25241,7 +25210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25256,7 +25225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25275,7 +25244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25290,7 +25259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25309,7 +25278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25324,7 +25293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25343,7 +25312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25358,7 +25327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25377,7 +25346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25392,7 +25361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25411,7 +25380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25426,7 +25395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25445,7 +25414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25460,7 +25429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25479,7 +25448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25494,7 +25463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25513,7 +25482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25528,7 +25497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25547,7 +25516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25562,7 +25531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25581,7 +25550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25596,7 +25565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25615,7 +25584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25630,7 +25599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25649,7 +25618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25664,7 +25633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25683,7 +25652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25698,7 +25667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25717,7 +25686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25732,7 +25701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25751,7 +25720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25766,7 +25735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25785,7 +25754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25800,7 +25769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25819,7 +25788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25834,7 +25803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25853,7 +25822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25868,7 +25837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25887,7 +25856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25902,7 +25871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25921,7 +25890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25936,7 +25905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25955,7 +25924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -25970,7 +25939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25989,7 +25958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26004,7 +25973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -26023,7 +25992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26038,7 +26007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 615,
+        "line": 614,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26057,7 +26026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26072,7 +26041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 615,
+        "line": 614,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26091,7 +26060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26106,7 +26075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 614,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26125,7 +26094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26140,7 +26109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26159,7 +26128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26174,7 +26143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26193,7 +26162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26208,7 +26177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26227,7 +26196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26242,7 +26211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26261,7 +26230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26276,7 +26245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26295,7 +26264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26310,7 +26279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26329,7 +26298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26344,7 +26313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26363,7 +26332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26378,7 +26347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26397,7 +26366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26412,7 +26381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26431,7 +26400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26446,7 +26415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26465,7 +26434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26480,7 +26449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26499,7 +26468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26514,7 +26483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26533,7 +26502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26548,7 +26517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26567,7 +26536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26582,7 +26551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26601,7 +26570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26616,7 +26585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26635,7 +26604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26650,7 +26619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26669,7 +26638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26684,7 +26653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26703,7 +26672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26718,7 +26687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26737,7 +26706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26752,7 +26721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26771,7 +26740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26786,7 +26755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26805,7 +26774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26820,7 +26789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26839,7 +26808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26854,7 +26823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26873,7 +26842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26888,7 +26857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26907,7 +26876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26922,7 +26891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26941,7 +26910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26956,7 +26925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26975,7 +26944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -26990,7 +26959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27009,7 +26978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27024,7 +26993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27043,7 +27012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27058,7 +27027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27077,7 +27046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27092,7 +27061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27111,7 +27080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27126,7 +27095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27145,7 +27114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27160,7 +27129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27179,7 +27148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27194,7 +27163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27213,7 +27182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27228,7 +27197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27247,7 +27216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27262,7 +27231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27281,7 +27250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27296,7 +27265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27315,7 +27284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27330,7 +27299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27349,7 +27318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27364,7 +27333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27383,7 +27352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27398,7 +27367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27417,7 +27386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27432,7 +27401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27451,7 +27420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27466,7 +27435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27485,7 +27454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27500,7 +27469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27519,7 +27488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27534,7 +27503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27553,7 +27522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27568,7 +27537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27587,7 +27556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27602,7 +27571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27621,7 +27590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27636,7 +27605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27655,7 +27624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27670,7 +27639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27689,7 +27658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27704,7 +27673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27723,7 +27692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27738,7 +27707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27757,7 +27726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27772,7 +27741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27791,7 +27760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27806,7 +27775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27825,7 +27794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27840,7 +27809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27859,7 +27828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27874,7 +27843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27893,7 +27862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27908,7 +27877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27927,7 +27896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27942,7 +27911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27961,7 +27930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -27976,7 +27945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27995,7 +27964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28010,7 +27979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28029,7 +27998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28044,7 +28013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28063,7 +28032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28078,7 +28047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28097,7 +28066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28112,7 +28081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28131,7 +28100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28146,7 +28115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28165,7 +28134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28180,7 +28149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28199,7 +28168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28214,7 +28183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28233,7 +28202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28248,7 +28217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28267,7 +28236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28282,7 +28251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28301,7 +28270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28316,7 +28285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28335,7 +28304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28350,7 +28319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28369,7 +28338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28384,7 +28353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28403,7 +28372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28418,7 +28387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28437,7 +28406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28452,7 +28421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28471,7 +28440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28486,7 +28455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28505,7 +28474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28520,7 +28489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 704,
+        "line": 703,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28539,7 +28508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28554,7 +28523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 704,
+        "line": 703,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28573,7 +28542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28588,7 +28557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 704,
+        "line": 703,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28607,7 +28576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28622,7 +28591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28641,7 +28610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28656,7 +28625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28675,7 +28644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28690,7 +28659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28709,7 +28678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28724,7 +28693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28743,7 +28712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28758,7 +28727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28777,7 +28746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28792,7 +28761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 716,
+        "line": 715,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28811,7 +28780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28826,7 +28795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28845,7 +28814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28860,7 +28829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28879,7 +28848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28894,7 +28863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28913,7 +28882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28928,7 +28897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28947,7 +28916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28962,7 +28931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28981,7 +28950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -28996,7 +28965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29015,7 +28984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29030,7 +28999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29049,7 +29018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29064,7 +29033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29083,7 +29052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29098,7 +29067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29117,7 +29086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29132,7 +29101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29151,7 +29120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29166,7 +29135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29185,7 +29154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29200,7 +29169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29219,7 +29188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29234,7 +29203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29253,7 +29222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29268,7 +29237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29287,7 +29256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29302,7 +29271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29321,7 +29290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29336,7 +29305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29355,7 +29324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29370,7 +29339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29389,7 +29358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29404,7 +29373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29423,7 +29392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29438,7 +29407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29457,7 +29426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29472,7 +29441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29491,7 +29460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29506,7 +29475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29525,7 +29494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29540,7 +29509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29559,7 +29528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29574,7 +29543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29593,7 +29562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29608,7 +29577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29627,7 +29596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29642,7 +29611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29661,7 +29630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29676,7 +29645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29695,7 +29664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29710,7 +29679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29729,7 +29698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29744,7 +29713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29763,7 +29732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29778,7 +29747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29797,7 +29766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29812,7 +29781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29831,7 +29800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29846,7 +29815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29865,7 +29834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29880,7 +29849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29899,7 +29868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29914,7 +29883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29933,7 +29902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29948,7 +29917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29967,7 +29936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -29982,7 +29951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30001,7 +29970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30016,7 +29985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30035,7 +30004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30050,7 +30019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30069,7 +30038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30084,7 +30053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30103,7 +30072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30118,7 +30087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30137,7 +30106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30152,7 +30121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30171,7 +30140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30186,7 +30155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30205,7 +30174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30220,7 +30189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30239,7 +30208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30254,7 +30223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30273,7 +30242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30288,7 +30257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30307,7 +30276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30322,7 +30291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30341,7 +30310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30356,7 +30325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30375,7 +30344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30390,7 +30359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30409,7 +30378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30424,7 +30393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30443,7 +30412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30458,7 +30427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30477,7 +30446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30492,7 +30461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30511,7 +30480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30526,7 +30495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30545,7 +30514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30560,7 +30529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30579,7 +30548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30594,7 +30563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30613,7 +30582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30628,7 +30597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30647,7 +30616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30662,7 +30631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30681,7 +30650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30696,7 +30665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30715,7 +30684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30730,7 +30699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30749,7 +30718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30764,7 +30733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30783,7 +30752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30798,7 +30767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30817,7 +30786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30832,7 +30801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30851,7 +30820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30866,7 +30835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30885,7 +30854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30900,7 +30869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30919,7 +30888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30934,7 +30903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30953,7 +30922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -30968,7 +30937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30987,7 +30956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31002,7 +30971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31021,7 +30990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31036,7 +31005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31055,7 +31024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31070,7 +31039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31089,7 +31058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31104,7 +31073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31123,7 +31092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31138,7 +31107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31157,7 +31126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31172,7 +31141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31191,7 +31160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31206,7 +31175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31225,7 +31194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31240,7 +31209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31259,7 +31228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31274,7 +31243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31293,7 +31262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31308,7 +31277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31327,7 +31296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31342,7 +31311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31361,7 +31330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31376,7 +31345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31395,7 +31364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31410,7 +31379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31429,7 +31398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31444,7 +31413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31463,7 +31432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31478,7 +31447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31497,7 +31466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31512,7 +31481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31531,7 +31500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31546,7 +31515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31565,7 +31534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31580,7 +31549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31599,7 +31568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31614,7 +31583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31633,7 +31602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31648,7 +31617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31667,7 +31636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31682,7 +31651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31701,7 +31670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31716,7 +31685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31735,7 +31704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31750,7 +31719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31769,7 +31738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31784,7 +31753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31803,7 +31772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31818,7 +31787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31837,7 +31806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31852,7 +31821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31871,7 +31840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31886,7 +31855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31905,7 +31874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31920,7 +31889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31939,7 +31908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31954,7 +31923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31973,7 +31942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -31988,7 +31957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32007,7 +31976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32022,7 +31991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32041,7 +32010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32056,7 +32025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 921,
+        "line": 920,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32075,7 +32044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32090,7 +32059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 921,
+        "line": 920,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32109,7 +32078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32124,7 +32093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 921,
+        "line": 920,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32143,7 +32112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32158,7 +32127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 926,
+        "line": 925,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32177,7 +32146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32192,7 +32161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 926,
+        "line": 925,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32211,7 +32180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32226,7 +32195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 926,
+        "line": 925,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32245,7 +32214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32260,7 +32229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32279,7 +32248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32294,7 +32263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32313,7 +32282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32328,7 +32297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32347,7 +32316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32362,7 +32331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32381,7 +32350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32396,7 +32365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32415,7 +32384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32430,7 +32399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32449,7 +32418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32464,7 +32433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32483,7 +32452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32498,7 +32467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 941,
+        "line": 940,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32517,7 +32486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32532,7 +32501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 941,
+        "line": 940,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32551,7 +32520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32566,7 +32535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 941,
+        "line": 940,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32585,7 +32554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32600,7 +32569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32619,7 +32588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32634,7 +32603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32653,7 +32622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32668,7 +32637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32687,7 +32656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32702,7 +32671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32721,7 +32690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32736,7 +32705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 965,
+        "line": 964,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32755,7 +32724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32770,7 +32739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 965,
+        "line": 964,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32789,7 +32758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32804,7 +32773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32823,7 +32792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32838,7 +32807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32857,7 +32826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32872,42 +32841,8 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "_find_comfy_node_class",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "alias": "_adapter_find_loaded_node_class",
-        "bound_name": "_adapter_find_loaded_node_class",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_find_loaded_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
-        "kind": "static_from",
-        "line": 973,
-        "name": "_find_loaded_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
         "role": "compatibility_fallback",
@@ -32925,7 +32860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32940,7 +32875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32959,7 +32894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -32974,7 +32909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "_require_any_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32993,7 +32928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33008,7 +32943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33027,7 +32962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33042,7 +32977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33061,7 +32996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33076,7 +33011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33095,7 +33030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33110,7 +33045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33129,7 +33064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33144,7 +33079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33163,7 +33098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33178,7 +33113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -33197,7 +33132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33212,7 +33147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33231,7 +33166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33246,7 +33181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33265,7 +33200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33280,7 +33215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33299,7 +33234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33314,7 +33249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33333,7 +33268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33348,7 +33283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33367,7 +33302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33382,7 +33317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33401,7 +33336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33416,7 +33351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33435,7 +33370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33450,7 +33385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1002,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33469,7 +33404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33484,7 +33419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33503,7 +33438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33518,7 +33453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33537,7 +33472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33552,7 +33487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33571,7 +33506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33586,7 +33521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33605,7 +33540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33620,7 +33555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33639,7 +33574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33654,7 +33589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33673,7 +33608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33688,7 +33623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33707,7 +33642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33722,7 +33657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33741,7 +33676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33756,7 +33691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1018,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33775,7 +33710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33790,7 +33725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1018,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33809,7 +33744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33824,7 +33759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1018,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33843,7 +33778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33858,7 +33793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1023,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33877,7 +33812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33892,7 +33827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1023,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33911,7 +33846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33926,7 +33861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1023,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33945,7 +33880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33960,7 +33895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33979,7 +33914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -33994,7 +33929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34013,7 +33948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34028,7 +33963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34047,7 +33982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34062,7 +33997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34081,7 +34016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34096,7 +34031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34115,7 +34050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34130,7 +34065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1064,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34149,7 +34084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34164,7 +34099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1064,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34183,7 +34118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34198,7 +34133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34217,7 +34152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34232,7 +34167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34251,7 +34186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34266,7 +34201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34285,7 +34220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34300,7 +34235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34319,7 +34254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34334,7 +34269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34353,7 +34288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34368,7 +34303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34387,7 +34322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34402,7 +34337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34421,7 +34356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34436,7 +34371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34455,7 +34390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34470,7 +34405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34489,7 +34424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34504,7 +34439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34523,7 +34458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34538,7 +34473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34557,7 +34492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34572,7 +34507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34591,7 +34526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34606,7 +34541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34625,7 +34560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34640,7 +34575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34659,7 +34594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34674,7 +34609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34693,7 +34628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34708,7 +34643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34727,7 +34662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34742,7 +34677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34761,7 +34696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34776,7 +34711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34795,7 +34730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34810,7 +34745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34829,7 +34764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34844,7 +34779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34863,7 +34798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34878,7 +34813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34897,7 +34832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34912,7 +34847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34931,7 +34866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34946,7 +34881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34965,7 +34900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -34980,7 +34915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34999,7 +34934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35014,7 +34949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -35033,7 +34968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35048,7 +34983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -35067,7 +35002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35082,7 +35017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -35101,7 +35036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35116,7 +35051,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -35135,7 +35070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35150,7 +35085,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -35169,7 +35104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35184,7 +35119,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1105,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -35203,7 +35138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35218,7 +35153,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -35237,7 +35172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35252,7 +35187,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35271,7 +35206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35286,7 +35221,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35305,7 +35240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35320,7 +35255,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1111,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35339,7 +35274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35354,7 +35289,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1111,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35373,7 +35308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35388,7 +35323,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35407,7 +35342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35422,7 +35357,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35441,7 +35376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35456,7 +35391,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35475,7 +35410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35490,7 +35425,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35509,7 +35444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35524,7 +35459,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35543,7 +35478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35558,7 +35493,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35577,7 +35512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35592,7 +35527,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35611,7 +35546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35626,7 +35561,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35645,7 +35580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35660,7 +35595,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35679,7 +35614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35694,7 +35629,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35713,7 +35648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35728,7 +35663,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35747,7 +35682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35762,7 +35697,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35781,7 +35716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35796,7 +35731,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35815,7 +35750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35830,7 +35765,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35849,7 +35784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35864,7 +35799,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35883,7 +35818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35898,7 +35833,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35917,7 +35852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35932,7 +35867,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35951,7 +35886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -35966,7 +35901,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35985,7 +35920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -36000,7 +35935,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -36018,7 +35953,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1631
+            "line": 1629
           }
         ],
         "classification": "external",
@@ -36026,7 +35961,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1632,
+        "line": 1630,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -39340,13 +39275,13 @@
       },
       {
         "is_package": false,
-        "loc": 79,
+        "loc": 85,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
-        "normalized_git_blob_sha1": "cf4fe1c276a60bbc1f5499096223d62776e84ac3",
+        "normalized_git_blob_sha1": "2fac88dd5fa246ed7b4cf075ddea636b6e72cea9",
         "path": "easyuse_anima/infrastructure/comfy/wiring.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 3,
+          "function_count": 4,
           "global_count": 1
         }
       },
@@ -39748,13 +39683,13 @@
       },
       {
         "is_package": false,
-        "loc": 1896,
+        "loc": 1888,
         "module": "nodes",
-        "normalized_git_blob_sha1": "6fb2ffb410efe4658d99f17b474fbd8b296a1881",
+        "normalized_git_blob_sha1": "20b2d41320caeb93a1d60f9bc3e308d66bb73619",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
+          "function_count": 5,
           "global_count": 26
         }
       },
@@ -41114,7 +41049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41123,7 +41058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41137,7 +41072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41146,7 +41081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41160,7 +41095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41169,7 +41104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41183,7 +41118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41192,7 +41127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41206,7 +41141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41215,7 +41150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41229,7 +41164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41238,7 +41173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41252,7 +41187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41261,7 +41196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41275,7 +41210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41284,7 +41219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 573,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41298,7 +41233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41307,7 +41242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41321,7 +41256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41330,7 +41265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41344,7 +41279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41353,7 +41288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41367,7 +41302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41376,7 +41311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41390,7 +41325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41399,7 +41334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41413,7 +41348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41422,7 +41357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41436,7 +41371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41445,7 +41380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41459,7 +41394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41468,7 +41403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 584,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41482,7 +41417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41491,7 +41426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41505,7 +41440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41514,7 +41449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41528,7 +41463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41537,7 +41472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41551,7 +41486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41560,7 +41495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41574,7 +41509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41583,7 +41518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41597,7 +41532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41606,7 +41541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41620,7 +41555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41629,7 +41564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41643,7 +41578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41652,7 +41587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41666,7 +41601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41675,7 +41610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41689,7 +41624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41698,7 +41633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41712,7 +41647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41721,7 +41656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41735,7 +41670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41744,7 +41679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41758,7 +41693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41767,7 +41702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41781,7 +41716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41790,7 +41725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41804,7 +41739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41813,7 +41748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41827,7 +41762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41836,7 +41771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 594,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41850,7 +41785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41859,7 +41794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41873,7 +41808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41882,7 +41817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 615,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41896,7 +41831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41905,7 +41840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 615,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41919,7 +41854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41928,7 +41863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 614,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41942,7 +41877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41951,7 +41886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41965,7 +41900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41974,7 +41909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41988,7 +41923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -41997,7 +41932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42011,7 +41946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42020,7 +41955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42034,7 +41969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42043,7 +41978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 620,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42057,7 +41992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42066,7 +42001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42080,7 +42015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42089,7 +42024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42103,7 +42038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42112,7 +42047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42126,7 +42061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42135,7 +42070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 627,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42149,7 +42084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42158,7 +42093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42172,7 +42107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42181,7 +42116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42195,7 +42130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42204,7 +42139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42218,7 +42153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42227,7 +42162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42241,7 +42176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42250,7 +42185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42264,7 +42199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42273,7 +42208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42287,7 +42222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42296,7 +42231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42310,7 +42245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42319,7 +42254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42333,7 +42268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42342,7 +42277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42356,7 +42291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42365,7 +42300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42379,7 +42314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42388,7 +42323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42402,7 +42337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42411,7 +42346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42425,7 +42360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42434,7 +42369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 633,
+        "line": 632,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42448,7 +42383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42457,7 +42392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42471,7 +42406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42480,7 +42415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42494,7 +42429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42503,7 +42438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42517,7 +42452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42526,7 +42461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42540,7 +42475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42549,7 +42484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42563,7 +42498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42572,7 +42507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42586,7 +42521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42595,7 +42530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42609,7 +42544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42618,7 +42553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42632,7 +42567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42641,7 +42576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42655,7 +42590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42664,7 +42599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42678,7 +42613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42687,7 +42622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42701,7 +42636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42710,7 +42645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 648,
+        "line": 647,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42724,7 +42659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42733,7 +42668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42747,7 +42682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42756,7 +42691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42770,7 +42705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42779,7 +42714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42793,7 +42728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42802,7 +42737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42816,7 +42751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42825,7 +42760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42839,7 +42774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42848,7 +42783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42862,7 +42797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42871,7 +42806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42885,7 +42820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42894,7 +42829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42908,7 +42843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42917,7 +42852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42931,7 +42866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42940,7 +42875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 662,
+        "line": 661,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42954,7 +42889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42963,7 +42898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42977,7 +42912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -42986,7 +42921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43000,7 +42935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43009,7 +42944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43023,7 +42958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43032,7 +42967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43046,7 +42981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43055,7 +42990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43069,7 +43004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43078,7 +43013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43092,7 +43027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43101,7 +43036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43115,7 +43050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43124,7 +43059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43138,7 +43073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43147,7 +43082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43161,7 +43096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43170,7 +43105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 674,
+        "line": 673,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43184,7 +43119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43193,7 +43128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43207,7 +43142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43216,7 +43151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43230,7 +43165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43239,7 +43174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43253,7 +43188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43262,7 +43197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43276,7 +43211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43285,7 +43220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43299,7 +43234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43308,7 +43243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43322,7 +43257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43331,7 +43266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43345,7 +43280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43354,7 +43289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43368,7 +43303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43377,7 +43312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43391,7 +43326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43400,7 +43335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43414,7 +43349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43423,7 +43358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43437,7 +43372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43446,7 +43381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43460,7 +43395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43469,7 +43404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43483,7 +43418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43492,7 +43427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43506,7 +43441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43515,7 +43450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43529,7 +43464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43538,7 +43473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 686,
+        "line": 685,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43552,7 +43487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43561,7 +43496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 704,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43575,7 +43510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43584,7 +43519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 704,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43598,7 +43533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43607,7 +43542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 704,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43621,7 +43556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43630,7 +43565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43644,7 +43579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43653,7 +43588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43667,7 +43602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43676,7 +43611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43690,7 +43625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43699,7 +43634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43713,7 +43648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43722,7 +43657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 709,
+        "line": 708,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43736,7 +43671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43745,7 +43680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 716,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43759,7 +43694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43768,7 +43703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43782,7 +43717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43791,7 +43726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43805,7 +43740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43814,7 +43749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43828,7 +43763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43837,7 +43772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 717,
+        "line": 716,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43851,7 +43786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43860,7 +43795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43874,7 +43809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43883,7 +43818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43897,7 +43832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43906,7 +43841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43920,7 +43855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43929,7 +43864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43943,7 +43878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43952,7 +43887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43966,7 +43901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43975,7 +43910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43989,7 +43924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -43998,7 +43933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44012,7 +43947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44021,7 +43956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44035,7 +43970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44044,7 +43979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44058,7 +43993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44067,7 +44002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 723,
+        "line": 722,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44081,7 +44016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44090,7 +44025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44104,7 +44039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44113,7 +44048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44127,7 +44062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44136,7 +44071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44150,7 +44085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44159,7 +44094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44173,7 +44108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44182,7 +44117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44196,7 +44131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44205,7 +44140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44219,7 +44154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44228,7 +44163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 737,
+        "line": 736,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44242,7 +44177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44251,7 +44186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44265,7 +44200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44274,7 +44209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44288,7 +44223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44297,7 +44232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44311,7 +44246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44320,7 +44255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44334,7 +44269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44343,7 +44278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44357,7 +44292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44366,7 +44301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44380,7 +44315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44389,7 +44324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44403,7 +44338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44412,7 +44347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44426,7 +44361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44435,7 +44370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44449,7 +44384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44458,7 +44393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44472,7 +44407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44481,7 +44416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44495,7 +44430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44504,7 +44439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44518,7 +44453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44527,7 +44462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44541,7 +44476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44550,7 +44485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44564,7 +44499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44573,7 +44508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44587,7 +44522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44596,7 +44531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44610,7 +44545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44619,7 +44554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44633,7 +44568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44642,7 +44577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44656,7 +44591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44665,7 +44600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44679,7 +44614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44688,7 +44623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44702,7 +44637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44711,7 +44646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44725,7 +44660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44734,7 +44669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 755,
+        "line": 754,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44748,7 +44683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44757,7 +44692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44771,7 +44706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44780,7 +44715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44794,7 +44729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44803,7 +44738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44817,7 +44752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44826,7 +44761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44840,7 +44775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44849,7 +44784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44863,7 +44798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44872,7 +44807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44886,7 +44821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44895,7 +44830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44909,7 +44844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44918,7 +44853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44932,7 +44867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44941,7 +44876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44955,7 +44890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44964,7 +44899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44978,7 +44913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -44987,7 +44922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45001,7 +44936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45010,7 +44945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45024,7 +44959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45033,7 +44968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45047,7 +44982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45056,7 +44991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 791,
+        "line": 790,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45070,7 +45005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45079,7 +45014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45093,7 +45028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45102,7 +45037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45116,7 +45051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45125,7 +45060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45139,7 +45074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45148,7 +45083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45162,7 +45097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45171,7 +45106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45185,7 +45120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45194,7 +45129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45208,7 +45143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45217,7 +45152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45231,7 +45166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45240,7 +45175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45254,7 +45189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45263,7 +45198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 819,
+        "line": 818,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45277,7 +45212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45286,7 +45221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45300,7 +45235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45309,7 +45244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45323,7 +45258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45332,7 +45267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45346,7 +45281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45355,7 +45290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45369,7 +45304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45378,7 +45313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45392,7 +45327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45401,7 +45336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45415,7 +45350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45424,7 +45359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45438,7 +45373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45447,7 +45382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45461,7 +45396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45470,7 +45405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45484,7 +45419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45493,7 +45428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45507,7 +45442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45516,7 +45451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45530,7 +45465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45539,7 +45474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45553,7 +45488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45562,7 +45497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45576,7 +45511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45585,7 +45520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45599,7 +45534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45608,7 +45543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45622,7 +45557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45631,7 +45566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45645,7 +45580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45654,7 +45589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45668,7 +45603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45677,7 +45612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45691,7 +45626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45700,7 +45635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45714,7 +45649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45723,7 +45658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45737,7 +45672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45746,7 +45681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45760,7 +45695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45769,7 +45704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45783,7 +45718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45792,7 +45727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45806,7 +45741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45815,7 +45750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45829,7 +45764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45838,7 +45773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 835,
+        "line": 834,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45852,7 +45787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45861,7 +45796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45875,7 +45810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45884,7 +45819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45898,7 +45833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45907,7 +45842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45921,7 +45856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45930,7 +45865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 914,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45944,7 +45879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45953,7 +45888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 921,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45967,7 +45902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45976,7 +45911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 921,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45990,7 +45925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -45999,7 +45934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 921,
+        "line": 920,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46013,7 +45948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46022,7 +45957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 926,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46036,7 +45971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46045,7 +45980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 926,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46059,7 +45994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46068,7 +46003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 926,
+        "line": 925,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46082,7 +46017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46091,7 +46026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46105,7 +46040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46114,7 +46049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46128,7 +46063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46137,7 +46072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46151,7 +46086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46160,7 +46095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46174,7 +46109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46183,7 +46118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46197,7 +46132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46206,7 +46141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46220,7 +46155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46229,7 +46164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 932,
+        "line": 931,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46243,7 +46178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46252,7 +46187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 941,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46266,7 +46201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46275,7 +46210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 941,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46289,7 +46224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46298,7 +46233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 941,
+        "line": 940,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46312,7 +46247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46321,7 +46256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46335,7 +46270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46344,7 +46279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46358,7 +46293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46367,7 +46302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46381,7 +46316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46390,7 +46325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 952,
+        "line": 951,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46404,7 +46339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46413,7 +46348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 965,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46427,7 +46362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46436,7 +46371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 965,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46450,7 +46385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46459,7 +46394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46473,7 +46408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46482,7 +46417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46496,7 +46431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46505,7 +46440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46519,30 +46454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_loaded_node_class",
-        "kind": "static_from",
-        "line": 973,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46551,7 +46463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46565,7 +46477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46574,7 +46486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46588,7 +46500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46597,7 +46509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
         "kind": "static_from",
-        "line": 973,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46611,7 +46523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46620,7 +46532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46634,7 +46546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46643,7 +46555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46657,7 +46569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46666,7 +46578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46680,7 +46592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46689,7 +46601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46703,7 +46615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46712,7 +46624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 989,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46726,7 +46638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46735,7 +46647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46749,7 +46661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46758,7 +46670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46772,7 +46684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46781,7 +46693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46795,7 +46707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46804,7 +46716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46818,7 +46730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46827,7 +46739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46841,7 +46753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46850,7 +46762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46864,7 +46776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46873,7 +46785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46887,7 +46799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46896,7 +46808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1004,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46910,7 +46822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46919,7 +46831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46933,7 +46845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46942,7 +46854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46956,7 +46868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46965,7 +46877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1008,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46979,7 +46891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -46988,7 +46900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47002,7 +46914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47011,7 +46923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47025,7 +46937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47034,7 +46946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47048,7 +46960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47057,7 +46969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47071,7 +46983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47080,7 +46992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1013,
+        "line": 1011,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47094,7 +47006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47103,7 +47015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47117,7 +47029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47126,7 +47038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47140,7 +47052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47149,7 +47061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1020,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47163,7 +47075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47172,7 +47084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1023,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47186,7 +47098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47195,7 +47107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1023,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47209,7 +47121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47218,7 +47130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1025,
+        "line": 1023,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47232,7 +47144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47241,7 +47153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47255,7 +47167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47264,7 +47176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47278,7 +47190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47287,7 +47199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47301,7 +47213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47310,7 +47222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47324,7 +47236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47333,7 +47245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1043,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47347,7 +47259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47356,7 +47268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47370,7 +47282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47379,7 +47291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47393,7 +47305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47402,7 +47314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47416,7 +47328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47425,7 +47337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47439,7 +47351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47448,7 +47360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47462,7 +47374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47471,7 +47383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47485,7 +47397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47494,7 +47406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47508,7 +47420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47517,7 +47429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47531,7 +47443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47540,7 +47452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47554,7 +47466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47563,7 +47475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47577,7 +47489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47586,7 +47498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47600,7 +47512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47609,7 +47521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47623,7 +47535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47632,7 +47544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47646,7 +47558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47655,7 +47567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47669,7 +47581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47678,7 +47590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47692,7 +47604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47701,7 +47613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47715,7 +47627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47724,7 +47636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47738,7 +47650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47747,7 +47659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47761,7 +47673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47770,7 +47682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47784,7 +47696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47793,7 +47705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47807,7 +47719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47816,7 +47728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47830,7 +47742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47839,7 +47751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47853,7 +47765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47862,7 +47774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47876,7 +47788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47885,7 +47797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47899,7 +47811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47908,7 +47820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47922,7 +47834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47931,7 +47843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47945,7 +47857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47954,7 +47866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1090,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47968,7 +47880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -47977,7 +47889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47991,7 +47903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48000,7 +47912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48014,7 +47926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48023,7 +47935,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48037,7 +47949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48046,7 +47958,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48060,7 +47972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48069,7 +47981,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48083,7 +47995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48092,7 +48004,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48106,7 +48018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48115,7 +48027,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48129,7 +48041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48138,7 +48050,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48152,7 +48064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48161,7 +48073,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48175,7 +48087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48184,7 +48096,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1113,
+        "line": 1111,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48198,7 +48110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48207,7 +48119,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48221,7 +48133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48230,7 +48142,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48244,7 +48156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48253,7 +48165,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48267,7 +48179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48276,7 +48188,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48290,7 +48202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48299,7 +48211,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48313,7 +48225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48322,7 +48234,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48336,7 +48248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48345,7 +48257,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48359,7 +48271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48368,7 +48280,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48382,7 +48294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48391,7 +48303,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48405,7 +48317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48414,7 +48326,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48428,7 +48340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48437,7 +48349,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48451,7 +48363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48460,7 +48372,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48474,7 +48386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48483,7 +48395,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48497,7 +48409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48506,7 +48418,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48520,7 +48432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48529,7 +48441,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48543,7 +48455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48552,7 +48464,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48566,7 +48478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48575,7 +48487,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48589,7 +48501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48598,7 +48510,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48612,7 +48524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 572,
+            "handler_line": 571,
             "kind": "try",
             "line": 9
           }
@@ -48621,7 +48533,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1114,
+        "line": 1112,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52566,14 +52478,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1631
+            "line": 1629
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1632,
+        "line": 1630,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53967,14 +53879,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1631
+            "line": 1629
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1632,
+        "line": 1630,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55450,7 +55362,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1136,
+        "line": 1134,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55459,7 +55371,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1747,
+        "line": 1739,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55468,7 +55380,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1750,
+        "line": 1742,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55477,7 +55389,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1756,
+        "line": 1748,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55486,7 +55398,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1762,
+        "line": 1754,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55495,7 +55407,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1765,
+        "line": 1757,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55504,7 +55416,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1768,
+        "line": 1760,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55513,7 +55425,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1774,
+        "line": 1766,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55522,7 +55434,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1780,
+        "line": 1772,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55531,7 +55443,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1786,
+        "line": 1778,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55540,7 +55452,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1792,
+        "line": 1784,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55549,7 +55461,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1798,
+        "line": 1790,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55558,7 +55470,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1804,
+        "line": 1796,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55567,7 +55479,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1810,
+        "line": 1802,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55576,7 +55488,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1816,
+        "line": 1808,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55585,7 +55497,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1822,
+        "line": 1814,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55594,7 +55506,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1825,
+        "line": 1817,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55603,7 +55515,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1832,
+        "line": 1824,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55612,7 +55524,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1835,
+        "line": 1827,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55621,7 +55533,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1839,
+        "line": 1831,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55630,7 +55542,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1842,
+        "line": 1834,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55639,7 +55551,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1849,
+        "line": 1841,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55648,7 +55560,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1855,
+        "line": 1847,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55657,7 +55569,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1861,
+        "line": 1853,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55666,7 +55578,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1864,
+        "line": 1856,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55675,7 +55587,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1867,
+        "line": 1859,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55684,7 +55596,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1870,
+        "line": 1862,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55693,7 +55605,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1877,
+        "line": 1869,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55702,7 +55614,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1883,
+        "line": 1875,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55711,7 +55623,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1888,
+        "line": 1880,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55720,7 +55632,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1892,
+        "line": 1884,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56234,13 +56146,13 @@
       },
       {
         "kind": "dict",
-        "line": 1198,
+        "line": 1196,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1187,
+        "line": 1185,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -60,7 +60,8 @@
       "B-11c27",
       "B-11c28",
       "B-11c29a",
-      "B-11c29b1"
+      "B-11c29b1",
+      "B-11c29b2"
     ]
   },
   "enums": {
@@ -95,11 +96,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 300,
+    "nodes_canonical_bindings": 299,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 6,
+    "root_residual_functions": 5,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -734,9 +735,6 @@
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.image.sam3"
-    ],
-    "_find_loaded_node_class": [
-      "easyuse_anima.prompt.conditioning"
     ],
     "_find_spectrum_anima_mod_guidance_class": [
       "easyuse_anima.prompt.conditioning"
@@ -2692,7 +2690,6 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_adapter_find_comfy_node_class": "_find_comfy_node_class",
-        "_adapter_find_loaded_node_class": "_find_loaded_node_class",
         "_adapter_require_any_custom_node_class": "_require_any_custom_node_class",
         "_adapter_require_custom_node_class": "_require_custom_node_class",
         "_comfy_sampler_names": "_comfy_sampler_names",
@@ -4249,7 +4246,6 @@
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
         "_encode_with_comfy_clip": "_encode_with_comfy_clip",
         "_find_comfy_node_class": "_find_comfy_node_class",
-        "_find_loaded_node_class": "_find_loaded_node_class",
         "_require_any_custom_node_class": "_require_any_custom_node_class",
         "_require_custom_node_class": "_require_custom_node_class"
       },

--- a/tests/test_comfy_host_provider.py
+++ b/tests/test_comfy_host_provider.py
@@ -101,6 +101,27 @@ class DefaultComfyHostProviderTests(unittest.TestCase):
         self.assertEqual(find_node_class.call_args_list[0].args, (node_id,))
         self.assertEqual(find_node_class.call_args_list[1].args, (node_id,))
 
+    def test_loaded_lookup_uses_first_loaded_mapping(self):
+        node_id = "EasyUseAnimaProviderLoadedOrderNode"
+        first_class = type("FirstLoadedNode", (), {})
+        second_class = type("SecondLoadedNode", (), {})
+        first_module = types.ModuleType("easyuse_anima_provider_loaded_first")
+        first_module.NODE_CLASS_MAPPINGS = {node_id: first_class}
+        second_module = types.ModuleType("easyuse_anima_provider_loaded_second")
+        second_module.NODE_CLASS_MAPPINGS = {node_id: second_class}
+
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    first_module.__name__: first_module,
+                    second_module.__name__: second_module,
+                },
+            ),
+            patch.object(self.provider, "find_node_class", return_value=None),
+        ):
+            self.assertIs(self.provider.find_loaded_node_class(node_id), first_class)
+
     def test_lookup_is_not_cached_between_host_updates(self):
         node_id = "EasyUseAnimaProviderDynamicNode"
         first_class = type("FirstNode", (), {})

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -98,6 +98,35 @@ class ComfyHostWiringTests(unittest.TestCase):
             comfy_nodes.NODE_CLASS_MAPPINGS = object()
             self.assertIsNone(helper("MappingOnly"))
 
+    def test_retired_loaded_lookup_uses_default_provider_before_runtime_install(self):
+        direct_class = object()
+        loaded_class = object()
+        comfy_nodes = types.ModuleType("nodes")
+        comfy_nodes.NODE_CLASS_MAPPINGS = {"Direct": direct_class}
+        loaded_nodes = types.ModuleType("easyuse_anima_test_loaded_nodes")
+        loaded_nodes.NODE_CLASS_MAPPINGS = {"Loaded": loaded_class}
+
+        def unexpected_fallback(name: str):
+            self.fail(f"retired helper reached root fallback: {name}")
+
+        with patch.dict(
+            sys.modules,
+            {
+                "nodes": comfy_nodes,
+                loaded_nodes.__name__: loaded_nodes,
+            },
+        ):
+            helper = resolve_comfy_host_helper(
+                "_find_loaded_node_class",
+                unexpected_fallback,
+            )
+
+            self.assertIs(helper("Direct"), direct_class)
+            comfy_nodes.NODE_CLASS_MAPPINGS = {}
+            self.assertIs(helper("Loaded"), loaded_class)
+            loaded_nodes.NODE_CLASS_MAPPINGS = {}
+            self.assertIsNone(helper("Missing"))
+
     def test_provider_owned_helpers_delegate_to_narrow_methods(self):
         direct = object()
         mapping = object()

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2151,6 +2151,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
     def test_root_nodes_comfy_aliases_are_canonical_objects(self):
         self.assertFalse(hasattr(nodes, "_comfy_max_resolution"))
         self.assertFalse(hasattr(nodes, "_find_comfy_node_mapping_class"))
+        self.assertFalse(hasattr(nodes, "_find_loaded_node_class"))
         for canonical_module, helper_names in self.DIRECT_HELPER_MODULES:
             for helper_name in helper_names:
                 with self.subTest(module=canonical_module.__name__, helper=helper_name):
@@ -2165,6 +2166,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
             self.assertFalse(
                 hasattr(package_nodes, "_find_comfy_node_mapping_class")
             )
+            self.assertFalse(hasattr(package_nodes, "_find_loaded_node_class"))
             self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
             self.assertFalse(hasattr(package_nodes, "_impact_core_module"))
             self.assertFalse(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "6fb2ffb410efe4658d99f17b474fbd8b296a1881")
-        # B-11c29b1 retires only the unsupported direct-mapping root lookup
-        # without changing imports or the public class surface.
-        self.assertEqual(report["top_level"]["function_count"], 6)
+        self.assertEqual(report["git_blob_sha1"], "20b2d41320caeb93a1d60f9bc3e308d66bb73619")
+        # B-11c29b2 retires only the unsupported loaded-node root lookup and
+        # its two adapter imports without changing the public class surface.
+        self.assertEqual(report["top_level"]["function_count"], 5)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_896)
+        self.assertEqual(report["line_count"], 1_888)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1694,6 +1694,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c28",
                 "B-11c29a",
                 "B-11c29b1",
+                "B-11c29b2",
             ],
         },
         "enums": {
@@ -1706,11 +1707,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 300,
+            "nodes_canonical_bindings": 299,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 6,
+            "root_residual_functions": 5,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,
@@ -2140,6 +2141,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             {
                 "_comfy_max_resolution",
                 "_find_comfy_node_mapping_class",
+                "_find_loaded_node_class",
             },
         )
         self.assertEqual(
@@ -2151,6 +2153,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             {
                 "_comfy_max_resolution": "_adapter_comfy_max_resolution",
                 "_find_comfy_node_mapping_class": None,
+                "_find_loaded_node_class": "_adapter_find_loaded_node_class",
             },
         )
         for symbol, entry in self.entries.items():


### PR DESCRIPTION
## 분류

- Task: B-11c29b2
- Owner: #184
- Type: Retirement
- Base: `dev@7eafe063d4b0e7b90028bbb3cdf0597543802641`
- 검증 head: `b8bed11`
- Contract/Behavior: 포함하지 않음

## 작업 전 inventory

- retiring symbol: root `_find_loaded_node_class(node_id: str)` 하나
- relative/flat adapter: `_adapter_find_loaded_node_class`
- root dependency: `_find_comfy_node_class`
- lookup order:
  1. general node lookup 호출
  2. non-`None` 결과 즉시 반환
  3. 현재 `sys.modules` 순서로 `NODE_CLASS_MAPPINGS[node_id]` scan
  4. 없으면 `None`
- production caller: `easyuse_anima.prompt.conditioning` 1 slot
- binder/observation: `_bind_conditioning_runtime`, call-time
- root/canonical monkeypatch consumers: 0/0
- confirmed external consumers: 0
- global state/import-time calls: 없음
- ledger: `provider_owned`, `unsupported_test_only`
- call-time root replacement required: false

Installed runtime은 이미 `ComfyHostProvider.find_loaded_node_class`를 사용합니다.
Flat pre-bootstrap만 fresh default provider로 전환합니다. General root lookup은
requirement/CLIP wrapper dependency이므로 유지합니다.

## 변경

- root `_find_loaded_node_class` definition과 relative/flat adapter import를 제거했습니다.
- runtime 미설치 flat import는 fresh `DefaultComfyHostProvider`를 call-time에
  사용합니다.
- general lookup 우선, 현재 loaded-module 순서, missing `None`, 비캐시 의미를
  유지했습니다.
- root/package absence와 retired adapter 재도입 방지 ledger를 고정했습니다.
- analyzer, package closure fixture, 실행 로드맵을 현재 surface에 맞췄습니다.

## 허용 경계

Production:

- `nodes.py`
- `easyuse_anima/infrastructure/comfy/wiring.py`

Tests/gates/docs:

- Comfy provider/wiring, root/package contract tests
- Comfy host ledger
- compatibility/backend/nodes analyzer fixture와 gate
- architecture 문서

## 금지 경계 확인

- general node lookup, requirement helper, CLIP wrapper 이동 없음
- provider interface/implementation 변경 없음
- conditioning/schema/workflow/seed/stage/route/persistence 변경 없음
- cache/snapshot/mutable override/optional import 추가 없음

## 검증

- focused:
  - `python -m unittest tests.test_comfy_host_wiring tests.test_comfy_host_provider tests.test_comfy_adapters.ComfyCapabilityAdapterTests.test_node_discovery_checks_injected_and_loaded_module_mappings tests.test_node_contracts.ComfyAdapterMoveContractTests tests.test_python_compatibility_surface tests.test_nodes_module_analyzer tests.test_python_backend_analyzer`
  - 58 tests passed
- official full:
  - `tools/check_custom_node.ps1 -Project <absolute PR worktree> -Profile full`
  - Python 960 tests passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline, G-03 import boundary 6 groups, diff check passed
  - Ruff 113 existing findings, report-only
- `comfy node validate`: passed
- actual `comfy node pack`: 218 entries
  - Python 86/86, analyzer `shipped_python_modules`와 exact match
  - `easyuse_anima/infrastructure/comfy/wiring.py` 포함

## 테스트 표면과 남은 위험

- ComfyUI v0.27.0 Codex test instance: official runner/import/module surface
- live ComfyUI smoke: 미실행
- private unsupported root retirement이므로 workflow/schema 결과 변화는 없습니다.
- 저장소 외 소비자는 확인되지 않았지만 공개 코드 검색은 비포괄적입니다.

## 롤백

loaded root definition, 두 adapter import, flat fallback, ledger/analyzer 상태만
한 단위로 복원합니다.

## 다음 단계

병합 후 B-11c29c required-node helpers를 별도 retirement 단위로 진행합니다.
