### PR TITLE
B-11c29c: retire required-node helpers

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -689,7 +689,7 @@ Forbidden:
 
 #### B-11c29b2 — Loaded node lookup
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE in PR #331 / `164b53e`
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -756,9 +756,9 @@ Forbidden:
 
 ### B-11c29c — Required-node helpers
 
-- **State:** BLOCKED by B-11c29b2; precedes B-11c29b3
+- **State:** IN PROGRESS; precedes B-11c29d and B-11c29b3
 - **Owner:** #184
-- **Type:** Move/retirement
+- **Type:** Retirement
 
 Symbols:
 
@@ -767,8 +767,77 @@ _require_custom_node_class
 _require_any_custom_node_class
 ```
 
-Preserve exact search order, tuple result, and error text. These stay pure
-helpers; do not expand the provider interface merely to host them.
+Pre-edit inventory at `dev@164b53ec89947bc5a72889d83641c5db947dbef5`:
+
+- root `nodes.py` owns both definitions and imports
+  `_adapter_require_custom_node_class` and
+  `_adapter_require_any_custom_node_class` in relative and flat modes;
+- `_require_custom_node_class` has four call-time production consumer modules:
+  `easyuse_anima.aio.legacy_generation`, `model_preparation`, `output`, and
+  `sampling`;
+- `_require_any_custom_node_class` has one call-time production consumer module,
+  `easyuse_anima.aio.model_preparation`;
+- installed runtime already resolves both canonical pure helpers with only
+  `ComfyHostProvider.find_node_class` injected. The provider interface does not
+  own requirement or error policy;
+- both wrappers have zero repository root/canonical monkeypatch consumers, zero
+  confirmed external consumers, no import-time calls, and no mutable state;
+- the single helper calls the lookup once, returns the class object unchanged,
+  or raises the exact existing node-id/pack/hint `RuntimeError`;
+- the multi helper checks caller tuple order, returns the first
+  `(node_id, class)` pair, or raises the exact existing joined-candidate
+  `RuntimeError`; and
+- the ledger classifies both as `pure_helper_with_provider_input`,
+  `unsupported_test_only`, with no call-time root replacement requirement.
+
+These symbols form one rollback unit because they share the same pure canonical
+owner, root dependency, relative/flat adapter boundary, provider input, and
+wiring branch. No Contract or Behavior change is included.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/infrastructure/comfy/wiring.py
+```
+
+Allowed test, fixture, and documentation files:
+
+```text
+tests/test_comfy_adapters.py
+tests/test_comfy_host_wiring.py
+tests/test_node_contracts.py
+tests/test_python_compatibility_surface.py
+tests/test_nodes_module_analyzer.py
+tests/fixtures/comfy_host_compatibility.v1.json
+tests/fixtures/python_compatibility_surface.v1.json
+tests/fixtures/python_backend_baseline.json
+docs/architecture/*
+```
+
+Exit:
+
+- both root definitions and all four adapter imports are absent;
+- installed-runtime consumers keep the existing provider-injected pure helpers;
+- flat pre-bootstrap calls use a fresh default provider lookup at call time;
+- success identity, candidate order, tuple shape, exact error text, and
+  use-time-only optional dependency behavior remain unchanged;
+- root general lookup remains available to the CLIP wrapper;
+- retirement gates reject restored roots or adapter bindings; and
+- root residual/analyzer/package closure gates pass.
+
+Forbidden:
+
+- changing canonical capability helper implementations or the provider
+  interface/implementation;
+- changing AiO consumers, binders, node/workflow schemas, or selected-feature
+  timing;
+- moving the CLIP or general lookup wrappers;
+- changing search order, tuple/result identity, exception type/text, or error
+  timing;
+- adding cache, snapshot, mutable override state, optional imports, or
+  canonical root imports; and
+- changing seed, stage, route, persistence, or postprocess behavior.
 
 ### B-11c29d — CLIP invocation wrapper
 
@@ -830,8 +899,9 @@ COMPLETE: E-07b wiring and compatibility gate / PR #328
 
 COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
 COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
-IN PROGRESS: B-11c29b2 loaded lookup retirement
-BLOCKED:  B-11c29c-d requirement and CLIP wrapper retirements
+COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
+IN PROGRESS: B-11c29c requirement helper retirement
+BLOCKED:  B-11c29d CLIP wrapper retirement
 BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -756,7 +756,7 @@ Forbidden:
 
 ### B-11c29c — Required-node helpers
 
-- **State:** IN PROGRESS; precedes B-11c29d and B-11c29b3
+- **State:** IN PROGRESS in PR #332; precedes B-11c29d and B-11c29b3
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -900,7 +900,7 @@ COMPLETE: E-07b wiring and compatibility gate / PR #328
 COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
 COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
 COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
-IN PROGRESS: B-11c29c requirement helper retirement
+IN PROGRESS: B-11c29c requirement helper retirement / PR #332
 BLOCKED:  B-11c29d CLIP wrapper retirement
 BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29b1 / PR #330; B-11c29b2 loaded lookup retirement in PR #331 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29b2 / PR #331; B-11c29c requirement helper retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -93,8 +93,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   in PR #329 while preserving the flat pre-bootstrap fallback.
   B-11c29b1 retires only the unsupported direct mapping node lookup in PR #330;
   loaded, requirement, CLIP, and general lookup retirements remain separate.
-  B-11c29b2 retires only the unsupported loaded-node root lookup in PR #331;
-  the general root lookup remains for requirement and CLIP wrappers.
+  B-11c29b2 retired only the unsupported loaded-node root lookup in PR #331.
+  B-11c29c next retires the two pure requirement root helpers together while
+  the general root lookup remains for the CLIP wrapper.
 
 ### Current quality baseline
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29b2 / PR #331; B-11c29c requirement helper retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29b2 / PR #331; B-11c29c requirement helper retirement in PR #332 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -337,7 +337,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b2 loaded lookup retirement PR #331; next B-11c29c requirement helpers | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29c requirement helper retirement PR #332; next B-11c29d CLIP invocation | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,10 +8,10 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c29b1 are integrated. B-11c is split into
+- Current state: B-11a through B-11c29b2 are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c29b2 retires the unsupported loaded-node root lookup in PR
-  #331.
+  root shim; B-11c29c retires the two pure required-node root helpers in PR
+  #332.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +76,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 299 in B-11c29b2
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 297 in B-11c29c
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +85,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 5 functions, 0 classes, and 26 assigned
-  globals in B-11c29b2 (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 3 functions, 0 classes, and 26 assigned
+  globals in B-11c29c (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 288, including
+- root names reached by those canonical runtime resolvers: 286, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -103,7 +103,9 @@ inferring public support from spelling or test imports:
   the five B-10b15 conditioning aliases, the 12 B-10b16 Prompt Advanced aliases,
   the 12 B-10b17 Regional aliases, the 11 B-10b18 Artist Mix parsing/config
   aliases, the 21 B-10b19 Artist Mix mode/key/tag-position aliases, and the 21
-  B-10b20 Artist Mix conditioning/tensor aliases; their production
+  B-10b20 Artist Mix conditioning/tensor aliases, plus the B-11c29a-c
+  `_comfy_max_resolution`, direct mapping, loaded lookup, and two requirement
+  root helpers; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -116,7 +118,7 @@ mapped-public classification drift, and silent promotion of residual root
 implementation. A repository test import can justify migration work, but never
 supported-public classification by itself.
 
-The six preamble imports are implementation dependencies of the remaining
+The five preamble imports are implementation dependencies of the remaining
 root body, not compatibility aliases or supported exports. Any addition,
 removal, or retargeting fails the fixture build until it is deliberately
 classified; B-10b must not treat these imports as private-alias cleanup.
@@ -633,6 +635,23 @@ convenience-node compatibility; it remains unmapped and is not public support.
   packs are not imported and no cache or mutable override is added.
 - Requirement helpers and CLIP invocation must retire before the general root
   lookup.
+
+### B-11c29c required-node helper retirement
+
+- `_require_custom_node_class` and `_require_any_custom_node_class` are
+  unsupported/test-only pure root seams with provider-injected canonical
+  implementations, no repository replacement, and no confirmed external
+  consumer.
+- PR #332 removes both root definitions and their four relative/flat adapter
+  imports as one rollback unit.
+- Installed-runtime consumers keep the canonical pure helpers with
+  `ComfyHostProvider.find_node_class` injected. Flat pre-bootstrap calls use a
+  fresh default provider lookup at call time.
+- Single lookup identity, multi-candidate order and tuple result, exact missing
+  `RuntimeError` text, raw finder exception propagation, and use-time-only
+  optional dependency behavior remain unchanged.
+- The provider interface and canonical capability helpers are unchanged. CLIP
+  invocation retires next, before the general root lookup.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -27,6 +27,32 @@ def _default_loaded_node_class(node_id: str):
     return DefaultComfyHostProvider().find_loaded_node_class(node_id)
 
 
+def _default_require_custom_node_class(
+    node_id: str,
+    node_pack: str,
+    install_hint: str,
+):
+    return _require_custom_node_class(
+        node_id,
+        node_pack,
+        install_hint,
+        find_node_class=DefaultComfyHostProvider().find_node_class,
+    )
+
+
+def _default_require_any_custom_node_class(
+    node_ids: tuple[str, ...],
+    node_pack: str,
+    install_hint: str,
+):
+    return _require_any_custom_node_class(
+        node_ids,
+        node_pack,
+        install_hint,
+        find_node_class=DefaultComfyHostProvider().find_node_class,
+    )
+
+
 def resolve_comfy_host_helper(
     name: str,
     fallback: Callable[[str], Any],
@@ -56,6 +82,10 @@ def resolve_comfy_host_helper(
             return _default_node_mapping_class
         if name == "_find_loaded_node_class":
             return _default_loaded_node_class
+        if name == "_require_custom_node_class":
+            return _default_require_custom_node_class
+        if name == "_require_any_custom_node_class":
+            return _default_require_any_custom_node_class
         return fallback(name)
 
     if name == "_comfy_max_resolution":

--- a/nodes.py
+++ b/nodes.py
@@ -413,8 +413,6 @@ try:
         _find_comfy_node_class as _adapter_find_comfy_node_class,
         # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
-        _require_any_custom_node_class as _adapter_require_any_custom_node_class,
-        _require_custom_node_class as _adapter_require_custom_node_class,
     )
     from .easyuse_anima.infrastructure.comfy.invocation import (
         _call_with_supported_kwargs as _call_with_supported_kwargs,
@@ -975,8 +973,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _find_comfy_node_class as _adapter_find_comfy_node_class,
         # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
-        _require_any_custom_node_class as _adapter_require_any_custom_node_class,
-        _require_custom_node_class as _adapter_require_custom_node_class,
     )
     from easyuse_anima.infrastructure.comfy.invocation import (
         _call_with_supported_kwargs as _call_with_supported_kwargs,
@@ -1631,24 +1627,6 @@ def _find_comfy_node_class(node_id: str):
     except Exception:
         comfy_nodes = None
     return _adapter_find_comfy_node_class(node_id, comfy_nodes)
-
-
-def _require_custom_node_class(node_id: str, node_pack: str, install_hint: str):
-    return _adapter_require_custom_node_class(
-        node_id,
-        node_pack,
-        install_hint,
-        _find_comfy_node_class,
-    )
-
-
-def _require_any_custom_node_class(node_ids: tuple[str, ...], node_pack: str, install_hint: str):
-    return _adapter_require_any_custom_node_class(
-        node_ids,
-        node_pack,
-        install_hint,
-        _find_comfy_node_class,
-    )
 
 
 def _encode_with_comfy_clip(clip, text: str):

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -352,37 +352,10 @@
     },
     {
       "symbol": "_require_any_custom_node_class",
-      "root_signature": {
-        "parameters": [
-          {
-            "name": "node_ids",
-            "kind": "positional_or_keyword",
-            "annotation": "tuple[str, ...]",
-            "default": null
-          },
-          {
-            "name": "node_pack",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          },
-          {
-            "name": "install_hint",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          }
-        ],
-        "return": null
-      },
-      "adapter_binding": {
-        "alias": "_adapter_require_any_custom_node_class",
-        "target": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class"
-      },
-      "root_dependencies": [
-        "_adapter_require_any_custom_node_class",
-        "_find_comfy_node_class"
-      ],
+      "root_signature": null,
+      "adapter_binding": null,
+      "retired_adapter_alias": "_adapter_require_any_custom_node_class",
+      "root_dependencies": [],
       "canonical_target": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
       "production_consumers": [
         {
@@ -416,43 +389,16 @@
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
       "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
-      "root_removal_gate": "E-07b injected lookup and exact error parity, then #184 B-11c29c",
+      "root_removal_gate": "completed in #184 B-11c29c / PR #332",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29c"
     },
     {
       "symbol": "_require_custom_node_class",
-      "root_signature": {
-        "parameters": [
-          {
-            "name": "node_id",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          },
-          {
-            "name": "node_pack",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          },
-          {
-            "name": "install_hint",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          }
-        ],
-        "return": null
-      },
-      "adapter_binding": {
-        "alias": "_adapter_require_custom_node_class",
-        "target": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class"
-      },
-      "root_dependencies": [
-        "_adapter_require_custom_node_class",
-        "_find_comfy_node_class"
-      ],
+      "root_signature": null,
+      "adapter_binding": null,
+      "retired_adapter_alias": "_adapter_require_custom_node_class",
+      "root_dependencies": [],
       "canonical_target": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
       "production_consumers": [
         {
@@ -499,7 +445,7 @@
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
       "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
-      "root_removal_gate": "E-07b injected lookup and exact error parity, then #184 B-11c29c",
+      "root_removal_gate": "completed in #184 B-11c29c / PR #332",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29c"
     }

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -22071,68 +22071,6 @@
         "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
-        "alias": "_adapter_require_any_custom_node_class",
-        "bound_name": "_adapter_require_any_custom_node_class",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_require_any_custom_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
-        "kind": "static_from",
-        "line": 410,
-        "name": "_require_any_custom_node_class",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "alias": "_adapter_require_custom_node_class",
-        "bound_name": "_adapter_require_custom_node_class",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_require_custom_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
-        "kind": "static_from",
-        "line": 410,
-        "name": "_require_custom_node_class",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
         "alias": "_call_with_supported_kwargs",
         "bound_name": "_call_with_supported_kwargs",
         "branch_context": [
@@ -22154,7 +22092,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 419,
+        "line": 417,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22185,7 +22123,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 419,
+        "line": 417,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22216,7 +22154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 419,
+        "line": 417,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22247,7 +22185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 419,
+        "line": 417,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22278,7 +22216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 425,
+        "line": 423,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22309,7 +22247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22340,7 +22278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22371,7 +22309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22402,7 +22340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22433,7 +22371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 428,
+        "line": 426,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22464,7 +22402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 436,
+        "line": 434,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22495,7 +22433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 436,
+        "line": 434,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22526,7 +22464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 440,
+        "line": 438,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22557,7 +22495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22588,7 +22526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22619,7 +22557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 444,
+        "line": 442,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22650,7 +22588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22681,7 +22619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22712,7 +22650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22743,7 +22681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22774,7 +22712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 449,
+        "line": 447,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22805,7 +22743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 456,
+        "line": 454,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22836,7 +22774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 456,
+        "line": 454,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22867,7 +22805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 456,
+        "line": 454,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22898,7 +22836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 461,
+        "line": 459,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22929,7 +22867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 461,
+        "line": 459,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22960,7 +22898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 461,
+        "line": 459,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22991,7 +22929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23022,7 +22960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23053,7 +22991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23084,7 +23022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23115,7 +23053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 479,
+        "line": 477,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23146,7 +23084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 502,
+        "line": 500,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23177,7 +23115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 502,
+        "line": 500,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23208,7 +23146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23239,7 +23177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 506,
+        "line": 504,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23270,7 +23208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23301,7 +23239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23332,7 +23270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23363,7 +23301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23394,7 +23332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23425,7 +23363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23456,7 +23394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23487,7 +23425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23518,7 +23456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23549,7 +23487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23580,7 +23518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23611,7 +23549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23642,7 +23580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23673,7 +23611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23704,7 +23642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23735,7 +23673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23766,7 +23704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23797,7 +23735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23828,7 +23766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23859,7 +23797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23890,7 +23828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23921,7 +23859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23952,7 +23890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23983,7 +23921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 538,
+        "line": 536,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24014,7 +23952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 538,
+        "line": 536,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24045,7 +23983,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24076,7 +24014,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 542,
+        "line": 540,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24107,7 +24045,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 543,
+        "line": 541,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24138,7 +24076,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24169,7 +24107,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24200,7 +24138,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 544,
+        "line": 542,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24231,7 +24169,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 549,
+        "line": 547,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24262,7 +24200,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 549,
+        "line": 547,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24293,7 +24231,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24324,7 +24262,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24355,7 +24293,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24386,7 +24324,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24417,7 +24355,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24448,7 +24386,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24479,7 +24417,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24510,7 +24448,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24541,7 +24479,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24572,7 +24510,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24603,7 +24541,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24634,7 +24572,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24665,7 +24603,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24696,7 +24634,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24727,7 +24665,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24758,7 +24696,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24789,7 +24727,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24820,7 +24758,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24851,7 +24789,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 550,
+        "line": 548,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24870,7 +24808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -24885,7 +24823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24904,7 +24842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -24919,7 +24857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24938,7 +24876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -24953,7 +24891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24972,7 +24910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -24987,7 +24925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25006,7 +24944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25021,7 +24959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25040,7 +24978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25055,7 +24993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25074,7 +25012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25089,7 +25027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25108,7 +25046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25123,7 +25061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25142,7 +25080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25157,7 +25095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25176,7 +25114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25191,7 +25129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25210,7 +25148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25225,7 +25163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25244,7 +25182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25259,7 +25197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25278,7 +25216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25293,7 +25231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25312,7 +25250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25327,7 +25265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25346,7 +25284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25361,7 +25299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25380,7 +25318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25395,7 +25333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25414,7 +25352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25429,7 +25367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25448,7 +25386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25463,7 +25401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25482,7 +25420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25497,7 +25435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25516,7 +25454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25531,7 +25469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25550,7 +25488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25565,7 +25503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25584,7 +25522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25599,7 +25537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25618,7 +25556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25633,7 +25571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25652,7 +25590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25667,7 +25605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25686,7 +25624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25701,7 +25639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25720,7 +25658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25735,7 +25673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25754,7 +25692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25769,7 +25707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25788,7 +25726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25803,7 +25741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25822,7 +25760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25837,7 +25775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25856,7 +25794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25871,7 +25809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25890,7 +25828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25905,7 +25843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25924,7 +25862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25939,7 +25877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25958,7 +25896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -25973,7 +25911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 611,
+        "line": 609,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25992,7 +25930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26007,7 +25945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26026,7 +25964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26041,7 +25979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26060,7 +25998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26075,7 +26013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26094,7 +26032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26109,7 +26047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26128,7 +26066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26143,7 +26081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26162,7 +26100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26177,7 +26115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26196,7 +26134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26211,7 +26149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26230,7 +26168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26245,7 +26183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26264,7 +26202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26279,7 +26217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26298,7 +26236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26313,7 +26251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26332,7 +26270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26347,7 +26285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26366,7 +26304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26381,7 +26319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26400,7 +26338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26415,7 +26353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26434,7 +26372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26449,7 +26387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26468,7 +26406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26483,7 +26421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26502,7 +26440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26517,7 +26455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26536,7 +26474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26551,7 +26489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26570,7 +26508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26585,7 +26523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26604,7 +26542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26619,7 +26557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26638,7 +26576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26653,7 +26591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26672,7 +26610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26687,7 +26625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26706,7 +26644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26721,7 +26659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26740,7 +26678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26755,7 +26693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26774,7 +26712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26789,7 +26727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26808,7 +26746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26823,7 +26761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26842,7 +26780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26857,7 +26795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26876,7 +26814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26891,7 +26829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26910,7 +26848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26925,7 +26863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26944,7 +26882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26959,7 +26897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26978,7 +26916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -26993,7 +26931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27012,7 +26950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27027,7 +26965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27046,7 +26984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27061,7 +26999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27080,7 +27018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27095,7 +27033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27114,7 +27052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27129,7 +27067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27148,7 +27086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27163,7 +27101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27182,7 +27120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27197,7 +27135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27216,7 +27154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27231,7 +27169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27250,7 +27188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27265,7 +27203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27284,7 +27222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27299,7 +27237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27318,7 +27256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27333,7 +27271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27352,7 +27290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27367,7 +27305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27386,7 +27324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27401,7 +27339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27420,7 +27358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27435,7 +27373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27454,7 +27392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27469,7 +27407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27488,7 +27426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27503,7 +27441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27522,7 +27460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27537,7 +27475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27556,7 +27494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27571,7 +27509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27590,7 +27528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27605,7 +27543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27624,7 +27562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27639,7 +27577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27658,7 +27596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27673,7 +27611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27692,7 +27630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27707,7 +27645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27726,7 +27664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27741,7 +27679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27760,7 +27698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27775,7 +27713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27794,7 +27732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27809,7 +27747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27828,7 +27766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27843,7 +27781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27862,7 +27800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27877,7 +27815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27896,7 +27834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27911,7 +27849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27930,7 +27868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27945,7 +27883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27964,7 +27902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -27979,7 +27917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27998,7 +27936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28013,7 +27951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28032,7 +27970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28047,7 +27985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28066,7 +28004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28081,7 +28019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28100,7 +28038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28115,7 +28053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28134,7 +28072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28149,7 +28087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28168,7 +28106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28183,7 +28121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28202,7 +28140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28217,7 +28155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28236,7 +28174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28251,7 +28189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28270,7 +28208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28285,7 +28223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28304,7 +28242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28319,7 +28257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28338,7 +28276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28353,7 +28291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28372,7 +28310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28387,7 +28325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28406,7 +28344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28421,7 +28359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28440,7 +28378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28455,7 +28393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28474,7 +28412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28489,7 +28427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28508,7 +28446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28523,7 +28461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28542,7 +28480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28557,7 +28495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28576,7 +28514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28591,7 +28529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28610,7 +28548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28625,7 +28563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28644,7 +28582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28659,7 +28597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28678,7 +28616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28693,7 +28631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28712,7 +28650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28727,7 +28665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28746,7 +28684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28761,7 +28699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28780,7 +28718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28795,7 +28733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28814,7 +28752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28829,7 +28767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28848,7 +28786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28863,7 +28801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28882,7 +28820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28897,7 +28835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28916,7 +28854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28931,7 +28869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28950,7 +28888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28965,7 +28903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28984,7 +28922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -28999,7 +28937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29018,7 +28956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29033,7 +28971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29052,7 +28990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29067,7 +29005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29086,7 +29024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29101,7 +29039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29120,7 +29058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29135,7 +29073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29154,7 +29092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29169,7 +29107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29188,7 +29126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29203,7 +29141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29222,7 +29160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29237,7 +29175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29256,7 +29194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29271,7 +29209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29290,7 +29228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29305,7 +29243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29324,7 +29262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29339,7 +29277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29358,7 +29296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29373,7 +29311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29392,7 +29330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29407,7 +29345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29426,7 +29364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29441,7 +29379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29460,7 +29398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29475,7 +29413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29494,7 +29432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29509,7 +29447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29528,7 +29466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29543,7 +29481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29562,7 +29500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29577,7 +29515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29596,7 +29534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29611,7 +29549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29630,7 +29568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29645,7 +29583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29664,7 +29602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29679,7 +29617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29698,7 +29636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29713,7 +29651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29732,7 +29670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29747,7 +29685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29766,7 +29704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29781,7 +29719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29800,7 +29738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29815,7 +29753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29834,7 +29772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29849,7 +29787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29868,7 +29806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29883,7 +29821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29902,7 +29840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29917,7 +29855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29936,7 +29874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29951,7 +29889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29970,7 +29908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -29985,7 +29923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30004,7 +29942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30019,7 +29957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30038,7 +29976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30053,7 +29991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30072,7 +30010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30087,7 +30025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30106,7 +30044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30121,7 +30059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30140,7 +30078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30155,7 +30093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30174,7 +30112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30189,7 +30127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30208,7 +30146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30223,7 +30161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30242,7 +30180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30257,7 +30195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30276,7 +30214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30291,7 +30229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30310,7 +30248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30325,7 +30263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30344,7 +30282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30359,7 +30297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30378,7 +30316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30393,7 +30331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30412,7 +30350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30427,7 +30365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30446,7 +30384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30461,7 +30399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30480,7 +30418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30495,7 +30433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30514,7 +30452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30529,7 +30467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30548,7 +30486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30563,7 +30501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30582,7 +30520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30597,7 +30535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30616,7 +30554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30631,7 +30569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30650,7 +30588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30665,7 +30603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30684,7 +30622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30699,7 +30637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30718,7 +30656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30733,7 +30671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30752,7 +30690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30767,7 +30705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30786,7 +30724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30801,7 +30739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30820,7 +30758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30835,7 +30773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30854,7 +30792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30869,7 +30807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30888,7 +30826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30903,7 +30841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30922,7 +30860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30937,7 +30875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30956,7 +30894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -30971,7 +30909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30990,7 +30928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31005,7 +30943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31024,7 +30962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31039,7 +30977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31058,7 +30996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31073,7 +31011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31092,7 +31030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31107,7 +31045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31126,7 +31064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31141,7 +31079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31160,7 +31098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31175,7 +31113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31194,7 +31132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31209,7 +31147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31228,7 +31166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31243,7 +31181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31262,7 +31200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31277,7 +31215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31296,7 +31234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31311,7 +31249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31330,7 +31268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31345,7 +31283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31364,7 +31302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31379,7 +31317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31398,7 +31336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31413,7 +31351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31432,7 +31370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31447,7 +31385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31466,7 +31404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31481,7 +31419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31500,7 +31438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31515,7 +31453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31534,7 +31472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31549,7 +31487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31568,7 +31506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31583,7 +31521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31602,7 +31540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31617,7 +31555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31636,7 +31574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31651,7 +31589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31670,7 +31608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31685,7 +31623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31704,7 +31642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31719,7 +31657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31738,7 +31676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31753,7 +31691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31772,7 +31710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31787,7 +31725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31806,7 +31744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31821,7 +31759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31840,7 +31778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31855,7 +31793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31874,7 +31812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31889,7 +31827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31908,7 +31846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31923,7 +31861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31942,7 +31880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31957,7 +31895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31976,7 +31914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -31991,7 +31929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32010,7 +31948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32025,7 +31963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32044,7 +31982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32059,7 +31997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32078,7 +32016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32093,7 +32031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32112,7 +32050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32127,7 +32065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32146,7 +32084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32161,7 +32099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32180,7 +32118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32195,7 +32133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32214,7 +32152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32229,7 +32167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32248,7 +32186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32263,7 +32201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32282,7 +32220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32297,7 +32235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32316,7 +32254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32331,7 +32269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32350,7 +32288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32365,7 +32303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32384,7 +32322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32399,7 +32337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32418,7 +32356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32433,7 +32371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32452,7 +32390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32467,7 +32405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32486,7 +32424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32501,7 +32439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32520,7 +32458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32535,7 +32473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32554,7 +32492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32569,7 +32507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32588,7 +32526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32603,7 +32541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32622,7 +32560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32637,7 +32575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32656,7 +32594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32671,7 +32609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32690,7 +32628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32705,7 +32643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32724,7 +32662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32739,7 +32677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32758,7 +32696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32773,7 +32711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32792,7 +32730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32807,7 +32745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32826,7 +32764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32841,7 +32779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32860,7 +32798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32875,76 +32813,8 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "name": "_impact_scheduler_names",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "alias": "_adapter_require_any_custom_node_class",
-        "bound_name": "_adapter_require_any_custom_node_class",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_require_any_custom_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
-        "kind": "static_from",
-        "line": 972,
-        "name": "_require_any_custom_node_class",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "alias": "_adapter_require_custom_node_class",
-        "bound_name": "_adapter_require_custom_node_class",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_require_custom_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
-        "kind": "static_from",
-        "line": 972,
-        "name": "_require_custom_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
         "role": "compatibility_fallback",
@@ -32962,7 +32832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -32977,7 +32847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32996,7 +32866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33011,7 +32881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33030,7 +32900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33045,7 +32915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33064,7 +32934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33079,7 +32949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33098,7 +32968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33113,7 +32983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 987,
+        "line": 983,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -33132,7 +33002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33147,7 +33017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33166,7 +33036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33181,7 +33051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33200,7 +33070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33215,7 +33085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33234,7 +33104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33249,7 +33119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33268,7 +33138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33283,7 +33153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33302,7 +33172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33317,7 +33187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 998,
+        "line": 994,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33336,7 +33206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33351,7 +33221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 998,
+        "line": 994,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33370,7 +33240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33385,7 +33255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 998,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33404,7 +33274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33419,7 +33289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33438,7 +33308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33453,7 +33323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33472,7 +33342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33487,7 +33357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33506,7 +33376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33521,7 +33391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33540,7 +33410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33555,7 +33425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33574,7 +33444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33589,7 +33459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33608,7 +33478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33623,7 +33493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33642,7 +33512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33657,7 +33527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33676,7 +33546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33691,7 +33561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1014,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33710,7 +33580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33725,7 +33595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1014,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33744,7 +33614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33759,7 +33629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1014,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33778,7 +33648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33793,7 +33663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1019,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33812,7 +33682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33827,7 +33697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1019,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33846,7 +33716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33861,7 +33731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1019,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33880,7 +33750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33895,7 +33765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33914,7 +33784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33929,7 +33799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33948,7 +33818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33963,7 +33833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33982,7 +33852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -33997,7 +33867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34016,7 +33886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34031,7 +33901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34050,7 +33920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34065,7 +33935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1060,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34084,7 +33954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34099,7 +33969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1060,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34118,7 +33988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34133,7 +34003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34152,7 +34022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34167,7 +34037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34186,7 +34056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34201,7 +34071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34220,7 +34090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34235,7 +34105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34254,7 +34124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34269,7 +34139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34288,7 +34158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34303,7 +34173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34322,7 +34192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34337,7 +34207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34356,7 +34226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34371,7 +34241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34390,7 +34260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34405,7 +34275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34424,7 +34294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34439,7 +34309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34458,7 +34328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34473,7 +34343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34492,7 +34362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34507,7 +34377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34526,7 +34396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34541,7 +34411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34560,7 +34430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34575,7 +34445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34594,7 +34464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34609,7 +34479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34628,7 +34498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34643,7 +34513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34662,7 +34532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34677,7 +34547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34696,7 +34566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34711,7 +34581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34730,7 +34600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34745,7 +34615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34764,7 +34634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34779,7 +34649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34798,7 +34668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34813,7 +34683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34832,7 +34702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34847,7 +34717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34866,7 +34736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34881,7 +34751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34900,7 +34770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34915,7 +34785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34934,7 +34804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34949,7 +34819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34968,7 +34838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -34983,7 +34853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1096,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -35002,7 +34872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35017,7 +34887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1096,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -35036,7 +34906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35051,7 +34921,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1100,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -35070,7 +34940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35085,7 +34955,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1100,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -35104,7 +34974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35119,7 +34989,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1101,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -35138,7 +35008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35153,7 +35023,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1102,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -35172,7 +35042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35187,7 +35057,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1102,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35206,7 +35076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35221,7 +35091,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1102,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35240,7 +35110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35255,7 +35125,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1107,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35274,7 +35144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35289,7 +35159,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1107,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35308,7 +35178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35323,7 +35193,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35342,7 +35212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35357,7 +35227,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35376,7 +35246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35391,7 +35261,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35410,7 +35280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35425,7 +35295,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35444,7 +35314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35459,7 +35329,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35478,7 +35348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35493,7 +35363,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35512,7 +35382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35527,7 +35397,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35546,7 +35416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35561,7 +35431,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35580,7 +35450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35595,7 +35465,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35614,7 +35484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35629,7 +35499,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35648,7 +35518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35663,7 +35533,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35682,7 +35552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35697,7 +35567,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35716,7 +35586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35731,7 +35601,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35750,7 +35620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35765,7 +35635,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35784,7 +35654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35799,7 +35669,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35818,7 +35688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35833,7 +35703,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35852,7 +35722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35867,7 +35737,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35886,7 +35756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35901,7 +35771,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35920,7 +35790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -35935,7 +35805,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35953,7 +35823,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1629
+            "line": 1625
           }
         ],
         "classification": "external",
@@ -35961,7 +35831,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1630,
+        "line": 1626,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -39275,13 +39145,13 @@
       },
       {
         "is_package": false,
-        "loc": 85,
+        "loc": 115,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
-        "normalized_git_blob_sha1": "2fac88dd5fa246ed7b4cf075ddea636b6e72cea9",
+        "normalized_git_blob_sha1": "195c174dde130a0ef90c37f6d35d8ec49f523c08",
         "path": "easyuse_anima/infrastructure/comfy/wiring.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 4,
+          "function_count": 6,
           "global_count": 1
         }
       },
@@ -39683,13 +39553,13 @@
       },
       {
         "is_package": false,
-        "loc": 1888,
+        "loc": 1866,
         "module": "nodes",
-        "normalized_git_blob_sha1": "20b2d41320caeb93a1d60f9bc3e308d66bb73619",
+        "normalized_git_blob_sha1": "c25e302b3082a6fcefb4af799508ddc489e53d3d",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 5,
+          "function_count": 3,
           "global_count": 26
         }
       },
@@ -41049,7 +40919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41058,7 +40928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41072,7 +40942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41081,7 +40951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41095,7 +40965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41104,7 +40974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41118,7 +40988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41127,7 +40997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41141,7 +41011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41150,7 +41020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41164,7 +41034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41173,7 +41043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41187,7 +41057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41196,7 +41066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41210,7 +41080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41219,7 +41089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 572,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41233,7 +41103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41242,7 +41112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41256,7 +41126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41265,7 +41135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41279,7 +41149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41288,7 +41158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41302,7 +41172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41311,7 +41181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41325,7 +41195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41334,7 +41204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41348,7 +41218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41357,7 +41227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41371,7 +41241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41380,7 +41250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41394,7 +41264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41403,7 +41273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 583,
+        "line": 581,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41417,7 +41287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41426,7 +41296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41440,7 +41310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41449,7 +41319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41463,7 +41333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41472,7 +41342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41486,7 +41356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41495,7 +41365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41509,7 +41379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41518,7 +41388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41532,7 +41402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41541,7 +41411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41555,7 +41425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41564,7 +41434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41578,7 +41448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41587,7 +41457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41601,7 +41471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41610,7 +41480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41624,7 +41494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41633,7 +41503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41647,7 +41517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41656,7 +41526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41670,7 +41540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41679,7 +41549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41693,7 +41563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41702,7 +41572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41716,7 +41586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41725,7 +41595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41739,7 +41609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41748,7 +41618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41762,7 +41632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41771,7 +41641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 593,
+        "line": 591,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41785,7 +41655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41794,7 +41664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 611,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41808,7 +41678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41817,7 +41687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41831,7 +41701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41840,7 +41710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41854,7 +41724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41863,7 +41733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 614,
+        "line": 612,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41877,7 +41747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41886,7 +41756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41900,7 +41770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41909,7 +41779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41923,7 +41793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41932,7 +41802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41946,7 +41816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41955,7 +41825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41969,7 +41839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -41978,7 +41848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 619,
+        "line": 617,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41992,7 +41862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42001,7 +41871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42015,7 +41885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42024,7 +41894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42038,7 +41908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42047,7 +41917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42061,7 +41931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42070,7 +41940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 626,
+        "line": 624,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42084,7 +41954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42093,7 +41963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42107,7 +41977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42116,7 +41986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42130,7 +42000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42139,7 +42009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42153,7 +42023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42162,7 +42032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42176,7 +42046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42185,7 +42055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42199,7 +42069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42208,7 +42078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42222,7 +42092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42231,7 +42101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42245,7 +42115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42254,7 +42124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42268,7 +42138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42277,7 +42147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42291,7 +42161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42300,7 +42170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42314,7 +42184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42323,7 +42193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42337,7 +42207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42346,7 +42216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42360,7 +42230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42369,7 +42239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 632,
+        "line": 630,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42383,7 +42253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42392,7 +42262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42406,7 +42276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42415,7 +42285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42429,7 +42299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42438,7 +42308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42452,7 +42322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42461,7 +42331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42475,7 +42345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42484,7 +42354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42498,7 +42368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42507,7 +42377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42521,7 +42391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42530,7 +42400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42544,7 +42414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42553,7 +42423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42567,7 +42437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42576,7 +42446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42590,7 +42460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42599,7 +42469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42613,7 +42483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42622,7 +42492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42636,7 +42506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42645,7 +42515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 647,
+        "line": 645,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42659,7 +42529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42668,7 +42538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42682,7 +42552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42691,7 +42561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42705,7 +42575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42714,7 +42584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42728,7 +42598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42737,7 +42607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42751,7 +42621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42760,7 +42630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42774,7 +42644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42783,7 +42653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42797,7 +42667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42806,7 +42676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42820,7 +42690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42829,7 +42699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42843,7 +42713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42852,7 +42722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42866,7 +42736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42875,7 +42745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 661,
+        "line": 659,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42889,7 +42759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42898,7 +42768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42912,7 +42782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42921,7 +42791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42935,7 +42805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42944,7 +42814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42958,7 +42828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42967,7 +42837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42981,7 +42851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -42990,7 +42860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43004,7 +42874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43013,7 +42883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43027,7 +42897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43036,7 +42906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43050,7 +42920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43059,7 +42929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43073,7 +42943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43082,7 +42952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43096,7 +42966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43105,7 +42975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 673,
+        "line": 671,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43119,7 +42989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43128,7 +42998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43142,7 +43012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43151,7 +43021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43165,7 +43035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43174,7 +43044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43188,7 +43058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43197,7 +43067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43211,7 +43081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43220,7 +43090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43234,7 +43104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43243,7 +43113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43257,7 +43127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43266,7 +43136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43280,7 +43150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43289,7 +43159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43303,7 +43173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43312,7 +43182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43326,7 +43196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43335,7 +43205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43349,7 +43219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43358,7 +43228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43372,7 +43242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43381,7 +43251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43395,7 +43265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43404,7 +43274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43418,7 +43288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43427,7 +43297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43441,7 +43311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43450,7 +43320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43464,7 +43334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43473,7 +43343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 685,
+        "line": 683,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43487,7 +43357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43496,7 +43366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43510,7 +43380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43519,7 +43389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43533,7 +43403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43542,7 +43412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 701,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43556,7 +43426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43565,7 +43435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43579,7 +43449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43588,7 +43458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43602,7 +43472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43611,7 +43481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43625,7 +43495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43634,7 +43504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43648,7 +43518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43657,7 +43527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 708,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43671,7 +43541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43680,7 +43550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43694,7 +43564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43703,7 +43573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43717,7 +43587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43726,7 +43596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43740,7 +43610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43749,7 +43619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43763,7 +43633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43772,7 +43642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 716,
+        "line": 714,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43786,7 +43656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43795,7 +43665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43809,7 +43679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43818,7 +43688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43832,7 +43702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43841,7 +43711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43855,7 +43725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43864,7 +43734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43878,7 +43748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43887,7 +43757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43901,7 +43771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43910,7 +43780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43924,7 +43794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43933,7 +43803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43947,7 +43817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43956,7 +43826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43970,7 +43840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -43979,7 +43849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43993,7 +43863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44002,7 +43872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 722,
+        "line": 720,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44016,7 +43886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44025,7 +43895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44039,7 +43909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44048,7 +43918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44062,7 +43932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44071,7 +43941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44085,7 +43955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44094,7 +43964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44108,7 +43978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44117,7 +43987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44131,7 +44001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44140,7 +44010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44154,7 +44024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44163,7 +44033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 736,
+        "line": 734,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44177,7 +44047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44186,7 +44056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44200,7 +44070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44209,7 +44079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44223,7 +44093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44232,7 +44102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44246,7 +44116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44255,7 +44125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44269,7 +44139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44278,7 +44148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44292,7 +44162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44301,7 +44171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44315,7 +44185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44324,7 +44194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44338,7 +44208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44347,7 +44217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44361,7 +44231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44370,7 +44240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44384,7 +44254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44393,7 +44263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44407,7 +44277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44416,7 +44286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44430,7 +44300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44439,7 +44309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44453,7 +44323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44462,7 +44332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44476,7 +44346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44485,7 +44355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44499,7 +44369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44508,7 +44378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44522,7 +44392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44531,7 +44401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44545,7 +44415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44554,7 +44424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44568,7 +44438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44577,7 +44447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44591,7 +44461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44600,7 +44470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44614,7 +44484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44623,7 +44493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44637,7 +44507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44646,7 +44516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44660,7 +44530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44669,7 +44539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 754,
+        "line": 752,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44683,7 +44553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44692,7 +44562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44706,7 +44576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44715,7 +44585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44729,7 +44599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44738,7 +44608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44752,7 +44622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44761,7 +44631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44775,7 +44645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44784,7 +44654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44798,7 +44668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44807,7 +44677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44821,7 +44691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44830,7 +44700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44844,7 +44714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44853,7 +44723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44867,7 +44737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44876,7 +44746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44890,7 +44760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44899,7 +44769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44913,7 +44783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44922,7 +44792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44936,7 +44806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44945,7 +44815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44959,7 +44829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44968,7 +44838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44982,7 +44852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -44991,7 +44861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 790,
+        "line": 788,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45005,7 +44875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45014,7 +44884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45028,7 +44898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45037,7 +44907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45051,7 +44921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45060,7 +44930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45074,7 +44944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45083,7 +44953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45097,7 +44967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45106,7 +44976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45120,7 +44990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45129,7 +44999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45143,7 +45013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45152,7 +45022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45166,7 +45036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45175,7 +45045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45189,7 +45059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45198,7 +45068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 818,
+        "line": 816,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45212,7 +45082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45221,7 +45091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45235,7 +45105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45244,7 +45114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45258,7 +45128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45267,7 +45137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45281,7 +45151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45290,7 +45160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45304,7 +45174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45313,7 +45183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45327,7 +45197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45336,7 +45206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45350,7 +45220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45359,7 +45229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45373,7 +45243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45382,7 +45252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45396,7 +45266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45405,7 +45275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45419,7 +45289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45428,7 +45298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45442,7 +45312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45451,7 +45321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45465,7 +45335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45474,7 +45344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45488,7 +45358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45497,7 +45367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45511,7 +45381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45520,7 +45390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45534,7 +45404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45543,7 +45413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45557,7 +45427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45566,7 +45436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45580,7 +45450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45589,7 +45459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45603,7 +45473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45612,7 +45482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45626,7 +45496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45635,7 +45505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45649,7 +45519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45658,7 +45528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45672,7 +45542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45681,7 +45551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45695,7 +45565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45704,7 +45574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45718,7 +45588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45727,7 +45597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45741,7 +45611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45750,7 +45620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45764,7 +45634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45773,7 +45643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 834,
+        "line": 832,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45787,7 +45657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45796,7 +45666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45810,7 +45680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45819,7 +45689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45833,7 +45703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45842,7 +45712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45856,7 +45726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45865,7 +45735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 914,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45879,7 +45749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45888,7 +45758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45902,7 +45772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45911,7 +45781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45925,7 +45795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45934,7 +45804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 920,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45948,7 +45818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45957,7 +45827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45971,7 +45841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -45980,7 +45850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45994,7 +45864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46003,7 +45873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 925,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46017,7 +45887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46026,7 +45896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46040,7 +45910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46049,7 +45919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46063,7 +45933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46072,7 +45942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46086,7 +45956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46095,7 +45965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46109,7 +45979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46118,7 +45988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46132,7 +46002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46141,7 +46011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46155,7 +46025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46164,7 +46034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 931,
+        "line": 929,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46178,7 +46048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46187,7 +46057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46201,7 +46071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46210,7 +46080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46224,7 +46094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46233,7 +46103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 940,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46247,7 +46117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46256,7 +46126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46270,7 +46140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46279,7 +46149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46293,7 +46163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46302,7 +46172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46316,7 +46186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46325,7 +46195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 951,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46339,7 +46209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46348,7 +46218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46362,7 +46232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46371,7 +46241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 964,
+        "line": 962,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46385,7 +46255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46394,7 +46264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46408,7 +46278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46417,7 +46287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46431,7 +46301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46440,7 +46310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46454,7 +46324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46463,7 +46333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 970,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46477,53 +46347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class",
-        "kind": "static_from",
-        "line": 972,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class",
-        "kind": "static_from",
-        "line": 972,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46532,7 +46356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46546,7 +46370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46555,7 +46379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46569,7 +46393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46578,7 +46402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46592,7 +46416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46601,7 +46425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 981,
+        "line": 977,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46615,7 +46439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46624,7 +46448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 987,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46638,7 +46462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46647,7 +46471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46661,7 +46485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46670,7 +46494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46684,7 +46508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46693,7 +46517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46707,7 +46531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46716,7 +46540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46730,7 +46554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46739,7 +46563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 990,
+        "line": 986,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46753,7 +46577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46762,7 +46586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 998,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46776,7 +46600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46785,7 +46609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 998,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46799,7 +46623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46808,7 +46632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46822,7 +46646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46831,7 +46655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46845,7 +46669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46854,7 +46678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46868,7 +46692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46877,7 +46701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46891,7 +46715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46900,7 +46724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46914,7 +46738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46923,7 +46747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46937,7 +46761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46946,7 +46770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46960,7 +46784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46969,7 +46793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46983,7 +46807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -46992,7 +46816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1011,
+        "line": 1007,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47006,7 +46830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47015,7 +46839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47029,7 +46853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47038,7 +46862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47052,7 +46876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47061,7 +46885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1014,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47075,7 +46899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47084,7 +46908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47098,7 +46922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47107,7 +46931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47121,7 +46945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47130,7 +46954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1023,
+        "line": 1019,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47144,7 +46968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47153,7 +46977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47167,7 +46991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47176,7 +47000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47190,7 +47014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47199,7 +47023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47213,7 +47037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47222,7 +47046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47236,7 +47060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47245,7 +47069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1037,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47259,7 +47083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47268,7 +47092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47282,7 +47106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47291,7 +47115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47305,7 +47129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47314,7 +47138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47328,7 +47152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47337,7 +47161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47351,7 +47175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47360,7 +47184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47374,7 +47198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47383,7 +47207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47397,7 +47221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47406,7 +47230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47420,7 +47244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47429,7 +47253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47443,7 +47267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47452,7 +47276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47466,7 +47290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47475,7 +47299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47489,7 +47313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47498,7 +47322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47512,7 +47336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47521,7 +47345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47535,7 +47359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47544,7 +47368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47558,7 +47382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47567,7 +47391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47581,7 +47405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47590,7 +47414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47604,7 +47428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47613,7 +47437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47627,7 +47451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47636,7 +47460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47650,7 +47474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47659,7 +47483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47673,7 +47497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47682,7 +47506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47696,7 +47520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47705,7 +47529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47719,7 +47543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47728,7 +47552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47742,7 +47566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47751,7 +47575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47765,7 +47589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47774,7 +47598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47788,7 +47612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47797,7 +47621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47811,7 +47635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47820,7 +47644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47834,7 +47658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47843,7 +47667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47857,7 +47681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47866,7 +47690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1090,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47880,7 +47704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47889,7 +47713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47903,7 +47727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47912,7 +47736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47926,7 +47750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47935,7 +47759,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47949,7 +47773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47958,7 +47782,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47972,7 +47796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -47981,7 +47805,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1101,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47995,7 +47819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48004,7 +47828,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48018,7 +47842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48027,7 +47851,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48041,7 +47865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48050,7 +47874,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1102,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48064,7 +47888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48073,7 +47897,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48087,7 +47911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48096,7 +47920,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1111,
+        "line": 1107,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48110,7 +47934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48119,7 +47943,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48133,7 +47957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48142,7 +47966,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48156,7 +47980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48165,7 +47989,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48179,7 +48003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48188,7 +48012,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48202,7 +48026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48211,7 +48035,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48225,7 +48049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48234,7 +48058,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48248,7 +48072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48257,7 +48081,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48271,7 +48095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48280,7 +48104,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48294,7 +48118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48303,7 +48127,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48317,7 +48141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48326,7 +48150,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48340,7 +48164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48349,7 +48173,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48363,7 +48187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48372,7 +48196,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48386,7 +48210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48395,7 +48219,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48409,7 +48233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48418,7 +48242,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48432,7 +48256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48441,7 +48265,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48455,7 +48279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48464,7 +48288,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48478,7 +48302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48487,7 +48311,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48501,7 +48325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48510,7 +48334,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48524,7 +48348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 571,
+            "handler_line": 569,
             "kind": "try",
             "line": 9
           }
@@ -48533,7 +48357,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1112,
+        "line": 1108,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52478,14 +52302,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1629
+            "line": 1625
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1630,
+        "line": 1626,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53879,14 +53703,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1629
+            "line": 1625
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1630,
+        "line": 1626,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55362,7 +55186,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1134,
+        "line": 1130,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55371,7 +55195,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1739,
+        "line": 1717,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55380,7 +55204,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1742,
+        "line": 1720,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55389,7 +55213,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1748,
+        "line": 1726,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55398,7 +55222,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1754,
+        "line": 1732,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55407,7 +55231,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1757,
+        "line": 1735,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55416,7 +55240,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1760,
+        "line": 1738,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55425,7 +55249,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1766,
+        "line": 1744,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55434,7 +55258,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1772,
+        "line": 1750,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55443,7 +55267,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1778,
+        "line": 1756,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55452,7 +55276,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1784,
+        "line": 1762,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55461,7 +55285,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1790,
+        "line": 1768,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55470,7 +55294,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1796,
+        "line": 1774,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55479,7 +55303,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1802,
+        "line": 1780,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55488,7 +55312,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1808,
+        "line": 1786,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55497,7 +55321,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1814,
+        "line": 1792,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55506,7 +55330,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1817,
+        "line": 1795,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55515,7 +55339,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1824,
+        "line": 1802,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55524,7 +55348,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1827,
+        "line": 1805,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55533,7 +55357,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1831,
+        "line": 1809,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55542,7 +55366,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1834,
+        "line": 1812,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55551,7 +55375,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1841,
+        "line": 1819,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55560,7 +55384,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1847,
+        "line": 1825,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55569,7 +55393,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1853,
+        "line": 1831,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55578,7 +55402,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1856,
+        "line": 1834,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55587,7 +55411,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1859,
+        "line": 1837,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55596,7 +55420,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1862,
+        "line": 1840,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55605,7 +55429,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1869,
+        "line": 1847,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55614,7 +55438,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1875,
+        "line": 1853,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55623,7 +55447,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1880,
+        "line": 1858,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55632,7 +55456,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1884,
+        "line": 1862,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -56146,13 +55970,13 @@
       },
       {
         "kind": "dict",
-        "line": 1196,
+        "line": 1192,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1185,
+        "line": 1181,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -61,7 +61,8 @@
       "B-11c28",
       "B-11c29a",
       "B-11c29b1",
-      "B-11c29b2"
+      "B-11c29b2",
+      "B-11c29c"
     ]
   },
   "enums": {
@@ -96,11 +97,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 299,
+    "nodes_canonical_bindings": 297,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 5,
+    "root_residual_functions": 3,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -1001,15 +1002,6 @@
     ],
     "_regional_union_mask_for_ids": [
       "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_require_any_custom_node_class": [
-      "easyuse_anima.aio.model_preparation"
-    ],
-    "_require_custom_node_class": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.output",
-      "easyuse_anima.aio.sampling"
     ],
     "_require_easy_use_anima_input": [
       "easyuse_anima.aio.legacy_generation"
@@ -2690,8 +2682,6 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_adapter_find_comfy_node_class": "_find_comfy_node_class",
-        "_adapter_require_any_custom_node_class": "_require_any_custom_node_class",
-        "_adapter_require_custom_node_class": "_require_custom_node_class",
         "_comfy_sampler_names": "_comfy_sampler_names",
         "_comfy_scheduler_names": "_comfy_scheduler_names",
         "_impact_scheduler_names": "_impact_scheduler_names"
@@ -4245,9 +4235,7 @@
       "symbols": {
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
         "_encode_with_comfy_clip": "_encode_with_comfy_clip",
-        "_find_comfy_node_class": "_find_comfy_node_class",
-        "_require_any_custom_node_class": "_require_any_custom_node_class",
-        "_require_custom_node_class": "_require_custom_node_class"
+        "_find_comfy_node_class": "_find_comfy_node_class"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from easyuse_anima import runtime as runtime_module
+from easyuse_anima.infrastructure.comfy.provider import DefaultComfyHostProvider
 from easyuse_anima.infrastructure.comfy.wiring import resolve_comfy_host_helper
 from easyuse_anima.runtime import RuntimeServices
 from tests.comfy_host_fakes import FakeComfyHostProvider
@@ -126,6 +127,62 @@ class ComfyHostWiringTests(unittest.TestCase):
             self.assertIs(helper("Loaded"), loaded_class)
             loaded_nodes.NODE_CLASS_MAPPINGS = {}
             self.assertIsNone(helper("Missing"))
+
+    def test_retired_required_helpers_use_default_provider_before_runtime_install(self):
+        custom_class = object()
+        other_class = object()
+        comfy_nodes = types.ModuleType("nodes")
+        comfy_nodes.NODE_CLASS_MAPPINGS = {
+            "Custom": custom_class,
+            "Other": other_class,
+        }
+
+        def unexpected_fallback(name: str):
+            self.fail(f"retired helper reached root fallback: {name}")
+
+        with patch.dict(sys.modules, {"nodes": comfy_nodes}):
+            require = resolve_comfy_host_helper(
+                "_require_custom_node_class",
+                unexpected_fallback,
+            )
+            require_any = resolve_comfy_host_helper(
+                "_require_any_custom_node_class",
+                unexpected_fallback,
+            )
+
+            self.assertIs(require("Custom", "Pack", "Hint"), custom_class)
+            self.assertEqual(
+                require_any(("Missing", "Other"), "Pack", "Hint"),
+                ("Other", other_class),
+            )
+            comfy_nodes.NODE_CLASS_MAPPINGS = {}
+            with self.assertRaises(RuntimeError) as missing_one:
+                require("Custom", "Pack", "Hint")
+            self.assertEqual(
+                str(missing_one.exception),
+                "[EasyUseAnima] Missing required custom node 'Custom'. "
+                "Install/enable Pack, then restart ComfyUI. Hint",
+            )
+            with self.assertRaises(RuntimeError) as missing_any:
+                require_any(("First", "Second"), "Pack", "Hint")
+            self.assertEqual(
+                str(missing_any.exception),
+                "[EasyUseAnima] Missing required custom node. "
+                "Tried 'First', 'Second'. "
+                "Install/enable Pack, then restart ComfyUI. Hint",
+            )
+
+        with patch.object(
+            DefaultComfyHostProvider,
+            "find_node_class",
+            side_effect=LookupError("lookup failed"),
+        ):
+            require = resolve_comfy_host_helper(
+                "_require_custom_node_class",
+                unexpected_fallback,
+            )
+            with self.assertRaisesRegex(LookupError, "lookup failed"):
+                require("Custom", "Pack", "Hint")
 
     def test_provider_owned_helpers_delegate_to_narrow_methods(self):
         direct = object()

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2152,6 +2152,8 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
         self.assertFalse(hasattr(nodes, "_comfy_max_resolution"))
         self.assertFalse(hasattr(nodes, "_find_comfy_node_mapping_class"))
         self.assertFalse(hasattr(nodes, "_find_loaded_node_class"))
+        self.assertFalse(hasattr(nodes, "_require_custom_node_class"))
+        self.assertFalse(hasattr(nodes, "_require_any_custom_node_class"))
         for canonical_module, helper_names in self.DIRECT_HELPER_MODULES:
             for helper_name in helper_names:
                 with self.subTest(module=canonical_module.__name__, helper=helper_name):
@@ -2167,6 +2169,12 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
                 hasattr(package_nodes, "_find_comfy_node_mapping_class")
             )
             self.assertFalse(hasattr(package_nodes, "_find_loaded_node_class"))
+            self.assertFalse(
+                hasattr(package_nodes, "_require_custom_node_class")
+            )
+            self.assertFalse(
+                hasattr(package_nodes, "_require_any_custom_node_class")
+            )
             self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
             self.assertFalse(hasattr(package_nodes, "_impact_core_module"))
             self.assertFalse(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "20b2d41320caeb93a1d60f9bc3e308d66bb73619")
-        # B-11c29b2 retires only the unsupported loaded-node root lookup and
-        # its two adapter imports without changing the public class surface.
-        self.assertEqual(report["top_level"]["function_count"], 5)
+        self.assertEqual(report["git_blob_sha1"], "c25e302b3082a6fcefb4af799508ddc489e53d3d")
+        # B-11c29c retires only the two pure requirement root helpers and
+        # their four adapter imports without changing the public class surface.
+        self.assertEqual(report["top_level"]["function_count"], 3)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_888)
+        self.assertEqual(report["line_count"], 1_866)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1695,6 +1695,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c29a",
                 "B-11c29b1",
                 "B-11c29b2",
+                "B-11c29c",
             ],
         },
         "enums": {
@@ -1707,11 +1708,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 299,
+            "nodes_canonical_bindings": 297,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 5,
+            "root_residual_functions": 3,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,
@@ -2142,6 +2143,8 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
                 "_comfy_max_resolution",
                 "_find_comfy_node_mapping_class",
                 "_find_loaded_node_class",
+                "_require_any_custom_node_class",
+                "_require_custom_node_class",
             },
         )
         self.assertEqual(
@@ -2154,6 +2157,10 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
                 "_comfy_max_resolution": "_adapter_comfy_max_resolution",
                 "_find_comfy_node_mapping_class": None,
                 "_find_loaded_node_class": "_adapter_find_loaded_node_class",
+                "_require_any_custom_node_class": (
+                    "_adapter_require_any_custom_node_class"
+                ),
+                "_require_custom_node_class": "_adapter_require_custom_node_class",
             },
         )
         for symbol, entry in self.entries.items():


### PR DESCRIPTION
## 분류

- Task: B-11c29c
- Owner: #184
- Type: Retirement
- Base: `dev@164b53ec89947bc5a72889d83641c5db947dbef5`
- 검증 head: `dd34f04`
- Contract/Behavior: 포함하지 않음

## 작업 전 symbol/caller/alias/global-state inventory

### `_require_custom_node_class`

- root definition: `nodes.py` 1개
- relative/flat alias: `_adapter_require_custom_node_class` 2 imports
- canonical owner:
  `easyuse_anima.infrastructure.comfy.capabilities:_require_custom_node_class`
- root dependency: `_find_comfy_node_class`
- production: 4 binders / 13 call sites
  - `easyuse_anima.aio.legacy_generation`
    - `UltimateSDUpscale`, `ResShiftLoader`, `ResShiftUpscale`
  - `easyuse_anima.aio.model_preparation`
    - `ModelPatchTorchSettings`, `PathchSageAttentionKJ`,
      `TorchCompileModelAdvanced`, `AnimaDAVE`, `AnimaSafePAG`,
      `DiTCFGFSGPatch`
  - `easyuse_anima.aio.output`
    - `Civitai Hash Fetcher (Image Saver)`, `Image Saver`
  - `easyuse_anima.aio.sampling`
    - `SpectrumKSamplerAdvanced`, `SpectrumSPDKSampler`
- behavior:
  - injected finder를 정확히 한 번 호출
  - non-`None` class identity 그대로 반환
  - missing은 기존 node-id/pack/hint `RuntimeError` text
  - finder exception은 그대로 전파

### `_require_any_custom_node_class`

- root definition: `nodes.py` 1개
- relative/flat alias: `_adapter_require_any_custom_node_class` 2 imports
- canonical owner:
  `easyuse_anima.infrastructure.comfy.capabilities:_require_any_custom_node_class`
- root dependency: `_find_comfy_node_class`
- production: `easyuse_anima.aio.model_preparation` 1 binder / 1 call site
  - candidate order: `DiTSpectrumPatchAdvanced`, `DiTSpectrumPatch`
- behavior:
  - caller tuple 순서 조회, 최초 non-`None`에서 중단
  - `(node_id, class)` tuple 반환
  - 모두 missing이면 기존 joined-candidate `RuntimeError` text
  - finder exception은 그대로 전파

### 공통 상태와 호환성

- repository root/canonical monkeypatch consumers: 0/0
- confirmed external consumers: 0
- root/canonical helper mutable state와 import-time call: 없음
- 네 AiO consumer는 binder-owned `_RUNTIME_RESOLVER`를 사용하지만 실제 helper
  해석과 optional-node lookup은 선택 기능 실행 시점
- ledger: `pure_helper_with_provider_input`, `unsupported_test_only`
- call-time root replacement required: false

두 helper는 canonical owner·provider input·root dependency·relative/flat adapter
경계·wiring branch가 동일하여 하나의 rollback unit으로 퇴역합니다.

## 변경

- 두 root helper definition과 네 relative/flat adapter import를 제거했습니다.
- installed runtime은 기존 provider-injected canonical helper를 유지합니다.
- flat pre-bootstrap은 fresh default provider lookup을 call-time에 주입합니다.
- exact error text, candidate order, result/tuple identity, raw finder exception
  전파를 고정했습니다.
- root/package absence와 retired adapter 재도입 방지 ledger를 갱신했습니다.
- analyzer, package closure fixture, architecture 문서를 현재 surface에
  맞췄습니다.

## 금지 경계 확인

- `capabilities.py`, provider interface/implementation 변경 없음
- AiO consumer/binder 변경 없음
- CLIP/general lookup 이동 없음
- schema/workflow/seed/stage/route/persistence/postprocess 변경 없음
- cache/snapshot/mutable override/optional import/canonical root import 추가 없음

## 검증

- focused:
  - canonical/wiring/4 AiO binder/root-package/ledger/analyzer 94 tests passed
- official full:
  - `tools/check_custom_node.ps1 -Project <absolute PR worktree> -Profile full`
  - Python 961 tests passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline, G-03 import boundary 6 groups, diff check passed
  - Ruff 113 existing findings, report-only
- `comfy node validate`: passed
- actual `comfy node pack`: 218 entries
  - Python 86/86, analyzer `shipped_python_modules`와 exact match
  - `easyuse_anima/infrastructure/comfy/wiring.py` 포함

## 테스트 표면과 남은 위험

- ComfyUI v0.27.0 Codex test instance: official runner/import/module surface
- live ComfyUI smoke: 미실행
- private unsupported root retirement이므로 workflow/schema 결과 변화는 없습니다.
- 저장소 외 소비자는 확인되지 않았지만 공개 코드 검색은 비포괄적입니다.

## 롤백

두 root definition, 네 adapter import, flat fallback, ledger/analyzer 상태만
한 단위로 복원합니다.

## 다음 단계

병합 후 B-11c29d CLIP invocation을 별도 retirement 단위로 진행합니다.
