### PR TITLE
B-11c29d: retire CLIP invocation wrapper

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -841,7 +841,7 @@ Forbidden:
 
 ### B-11c29d — CLIP invocation wrapper
 
-- **State:** IN PROGRESS; precedes B-11c29b3
+- **State:** IN PROGRESS in PR #333; precedes B-11c29b3
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -974,7 +974,7 @@ COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
 COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
 COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
 COMPLETE: B-11c29c requirement helper retirement / PR #332
-IN PROGRESS: B-11c29d CLIP wrapper retirement
+IN PROGRESS: B-11c29d CLIP wrapper retirement / PR #333
 BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -756,7 +756,7 @@ Forbidden:
 
 ### B-11c29c — Required-node helpers
 
-- **State:** IN PROGRESS in PR #332; precedes B-11c29d and B-11c29b3
+- **State:** COMPLETE in PR #332 / `449d9da`; precedes B-11c29d and B-11c29b3
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -841,12 +841,85 @@ Forbidden:
 
 ### B-11c29d — CLIP invocation wrapper
 
-- **State:** BLOCKED by B-11c29b2; precedes B-11c29b3
+- **State:** IN PROGRESS; precedes B-11c29b3
 - **Owner:** #184
-- **Type:** Move/retirement
+- **Type:** Retirement
 
-Move or retire only `_encode_with_comfy_clip`. Preserve class lookup timing,
-constructor call, method lookup, result shape validation, and error text.
+Pre-edit inventory at `dev@449d9da6e9f1d296a154a3cb20d9147dfc492467`:
+
+- root `nodes.py` owns one `_encode_with_comfy_clip(clip, text: str)`
+  definition and imports `_adapter_encode_with_comfy_clip` in relative and flat
+  modes;
+- the canonical pure helper is
+  `easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip` and
+  accepts only the injected node finder in addition to `clip` and `text`;
+- six call-time production binder modules own 28 call sites:
+  `easyuse_anima.aio.conditioning`, `aio.legacy_generation`,
+  `nodes.prompt_data_nodes`, `nodes.regional_nodes`, `nodes.sam3_nodes`, and
+  `prompt.artist_mix`;
+- installed runtime already injects only
+  `ComfyHostProvider.find_node_class`; the provider does not own CLIP
+  construction, invocation, validation, or error policy;
+- the repository has no root/canonical monkeypatch consumer and no confirmed
+  external consumer. Focused tests replace this seam through the E-07 layered
+  fake provider; one legacy direct root invocation assertion is redundant with
+  canonical and flat-wiring coverage and must retire with the root symbol;
+- root/canonical helpers have no mutable state or import-time calls. The six
+  consumers keep binder-owned runtime resolver state, but resolve and invoke
+  the helper only at feature use time;
+- exact order is node lookup for `CLIPTextEncode`, class construction,
+  `encode` attribute read, `encode(clip, text)`, non-empty tuple validation,
+  then `result[0]`;
+- missing class, missing method, and invalid result each use the existing exact
+  `RuntimeError`; lookup, constructor, attribute, and encode exceptions remain
+  uncaught; and
+- the ledger classifies the seam as `pure_helper_with_provider_input`,
+  `unsupported_test_only`, with no call-time root replacement requirement.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/infrastructure/comfy/wiring.py
+```
+
+Allowed test, fixture, and documentation files:
+
+```text
+tests/test_comfy_adapters.py
+tests/test_comfy_host_wiring.py
+tests/test_node_contracts.py
+tests/test_python_compatibility_surface.py
+tests/test_nodes_module_analyzer.py
+tests/fixtures/comfy_host_compatibility.v1.json
+tests/fixtures/python_compatibility_surface.v1.json
+tests/fixtures/python_backend_baseline.json
+docs/architecture/*
+```
+
+Exit:
+
+- root definition and both adapter imports are absent;
+- installed-runtime consumers keep the provider-injected canonical helper;
+- flat pre-bootstrap calls inject a fresh default provider lookup at call time;
+- lookup/constructor/method/call/result order, success identity, exact errors,
+  and raw exception propagation remain unchanged;
+- root general lookup remains available for B-11c29b3;
+- retirement gates reject restored root or adapter bindings; and
+- root residual/analyzer/package closure gates pass.
+
+Forbidden:
+
+- changing the canonical invocation helper or provider
+  interface/implementation;
+- changing the six production consumers, binders, schemas, workflows, or
+  feature-selection timing;
+- moving the general node lookup;
+- changing lookup/construction/call order, return identity, result validation,
+  exception type/text/timing, or raw exception propagation;
+- adding cache, snapshot, mutable override state, optional imports, or
+  canonical root imports; and
+- changing seed, stage, route, persistence, or postprocess behavior.
 
 ### B-11c30 — Runtime binder/resolver migration audit
 
@@ -900,8 +973,8 @@ COMPLETE: E-07b wiring and compatibility gate / PR #328
 COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
 COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
 COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
-IN PROGRESS: B-11c29c requirement helper retirement / PR #332
-BLOCKED:  B-11c29d CLIP wrapper retirement
+COMPLETE: B-11c29c requirement helper retirement / PR #332
+IN PROGRESS: B-11c29d CLIP wrapper retirement
 BLOCKED:  B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29b2 / PR #331; B-11c29c requirement helper retirement in PR #332 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29c / PR #332; B-11c29d CLIP invocation retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -94,8 +94,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c29b1 retires only the unsupported direct mapping node lookup in PR #330;
   loaded, requirement, CLIP, and general lookup retirements remain separate.
   B-11c29b2 retired only the unsupported loaded-node root lookup in PR #331.
-  B-11c29c next retires the two pure requirement root helpers together while
-  the general root lookup remains for the CLIP wrapper.
+  B-11c29c retired the two pure requirement root helpers together in PR #332.
+  B-11c29d next retires the pure CLIP invocation root helper while the general
+  root lookup remains for its final B-11c29b3 unit.
 
 ### Current quality baseline
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29c / PR #332; B-11c29d CLIP invocation retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29c / PR #332; B-11c29d CLIP invocation retirement in PR #333 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -338,7 +338,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29c requirement helper retirement PR #332; next B-11c29d CLIP invocation | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29d CLIP invocation retirement PR #333; next B-11c29b3 general lookup | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,10 +8,9 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c29b2 are integrated. B-11c is split into
+- Current state: B-11a through B-11c29c are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c29c retires the two pure required-node root helpers in PR
-  #332.
+  root shim; B-11c29d retires the pure CLIP invocation root helper in PR #333.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 297 in B-11c29c
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 296 in B-11c29d
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -85,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 3 functions, 0 classes, and 26 assigned
-  globals in B-11c29c (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 2 functions, 0 classes, and 26 assigned
+  globals in B-11c29d (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 286, including
+- root names reached by those canonical runtime resolvers: 285, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -103,9 +102,9 @@ inferring public support from spelling or test imports:
   the five B-10b15 conditioning aliases, the 12 B-10b16 Prompt Advanced aliases,
   the 12 B-10b17 Regional aliases, the 11 B-10b18 Artist Mix parsing/config
   aliases, the 21 B-10b19 Artist Mix mode/key/tag-position aliases, and the 21
-  B-10b20 Artist Mix conditioning/tensor aliases, plus the B-11c29a-c
+  B-10b20 Artist Mix conditioning/tensor aliases, plus the B-11c29a-d
   `_comfy_max_resolution`, direct mapping, loaded lookup, and two requirement
-  root helpers; their production
+  root helpers and the CLIP invocation helper; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.
@@ -652,6 +651,23 @@ convenience-node compatibility; it remains unmapped and is not public support.
   optional dependency behavior remain unchanged.
 - The provider interface and canonical capability helpers are unchanged. CLIP
   invocation retires next, before the general root lookup.
+
+### B-11c29d CLIP invocation retirement
+
+- `_encode_with_comfy_clip` is an unsupported/test-only pure root seam with six
+  provider-wired production modules, no repository replacement, and no
+  confirmed external consumer.
+- PR #333 removes the root definition and both relative/flat adapter imports.
+  The redundant direct root invocation assertion retires; canonical and flat
+  wiring tests retain the behavior evidence.
+- Installed-runtime consumers keep the canonical invocation helper with
+  `ComfyHostProvider.find_node_class` injected. Flat pre-bootstrap calls use a
+  fresh default provider lookup at call time.
+- `CLIPTextEncode` lookup, construction, method resolution, invocation, tuple
+  validation, first-result identity, exact errors, and raw exception
+  propagation remain unchanged.
+- The provider interface, canonical invocation helper, and six production
+  consumers are unchanged. General lookup retires next as B-11c29b3.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -53,6 +53,14 @@ def _default_require_any_custom_node_class(
     )
 
 
+def _default_encode_with_comfy_clip(clip, text: str):
+    return _encode_with_comfy_clip(
+        clip,
+        text,
+        find_node_class=DefaultComfyHostProvider().find_node_class,
+    )
+
+
 def resolve_comfy_host_helper(
     name: str,
     fallback: Callable[[str], Any],
@@ -86,6 +94,8 @@ def resolve_comfy_host_helper(
             return _default_require_custom_node_class
         if name == "_require_any_custom_node_class":
             return _default_require_any_custom_node_class
+        if name == "_encode_with_comfy_clip":
+            return _default_encode_with_comfy_clip
         return fallback(name)
 
     if name == "_comfy_max_resolution":

--- a/nodes.py
+++ b/nodes.py
@@ -417,7 +417,6 @@ try:
     from .easyuse_anima.infrastructure.comfy.invocation import (
         _call_with_supported_kwargs as _call_with_supported_kwargs,
         _common_upscale_image as _common_upscale_image,
-        _encode_with_comfy_clip as _adapter_encode_with_comfy_clip,
         _node_output_tuple as _node_output_tuple,
     )
     from .easyuse_anima.infrastructure.comfy.wiring import (
@@ -977,7 +976,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.infrastructure.comfy.invocation import (
         _call_with_supported_kwargs as _call_with_supported_kwargs,
         _common_upscale_image as _common_upscale_image,
-        _encode_with_comfy_clip as _adapter_encode_with_comfy_clip,
         _node_output_tuple as _node_output_tuple,
     )
     from easyuse_anima.infrastructure.comfy.wiring import (
@@ -1627,10 +1625,6 @@ def _find_comfy_node_class(node_id: str):
     except Exception:
         comfy_nodes = None
     return _adapter_find_comfy_node_class(node_id, comfy_nodes)
-
-
-def _encode_with_comfy_clip(clip, text: str):
-    return _adapter_encode_with_comfy_clip(clip, text, _find_comfy_node_class)
 
 
 def _consume_reserved_wildcard_next_seed(

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -95,31 +95,10 @@
     },
     {
       "symbol": "_encode_with_comfy_clip",
-      "root_signature": {
-        "parameters": [
-          {
-            "name": "clip",
-            "kind": "positional_or_keyword",
-            "annotation": null,
-            "default": null
-          },
-          {
-            "name": "text",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          }
-        ],
-        "return": null
-      },
-      "adapter_binding": {
-        "alias": "_adapter_encode_with_comfy_clip",
-        "target": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip"
-      },
-      "root_dependencies": [
-        "_adapter_encode_with_comfy_clip",
-        "_find_comfy_node_class"
-      ],
+      "root_signature": null,
+      "adapter_binding": null,
+      "retired_adapter_alias": "_adapter_encode_with_comfy_clip",
+      "root_dependencies": [],
       "canonical_target": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
       "production_consumers": [
         {
@@ -180,7 +159,7 @@
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
       "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
-      "root_removal_gate": "E-07b injected provider lookup parity and repository root-patch migration, then #184 B-11c29d",
+      "root_removal_gate": "completed in #184 B-11c29d / PR #333",
       "owner_issue": "#323",
       "move_owner": "#184 B-11c29d"
     },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -22133,37 +22133,6 @@
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
       },
       {
-        "alias": "_adapter_encode_with_comfy_clip",
-        "bound_name": "_adapter_encode_with_comfy_clip",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_encode_with_comfy_clip",
-          "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
-        "kind": "static_from",
-        "line": 417,
-        "name": "_encode_with_comfy_clip",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.invocation",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
-      },
-      {
         "alias": "_node_output_tuple",
         "bound_name": "_node_output_tuple",
         "branch_context": [
@@ -22216,7 +22185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 423,
+        "line": 422,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22247,7 +22216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 426,
+        "line": 425,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22278,7 +22247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 425,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22309,7 +22278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 425,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22340,7 +22309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 425,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22371,7 +22340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 426,
+        "line": 425,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22402,7 +22371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 434,
+        "line": 433,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22433,7 +22402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 434,
+        "line": 433,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22464,7 +22433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 438,
+        "line": 437,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22495,7 +22464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 442,
+        "line": 441,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22526,7 +22495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 442,
+        "line": 441,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22557,7 +22526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 442,
+        "line": 441,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22588,7 +22557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 447,
+        "line": 446,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22619,7 +22588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 447,
+        "line": 446,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22650,7 +22619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 447,
+        "line": 446,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22681,7 +22650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 447,
+        "line": 446,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22712,7 +22681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 447,
+        "line": 446,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22743,7 +22712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 454,
+        "line": 453,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22774,7 +22743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 454,
+        "line": 453,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22805,7 +22774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 454,
+        "line": 453,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22836,7 +22805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 459,
+        "line": 458,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22867,7 +22836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 459,
+        "line": 458,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22898,7 +22867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 459,
+        "line": 458,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22929,7 +22898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22960,7 +22929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22991,7 +22960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23022,7 +22991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23053,7 +23022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 477,
+        "line": 476,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23084,7 +23053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 500,
+        "line": 499,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23115,7 +23084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 500,
+        "line": 499,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23146,7 +23115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 504,
+        "line": 503,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23177,7 +23146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 504,
+        "line": 503,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23208,7 +23177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23239,7 +23208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23270,7 +23239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23301,7 +23270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23332,7 +23301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23363,7 +23332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23394,7 +23363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23425,7 +23394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23456,7 +23425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23487,7 +23456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23518,7 +23487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23549,7 +23518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23580,7 +23549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23611,7 +23580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23642,7 +23611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 509,
+        "line": 508,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23673,7 +23642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23704,7 +23673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23735,7 +23704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23766,7 +23735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23797,7 +23766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23828,7 +23797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23859,7 +23828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23890,7 +23859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 526,
+        "line": 525,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23921,7 +23890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 536,
+        "line": 535,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23952,7 +23921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 536,
+        "line": 535,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23983,7 +23952,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 540,
+        "line": 539,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24014,7 +23983,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 540,
+        "line": 539,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24045,7 +24014,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 541,
+        "line": 540,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24076,7 +24045,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 542,
+        "line": 541,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24107,7 +24076,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 541,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24138,7 +24107,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 542,
+        "line": 541,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24169,7 +24138,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24200,7 +24169,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24231,7 +24200,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24262,7 +24231,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24293,7 +24262,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24324,7 +24293,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24355,7 +24324,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24386,7 +24355,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24417,7 +24386,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24448,7 +24417,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24479,7 +24448,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24510,7 +24479,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24541,7 +24510,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24572,7 +24541,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24603,7 +24572,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24634,7 +24603,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24665,7 +24634,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24696,7 +24665,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24727,7 +24696,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24758,7 +24727,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24789,7 +24758,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 548,
+        "line": 547,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24808,7 +24777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -24823,7 +24792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24842,7 +24811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -24857,7 +24826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24876,7 +24845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -24891,7 +24860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24910,7 +24879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -24925,7 +24894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24944,7 +24913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -24959,7 +24928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24978,7 +24947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -24993,7 +24962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25012,7 +24981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25027,7 +24996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25046,7 +25015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25061,7 +25030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25080,7 +25049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25095,7 +25064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25114,7 +25083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25129,7 +25098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25148,7 +25117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25163,7 +25132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25182,7 +25151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25197,7 +25166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25216,7 +25185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25231,7 +25200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25250,7 +25219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25265,7 +25234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25284,7 +25253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25299,7 +25268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25318,7 +25287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25333,7 +25302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25352,7 +25321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25367,7 +25336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25386,7 +25355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25401,7 +25370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25420,7 +25389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25435,7 +25404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25454,7 +25423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25469,7 +25438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25488,7 +25457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25503,7 +25472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25522,7 +25491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25537,7 +25506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25556,7 +25525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25571,7 +25540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25590,7 +25559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25605,7 +25574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25624,7 +25593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25639,7 +25608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25658,7 +25627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25673,7 +25642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25692,7 +25661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25707,7 +25676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25726,7 +25695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25741,7 +25710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25760,7 +25729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25775,7 +25744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25794,7 +25763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25809,7 +25778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25828,7 +25797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25843,7 +25812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25862,7 +25831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25877,7 +25846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25896,7 +25865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25911,7 +25880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 609,
+        "line": 608,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25930,7 +25899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25945,7 +25914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25964,7 +25933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -25979,7 +25948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25998,7 +25967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26013,7 +25982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26032,7 +26001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26047,7 +26016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26066,7 +26035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26081,7 +26050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26100,7 +26069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26115,7 +26084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26134,7 +26103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26149,7 +26118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26168,7 +26137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26183,7 +26152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26202,7 +26171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26217,7 +26186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26236,7 +26205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26251,7 +26220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26270,7 +26239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26285,7 +26254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26304,7 +26273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26319,7 +26288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26338,7 +26307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26353,7 +26322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26372,7 +26341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26387,7 +26356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26406,7 +26375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26421,7 +26390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26440,7 +26409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26455,7 +26424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26474,7 +26443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26489,7 +26458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26508,7 +26477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26523,7 +26492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26542,7 +26511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26557,7 +26526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26576,7 +26545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26591,7 +26560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26610,7 +26579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26625,7 +26594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26644,7 +26613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26659,7 +26628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26678,7 +26647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26693,7 +26662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26712,7 +26681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26727,7 +26696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26746,7 +26715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26761,7 +26730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26780,7 +26749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26795,7 +26764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26814,7 +26783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26829,7 +26798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26848,7 +26817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26863,7 +26832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26882,7 +26851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26897,7 +26866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26916,7 +26885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26931,7 +26900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26950,7 +26919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26965,7 +26934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26984,7 +26953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -26999,7 +26968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27018,7 +26987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27033,7 +27002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27052,7 +27021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27067,7 +27036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27086,7 +27055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27101,7 +27070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27120,7 +27089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27135,7 +27104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27154,7 +27123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27169,7 +27138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27188,7 +27157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27203,7 +27172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27222,7 +27191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27237,7 +27206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27256,7 +27225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27271,7 +27240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27290,7 +27259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27305,7 +27274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27324,7 +27293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27339,7 +27308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27358,7 +27327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27373,7 +27342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27392,7 +27361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27407,7 +27376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27426,7 +27395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27441,7 +27410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27460,7 +27429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27475,7 +27444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27494,7 +27463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27509,7 +27478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27528,7 +27497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27543,7 +27512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27562,7 +27531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27577,7 +27546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27596,7 +27565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27611,7 +27580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27630,7 +27599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27645,7 +27614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27664,7 +27633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27679,7 +27648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27698,7 +27667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27713,7 +27682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27732,7 +27701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27747,7 +27716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27766,7 +27735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27781,7 +27750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27800,7 +27769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27815,7 +27784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27834,7 +27803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27849,7 +27818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27868,7 +27837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27883,7 +27852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27902,7 +27871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27917,7 +27886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27936,7 +27905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27951,7 +27920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27970,7 +27939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -27985,7 +27954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28004,7 +27973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28019,7 +27988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28038,7 +28007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28053,7 +28022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28072,7 +28041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28087,7 +28056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28106,7 +28075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28121,7 +28090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28140,7 +28109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28155,7 +28124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28174,7 +28143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28189,7 +28158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28208,7 +28177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28223,7 +28192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28242,7 +28211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28257,7 +28226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28276,7 +28245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28291,7 +28260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28310,7 +28279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28325,7 +28294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28344,7 +28313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28359,7 +28328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28378,7 +28347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28393,7 +28362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28412,7 +28381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28427,7 +28396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28446,7 +28415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28461,7 +28430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28480,7 +28449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28495,7 +28464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28514,7 +28483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28529,7 +28498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28548,7 +28517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28563,7 +28532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28582,7 +28551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28597,7 +28566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28616,7 +28585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28631,7 +28600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28650,7 +28619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28665,7 +28634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28684,7 +28653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28699,7 +28668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28718,7 +28687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28733,7 +28702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28752,7 +28721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28767,7 +28736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28786,7 +28755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28801,7 +28770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28820,7 +28789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28835,7 +28804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28854,7 +28823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28869,7 +28838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28888,7 +28857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28903,7 +28872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28922,7 +28891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28937,7 +28906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28956,7 +28925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -28971,7 +28940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28990,7 +28959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29005,7 +28974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29024,7 +28993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29039,7 +29008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29058,7 +29027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29073,7 +29042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29092,7 +29061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29107,7 +29076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29126,7 +29095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29141,7 +29110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29160,7 +29129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29175,7 +29144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29194,7 +29163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29209,7 +29178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29228,7 +29197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29243,7 +29212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29262,7 +29231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29277,7 +29246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29296,7 +29265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29311,7 +29280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29330,7 +29299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29345,7 +29314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29364,7 +29333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29379,7 +29348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29398,7 +29367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29413,7 +29382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29432,7 +29401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29447,7 +29416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29466,7 +29435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29481,7 +29450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29500,7 +29469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29515,7 +29484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29534,7 +29503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29549,7 +29518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29568,7 +29537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29583,7 +29552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29602,7 +29571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29617,7 +29586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29636,7 +29605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29651,7 +29620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29670,7 +29639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29685,7 +29654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29704,7 +29673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29719,7 +29688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29738,7 +29707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29753,7 +29722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29772,7 +29741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29787,7 +29756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29806,7 +29775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29821,7 +29790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29840,7 +29809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29855,7 +29824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29874,7 +29843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29889,7 +29858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29908,7 +29877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29923,7 +29892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29942,7 +29911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29957,7 +29926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29976,7 +29945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -29991,7 +29960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30010,7 +29979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30025,7 +29994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30044,7 +30013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30059,7 +30028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30078,7 +30047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30093,7 +30062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30112,7 +30081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30127,7 +30096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30146,7 +30115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30161,7 +30130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30180,7 +30149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30195,7 +30164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30214,7 +30183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30229,7 +30198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30248,7 +30217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30263,7 +30232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30282,7 +30251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30297,7 +30266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30316,7 +30285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30331,7 +30300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30350,7 +30319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30365,7 +30334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30384,7 +30353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30399,7 +30368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30418,7 +30387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30433,7 +30402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30452,7 +30421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30467,7 +30436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30486,7 +30455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30501,7 +30470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30520,7 +30489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30535,7 +30504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30554,7 +30523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30569,7 +30538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30588,7 +30557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30603,7 +30572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30622,7 +30591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30637,7 +30606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30656,7 +30625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30671,7 +30640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30690,7 +30659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30705,7 +30674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30724,7 +30693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30739,7 +30708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30758,7 +30727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30773,7 +30742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30792,7 +30761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30807,7 +30776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30826,7 +30795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30841,7 +30810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30860,7 +30829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30875,7 +30844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30894,7 +30863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30909,7 +30878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30928,7 +30897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30943,7 +30912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30962,7 +30931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -30977,7 +30946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30996,7 +30965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31011,7 +30980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31030,7 +30999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31045,7 +31014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31064,7 +31033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31079,7 +31048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31098,7 +31067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31113,7 +31082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31132,7 +31101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31147,7 +31116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31166,7 +31135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31181,7 +31150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31200,7 +31169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31215,7 +31184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31234,7 +31203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31249,7 +31218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31268,7 +31237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31283,7 +31252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31302,7 +31271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31317,7 +31286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31336,7 +31305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31351,7 +31320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31370,7 +31339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31385,7 +31354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31404,7 +31373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31419,7 +31388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31438,7 +31407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31453,7 +31422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31472,7 +31441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31487,7 +31456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31506,7 +31475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31521,7 +31490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31540,7 +31509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31555,7 +31524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31574,7 +31543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31589,7 +31558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31608,7 +31577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31623,7 +31592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31642,7 +31611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31657,7 +31626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31676,7 +31645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31691,7 +31660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31710,7 +31679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31725,7 +31694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31744,7 +31713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31759,7 +31728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31778,7 +31747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31793,7 +31762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31812,7 +31781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31827,7 +31796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31846,7 +31815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31861,7 +31830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31880,7 +31849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31895,7 +31864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31914,7 +31883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31929,7 +31898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31948,7 +31917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31963,7 +31932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 918,
+        "line": 917,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31982,7 +31951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -31997,7 +31966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 918,
+        "line": 917,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32016,7 +31985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32031,7 +32000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 918,
+        "line": 917,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32050,7 +32019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32065,7 +32034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 923,
+        "line": 922,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32084,7 +32053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32099,7 +32068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 923,
+        "line": 922,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32118,7 +32087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32133,7 +32102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 922,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32152,7 +32121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32167,7 +32136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32186,7 +32155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32201,7 +32170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32220,7 +32189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32235,7 +32204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32254,7 +32223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32269,7 +32238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32288,7 +32257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32303,7 +32272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32322,7 +32291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32337,7 +32306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32356,7 +32325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32371,7 +32340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32390,7 +32359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32405,7 +32374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32424,7 +32393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32439,7 +32408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32458,7 +32427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32473,7 +32442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32492,7 +32461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32507,7 +32476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32526,7 +32495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32541,7 +32510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32560,7 +32529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32575,7 +32544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32594,7 +32563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32609,7 +32578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32628,7 +32597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32643,7 +32612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 962,
+        "line": 961,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32662,7 +32631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32677,7 +32646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 962,
+        "line": 961,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32696,7 +32665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32711,7 +32680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32730,7 +32699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32745,7 +32714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32764,7 +32733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32779,7 +32748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32798,7 +32767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32813,7 +32782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32832,7 +32801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32847,7 +32816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 977,
+        "line": 976,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32866,7 +32835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32881,42 +32850,8 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 977,
+        "line": 976,
         "name": "_common_upscale_image",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.invocation",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
-      },
-      {
-        "alias": "_adapter_encode_with_comfy_clip",
-        "bound_name": "_adapter_encode_with_comfy_clip",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 569,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_encode_with_comfy_clip",
-          "target": "easyuse_anima/infrastructure/comfy/invocation.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
-        "kind": "static_from",
-        "line": 977,
-        "name": "_encode_with_comfy_clip",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
         "role": "compatibility_fallback",
@@ -32934,7 +32869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32949,7 +32884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 977,
+        "line": 976,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32968,7 +32903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -32983,7 +32918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -33002,7 +32937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33017,7 +32952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33036,7 +32971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33051,7 +32986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33070,7 +33005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33085,7 +33020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33104,7 +33039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33119,7 +33054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33138,7 +33073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33153,7 +33088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33172,7 +33107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33187,7 +33122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33206,7 +33141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33221,7 +33156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33240,7 +33175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33255,7 +33190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 996,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33274,7 +33209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33289,7 +33224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33308,7 +33243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33323,7 +33258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33342,7 +33277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33357,7 +33292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33376,7 +33311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33391,7 +33326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33410,7 +33345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33425,7 +33360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33444,7 +33379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33459,7 +33394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33478,7 +33413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33493,7 +33428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33512,7 +33447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33527,7 +33462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33546,7 +33481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33561,7 +33496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1012,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33580,7 +33515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33595,7 +33530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1012,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33614,7 +33549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33629,7 +33564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1012,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33648,7 +33583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33663,7 +33598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1017,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33682,7 +33617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33697,7 +33632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1017,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33716,7 +33651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33731,7 +33666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1017,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33750,7 +33685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33765,7 +33700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33784,7 +33719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33799,7 +33734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33818,7 +33753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33833,7 +33768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33852,7 +33787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33867,7 +33802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33886,7 +33821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33901,7 +33836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33920,7 +33855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33935,7 +33870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1058,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33954,7 +33889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -33969,7 +33904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1058,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33988,7 +33923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34003,7 +33938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1062,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34022,7 +33957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34037,7 +33972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1062,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34056,7 +33991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34071,7 +34006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34090,7 +34025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34105,7 +34040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34124,7 +34059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34139,7 +34074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34158,7 +34093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34173,7 +34108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34192,7 +34127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34207,7 +34142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34226,7 +34161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34241,7 +34176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34260,7 +34195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34275,7 +34210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34294,7 +34229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34309,7 +34244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34328,7 +34263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34343,7 +34278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34362,7 +34297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34377,7 +34312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34396,7 +34331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34411,7 +34346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34430,7 +34365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34445,7 +34380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34464,7 +34399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34479,7 +34414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34498,7 +34433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34513,7 +34448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34532,7 +34467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34547,7 +34482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34566,7 +34501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34581,7 +34516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34600,7 +34535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34615,7 +34550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34634,7 +34569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34649,7 +34584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34668,7 +34603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34683,7 +34618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34702,7 +34637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34717,7 +34652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34736,7 +34671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34751,7 +34686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34770,7 +34705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34785,7 +34720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34804,7 +34739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34819,7 +34754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34838,7 +34773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34853,7 +34788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1094,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34872,7 +34807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34887,7 +34822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1094,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34906,7 +34841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34921,7 +34856,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34940,7 +34875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34955,7 +34890,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34974,7 +34909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -34989,7 +34924,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1099,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -35008,7 +34943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35023,7 +34958,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -35042,7 +34977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35057,7 +34992,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35076,7 +35011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35091,7 +35026,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35110,7 +35045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35125,7 +35060,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1105,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35144,7 +35079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35159,7 +35094,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1105,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35178,7 +35113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35193,7 +35128,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35212,7 +35147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35227,7 +35162,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35246,7 +35181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35261,7 +35196,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35280,7 +35215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35295,7 +35230,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35314,7 +35249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35329,7 +35264,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35348,7 +35283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35363,7 +35298,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35382,7 +35317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35397,7 +35332,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35416,7 +35351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35431,7 +35366,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35450,7 +35385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35465,7 +35400,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35484,7 +35419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35499,7 +35434,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35518,7 +35453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35533,7 +35468,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35552,7 +35487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35567,7 +35502,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35586,7 +35521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35601,7 +35536,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35620,7 +35555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35635,7 +35570,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35654,7 +35589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35669,7 +35604,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35688,7 +35623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35703,7 +35638,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35722,7 +35657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35737,7 +35672,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35756,7 +35691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35771,7 +35706,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35790,7 +35725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -35805,7 +35740,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35823,7 +35758,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1625
+            "line": 1623
           }
         ],
         "classification": "external",
@@ -35831,7 +35766,7 @@
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1626,
+        "line": 1624,
         "name": null,
         "optional": true,
         "requested": "nodes",
@@ -39145,13 +39080,13 @@
       },
       {
         "is_package": false,
-        "loc": 115,
+        "loc": 125,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
-        "normalized_git_blob_sha1": "195c174dde130a0ef90c37f6d35d8ec49f523c08",
+        "normalized_git_blob_sha1": "cb1ca27943e3938a8dfdd001e55741a0826ebae7",
         "path": "easyuse_anima/infrastructure/comfy/wiring.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 6,
+          "function_count": 7,
           "global_count": 1
         }
       },
@@ -39553,13 +39488,13 @@
       },
       {
         "is_package": false,
-        "loc": 1866,
+        "loc": 1860,
         "module": "nodes",
-        "normalized_git_blob_sha1": "c25e302b3082a6fcefb4af799508ddc489e53d3d",
+        "normalized_git_blob_sha1": "01eb4cea34d49871d438182bb214f53f755d78d9",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 3,
+          "function_count": 2,
           "global_count": 26
         }
       },
@@ -40919,7 +40854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -40928,7 +40863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40942,7 +40877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -40951,7 +40886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40965,7 +40900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -40974,7 +40909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40988,7 +40923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -40997,7 +40932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41011,7 +40946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41020,7 +40955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41034,7 +40969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41043,7 +40978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41057,7 +40992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41066,7 +41001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41080,7 +41015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41089,7 +41024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 570,
+        "line": 569,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41103,7 +41038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41112,7 +41047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41126,7 +41061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41135,7 +41070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41149,7 +41084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41158,7 +41093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41172,7 +41107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41181,7 +41116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41195,7 +41130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41204,7 +41139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41218,7 +41153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41227,7 +41162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41241,7 +41176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41250,7 +41185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41264,7 +41199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41273,7 +41208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 581,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41287,7 +41222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41296,7 +41231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41310,7 +41245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41319,7 +41254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41333,7 +41268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41342,7 +41277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41356,7 +41291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41365,7 +41300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41379,7 +41314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41388,7 +41323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41402,7 +41337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41411,7 +41346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41425,7 +41360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41434,7 +41369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41448,7 +41383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41457,7 +41392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41471,7 +41406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41480,7 +41415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41494,7 +41429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41503,7 +41438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41517,7 +41452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41526,7 +41461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41540,7 +41475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41549,7 +41484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41563,7 +41498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41572,7 +41507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41586,7 +41521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41595,7 +41530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41609,7 +41544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41618,7 +41553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41632,7 +41567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41641,7 +41576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 591,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41655,7 +41590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41664,7 +41599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 609,
+        "line": 608,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41678,7 +41613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41687,7 +41622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41701,7 +41636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41710,7 +41645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41724,7 +41659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41733,7 +41668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 612,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41747,7 +41682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41756,7 +41691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41770,7 +41705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41779,7 +41714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41793,7 +41728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41802,7 +41737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41816,7 +41751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41825,7 +41760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41839,7 +41774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41848,7 +41783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 617,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41862,7 +41797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41871,7 +41806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41885,7 +41820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41894,7 +41829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41908,7 +41843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41917,7 +41852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41931,7 +41866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41940,7 +41875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 624,
+        "line": 623,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41954,7 +41889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41963,7 +41898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41977,7 +41912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -41986,7 +41921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42000,7 +41935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42009,7 +41944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42023,7 +41958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42032,7 +41967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42046,7 +41981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42055,7 +41990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42069,7 +42004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42078,7 +42013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42092,7 +42027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42101,7 +42036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42115,7 +42050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42124,7 +42059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42138,7 +42073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42147,7 +42082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42161,7 +42096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42170,7 +42105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42184,7 +42119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42193,7 +42128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42207,7 +42142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42216,7 +42151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42230,7 +42165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42239,7 +42174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 630,
+        "line": 629,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42253,7 +42188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42262,7 +42197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42276,7 +42211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42285,7 +42220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42299,7 +42234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42308,7 +42243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42322,7 +42257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42331,7 +42266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42345,7 +42280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42354,7 +42289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42368,7 +42303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42377,7 +42312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42391,7 +42326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42400,7 +42335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42414,7 +42349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42423,7 +42358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42437,7 +42372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42446,7 +42381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42460,7 +42395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42469,7 +42404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42483,7 +42418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42492,7 +42427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42506,7 +42441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42515,7 +42450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 645,
+        "line": 644,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42529,7 +42464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42538,7 +42473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42552,7 +42487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42561,7 +42496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42575,7 +42510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42584,7 +42519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42598,7 +42533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42607,7 +42542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42621,7 +42556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42630,7 +42565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42644,7 +42579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42653,7 +42588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42667,7 +42602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42676,7 +42611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42690,7 +42625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42699,7 +42634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42713,7 +42648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42722,7 +42657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42736,7 +42671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42745,7 +42680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 659,
+        "line": 658,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42759,7 +42694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42768,7 +42703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42782,7 +42717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42791,7 +42726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42805,7 +42740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42814,7 +42749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42828,7 +42763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42837,7 +42772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42851,7 +42786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42860,7 +42795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42874,7 +42809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42883,7 +42818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42897,7 +42832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42906,7 +42841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42920,7 +42855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42929,7 +42864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42943,7 +42878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42952,7 +42887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42966,7 +42901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42975,7 +42910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 671,
+        "line": 670,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42989,7 +42924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -42998,7 +42933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43012,7 +42947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43021,7 +42956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43035,7 +42970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43044,7 +42979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43058,7 +42993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43067,7 +43002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43081,7 +43016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43090,7 +43025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43104,7 +43039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43113,7 +43048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43127,7 +43062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43136,7 +43071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43150,7 +43085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43159,7 +43094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43173,7 +43108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43182,7 +43117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43196,7 +43131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43205,7 +43140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43219,7 +43154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43228,7 +43163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43242,7 +43177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43251,7 +43186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43265,7 +43200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43274,7 +43209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43288,7 +43223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43297,7 +43232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43311,7 +43246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43320,7 +43255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43334,7 +43269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43343,7 +43278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 683,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43357,7 +43292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43366,7 +43301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43380,7 +43315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43389,7 +43324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43403,7 +43338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43412,7 +43347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 701,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43426,7 +43361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43435,7 +43370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43449,7 +43384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43458,7 +43393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43472,7 +43407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43481,7 +43416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43495,7 +43430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43504,7 +43439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43518,7 +43453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43527,7 +43462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 706,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43541,7 +43476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43550,7 +43485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43564,7 +43499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43573,7 +43508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43587,7 +43522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43596,7 +43531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43610,7 +43545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43619,7 +43554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43633,7 +43568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43642,7 +43577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 714,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43656,7 +43591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43665,7 +43600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43679,7 +43614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43688,7 +43623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43702,7 +43637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43711,7 +43646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43725,7 +43660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43734,7 +43669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43748,7 +43683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43757,7 +43692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43771,7 +43706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43780,7 +43715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43794,7 +43729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43803,7 +43738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43817,7 +43752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43826,7 +43761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43840,7 +43775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43849,7 +43784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43863,7 +43798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43872,7 +43807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 720,
+        "line": 719,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43886,7 +43821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43895,7 +43830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43909,7 +43844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43918,7 +43853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43932,7 +43867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43941,7 +43876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43955,7 +43890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43964,7 +43899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43978,7 +43913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -43987,7 +43922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44001,7 +43936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44010,7 +43945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44024,7 +43959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44033,7 +43968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 734,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44047,7 +43982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44056,7 +43991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44070,7 +44005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44079,7 +44014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44093,7 +44028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44102,7 +44037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44116,7 +44051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44125,7 +44060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44139,7 +44074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44148,7 +44083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44162,7 +44097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44171,7 +44106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44185,7 +44120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44194,7 +44129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44208,7 +44143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44217,7 +44152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44231,7 +44166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44240,7 +44175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44254,7 +44189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44263,7 +44198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44277,7 +44212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44286,7 +44221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44300,7 +44235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44309,7 +44244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44323,7 +44258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44332,7 +44267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44346,7 +44281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44355,7 +44290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44369,7 +44304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44378,7 +44313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44392,7 +44327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44401,7 +44336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44415,7 +44350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44424,7 +44359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44438,7 +44373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44447,7 +44382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44461,7 +44396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44470,7 +44405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44484,7 +44419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44493,7 +44428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44507,7 +44442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44516,7 +44451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44530,7 +44465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44539,7 +44474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 752,
+        "line": 751,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44553,7 +44488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44562,7 +44497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44576,7 +44511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44585,7 +44520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44599,7 +44534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44608,7 +44543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44622,7 +44557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44631,7 +44566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44645,7 +44580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44654,7 +44589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44668,7 +44603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44677,7 +44612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44691,7 +44626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44700,7 +44635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44714,7 +44649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44723,7 +44658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44737,7 +44672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44746,7 +44681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44760,7 +44695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44769,7 +44704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44783,7 +44718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44792,7 +44727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44806,7 +44741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44815,7 +44750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44829,7 +44764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44838,7 +44773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44852,7 +44787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44861,7 +44796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 788,
+        "line": 787,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44875,7 +44810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44884,7 +44819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44898,7 +44833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44907,7 +44842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44921,7 +44856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44930,7 +44865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44944,7 +44879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44953,7 +44888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44967,7 +44902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44976,7 +44911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44990,7 +44925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -44999,7 +44934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45013,7 +44948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45022,7 +44957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45036,7 +44971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45045,7 +44980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45059,7 +44994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45068,7 +45003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 816,
+        "line": 815,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45082,7 +45017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45091,7 +45026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45105,7 +45040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45114,7 +45049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45128,7 +45063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45137,7 +45072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45151,7 +45086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45160,7 +45095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45174,7 +45109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45183,7 +45118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45197,7 +45132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45206,7 +45141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45220,7 +45155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45229,7 +45164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45243,7 +45178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45252,7 +45187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45266,7 +45201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45275,7 +45210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45289,7 +45224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45298,7 +45233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45312,7 +45247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45321,7 +45256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45335,7 +45270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45344,7 +45279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45358,7 +45293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45367,7 +45302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45381,7 +45316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45390,7 +45325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45404,7 +45339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45413,7 +45348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45427,7 +45362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45436,7 +45371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45450,7 +45385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45459,7 +45394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45473,7 +45408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45482,7 +45417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45496,7 +45431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45505,7 +45440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45519,7 +45454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45528,7 +45463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45542,7 +45477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45551,7 +45486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45565,7 +45500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45574,7 +45509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45588,7 +45523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45597,7 +45532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45611,7 +45546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45620,7 +45555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45634,7 +45569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45643,7 +45578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 832,
+        "line": 831,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45657,7 +45592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45666,7 +45601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45680,7 +45615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45689,7 +45624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45703,7 +45638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45712,7 +45647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45726,7 +45661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45735,7 +45670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 911,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45749,7 +45684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45758,7 +45693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 918,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45772,7 +45707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45781,7 +45716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 918,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45795,7 +45730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45804,7 +45739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 918,
+        "line": 917,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45818,7 +45753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45827,7 +45762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 923,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45841,7 +45776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45850,7 +45785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 923,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45864,7 +45799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45873,7 +45808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 923,
+        "line": 922,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45887,7 +45822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45896,7 +45831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45910,7 +45845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45919,7 +45854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45933,7 +45868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45942,7 +45877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45956,7 +45891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45965,7 +45900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45979,7 +45914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -45988,7 +45923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46002,7 +45937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46011,7 +45946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46025,7 +45960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46034,7 +45969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 929,
+        "line": 928,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46048,7 +45983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46057,7 +45992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46071,7 +46006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46080,7 +46015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46094,7 +46029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46103,7 +46038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 938,
+        "line": 937,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46117,7 +46052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46126,7 +46061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46140,7 +46075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46149,7 +46084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46163,7 +46098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46172,7 +46107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46186,7 +46121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46195,7 +46130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 949,
+        "line": 948,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46209,7 +46144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46218,7 +46153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 962,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46232,7 +46167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46241,7 +46176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 962,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46255,7 +46190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46264,7 +46199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46278,7 +46213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46287,7 +46222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46301,7 +46236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46310,7 +46245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46324,7 +46259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46333,7 +46268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 970,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46347,7 +46282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46356,7 +46291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 977,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46370,7 +46305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46379,7 +46314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 977,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46393,30 +46328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip",
-        "kind": "static_from",
-        "line": 977,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/invocation.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46425,7 +46337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 977,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46439,7 +46351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46448,7 +46360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 983,
+        "line": 981,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46462,7 +46374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46471,7 +46383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46485,7 +46397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46494,7 +46406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46508,7 +46420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46517,7 +46429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46531,7 +46443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46540,7 +46452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46554,7 +46466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46563,7 +46475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 986,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46577,7 +46489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46586,7 +46498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46600,7 +46512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46609,7 +46521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 994,
+        "line": 992,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46623,7 +46535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46632,7 +46544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 996,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46646,7 +46558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46655,7 +46567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46669,7 +46581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46678,7 +46590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46692,7 +46604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46701,7 +46613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1002,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46715,7 +46627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46724,7 +46636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46738,7 +46650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46747,7 +46659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46761,7 +46673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46770,7 +46682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46784,7 +46696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46793,7 +46705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46807,7 +46719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46816,7 +46728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1007,
+        "line": 1005,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46830,7 +46742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46839,7 +46751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46853,7 +46765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46862,7 +46774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46876,7 +46788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46885,7 +46797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1014,
+        "line": 1012,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46899,7 +46811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46908,7 +46820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46922,7 +46834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46931,7 +46843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46945,7 +46857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46954,7 +46866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1019,
+        "line": 1017,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46968,7 +46880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -46977,7 +46889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46991,7 +46903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47000,7 +46912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47014,7 +46926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47023,7 +46935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47037,7 +46949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47046,7 +46958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47060,7 +46972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47069,7 +46981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1037,
+        "line": 1035,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47083,7 +46995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47092,7 +47004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47106,7 +47018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47115,7 +47027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1058,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47129,7 +47041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47138,7 +47050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47152,7 +47064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47161,7 +47073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1064,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47175,7 +47087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47184,7 +47096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47198,7 +47110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47207,7 +47119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47221,7 +47133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47230,7 +47142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47244,7 +47156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47253,7 +47165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47267,7 +47179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47276,7 +47188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47290,7 +47202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47299,7 +47211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47313,7 +47225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47322,7 +47234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47336,7 +47248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47345,7 +47257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47359,7 +47271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47368,7 +47280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47382,7 +47294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47391,7 +47303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47405,7 +47317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47414,7 +47326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47428,7 +47340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47437,7 +47349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47451,7 +47363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47460,7 +47372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47474,7 +47386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47483,7 +47395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47497,7 +47409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47506,7 +47418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1069,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47520,7 +47432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47529,7 +47441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47543,7 +47455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47552,7 +47464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47566,7 +47478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47575,7 +47487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47589,7 +47501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47598,7 +47510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47612,7 +47524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47621,7 +47533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47635,7 +47547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47644,7 +47556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47658,7 +47570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47667,7 +47579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47681,7 +47593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47690,7 +47602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47704,7 +47616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47713,7 +47625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47727,7 +47639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47736,7 +47648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1094,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47750,7 +47662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47759,7 +47671,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47773,7 +47685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47782,7 +47694,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47796,7 +47708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47805,7 +47717,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1101,
+        "line": 1099,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47819,7 +47731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47828,7 +47740,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47842,7 +47754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47851,7 +47763,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47865,7 +47777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47874,7 +47786,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1102,
+        "line": 1100,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47888,7 +47800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47897,7 +47809,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47911,7 +47823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47920,7 +47832,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1107,
+        "line": 1105,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47934,7 +47846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47943,7 +47855,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47957,7 +47869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47966,7 +47878,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47980,7 +47892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -47989,7 +47901,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48003,7 +47915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48012,7 +47924,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48026,7 +47938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48035,7 +47947,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48049,7 +47961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48058,7 +47970,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48072,7 +47984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48081,7 +47993,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48095,7 +48007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48104,7 +48016,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48118,7 +48030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48127,7 +48039,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48141,7 +48053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48150,7 +48062,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48164,7 +48076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48173,7 +48085,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48187,7 +48099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48196,7 +48108,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48210,7 +48122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48219,7 +48131,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48233,7 +48145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48242,7 +48154,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48256,7 +48168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48265,7 +48177,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48279,7 +48191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48288,7 +48200,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48302,7 +48214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48311,7 +48223,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48325,7 +48237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48334,7 +48246,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48348,7 +48260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 569,
+            "handler_line": 568,
             "kind": "try",
             "line": 9
           }
@@ -48357,7 +48269,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1108,
+        "line": 1106,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52302,14 +52214,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1625
+            "line": 1623
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1626,
+        "line": 1624,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -53703,14 +53615,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1625
+            "line": 1623
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "nodes",
         "kind": "static_import",
-        "line": 1626,
+        "line": 1624,
         "optional": true,
         "role": "optional_dependency",
         "source": "nodes.py"
@@ -55186,7 +55098,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1130,
+        "line": 1128,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55195,7 +55107,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1717,
+        "line": 1711,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55204,7 +55116,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1720,
+        "line": 1714,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55213,7 +55125,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1726,
+        "line": 1720,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55222,7 +55134,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1732,
+        "line": 1726,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55231,7 +55143,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1735,
+        "line": 1729,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55240,7 +55152,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1738,
+        "line": 1732,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55249,7 +55161,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1744,
+        "line": 1738,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55258,7 +55170,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1750,
+        "line": 1744,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55267,7 +55179,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1756,
+        "line": 1750,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55276,7 +55188,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1762,
+        "line": 1756,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55285,7 +55197,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1768,
+        "line": 1762,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55294,7 +55206,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1774,
+        "line": 1768,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55303,7 +55215,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1780,
+        "line": 1774,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55312,7 +55224,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1786,
+        "line": 1780,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55321,7 +55233,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1792,
+        "line": 1786,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55330,7 +55242,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1795,
+        "line": 1789,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55339,7 +55251,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1802,
+        "line": 1796,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55348,7 +55260,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1805,
+        "line": 1799,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55357,7 +55269,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1809,
+        "line": 1803,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55366,7 +55278,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1812,
+        "line": 1806,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55375,7 +55287,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1819,
+        "line": 1813,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55384,7 +55296,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1825,
+        "line": 1819,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55393,7 +55305,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1831,
+        "line": 1825,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55402,7 +55314,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1834,
+        "line": 1828,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55411,7 +55323,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1837,
+        "line": 1831,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55420,7 +55332,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1840,
+        "line": 1834,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55429,7 +55341,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1847,
+        "line": 1841,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55438,7 +55350,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1853,
+        "line": 1847,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55447,7 +55359,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1858,
+        "line": 1852,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55456,7 +55368,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1862,
+        "line": 1856,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55970,13 +55882,13 @@
       },
       {
         "kind": "dict",
-        "line": 1192,
+        "line": 1190,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1181,
+        "line": 1179,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -62,7 +62,8 @@
       "B-11c29a",
       "B-11c29b1",
       "B-11c29b2",
-      "B-11c29c"
+      "B-11c29c",
+      "B-11c29d"
     ]
   },
   "enums": {
@@ -97,11 +98,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 297,
+    "nodes_canonical_bindings": 296,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 3,
+    "root_residual_functions": 2,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -708,14 +709,6 @@
     "_encode_prompt_data_positive_conditioning": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.prompt_data_nodes"
-    ],
-    "_encode_with_comfy_clip": [
-      "easyuse_anima.aio.conditioning",
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.nodes.sam3_nodes",
-      "easyuse_anima.prompt.artist_mix"
     ],
     "_expand_advanced_wildcard_fields": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -2716,7 +2709,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.invocation:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_adapter_encode_with_comfy_clip": "_encode_with_comfy_clip",
         "_call_with_supported_kwargs": "_call_with_supported_kwargs",
         "_common_upscale_image": "_common_upscale_image",
         "_node_output_tuple": "_node_output_tuple"
@@ -2731,7 +2723,6 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.model_preparation",
         "canonical runtime resolver: easyuse_anima.aio.postprocess",
@@ -2739,7 +2730,6 @@
         "canonical runtime resolver: easyuse_anima.aio.sampling"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.model_preparation string runtime lookup",
         "AST:easyuse_anima.aio.postprocess string runtime lookup",
@@ -4234,7 +4224,6 @@
       "kind": "functions",
       "symbols": {
         "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
-        "_encode_with_comfy_clip": "_encode_with_comfy_clip",
         "_find_comfy_node_class": "_find_comfy_node_class"
       },
       "classification": "transitional_private_seam",

--- a/tests/test_comfy_adapters.py
+++ b/tests/test_comfy_adapters.py
@@ -263,8 +263,60 @@ class ComfyInvocationAdapterTests(unittest.TestCase):
         )
         self.assertEqual(calls, [("clip", "prompt")])
 
-        with self.assertRaisesRegex(RuntimeError, "Could not find ComfyUI CLIPTextEncode"):
+        with self.assertRaises(RuntimeError) as missing_class:
             invocation._encode_with_comfy_clip("clip", "prompt", lambda _node_id: None)
+        self.assertEqual(
+            str(missing_class.exception),
+            "[EasyUseAnima] Could not find ComfyUI CLIPTextEncode.",
+        )
+
+        class MissingEncode:
+            pass
+
+        with self.assertRaises(RuntimeError) as missing_method:
+            invocation._encode_with_comfy_clip(
+                "clip",
+                "prompt",
+                lambda _node_id: MissingEncode,
+            )
+        self.assertEqual(
+            str(missing_method.exception),
+            "[EasyUseAnima] CLIPTextEncode does not expose encode.",
+        )
+
+        for invalid_result in ((), ["conditioning"]):
+            class InvalidResult:
+                def encode(self, _clip, _text):
+                    return invalid_result
+
+            with self.subTest(invalid_result=invalid_result):
+                with self.assertRaises(RuntimeError) as invalid:
+                    invocation._encode_with_comfy_clip(
+                        "clip",
+                        "prompt",
+                        lambda _node_id: InvalidResult,
+                    )
+                self.assertEqual(
+                    str(invalid.exception),
+                    "[EasyUseAnima] CLIPTextEncode returned no conditioning.",
+                )
+
+        def failing_lookup(_node_id):
+            raise LookupError("lookup failed")
+
+        with self.assertRaisesRegex(LookupError, "lookup failed"):
+            invocation._encode_with_comfy_clip("clip", "prompt", failing_lookup)
+
+        class FailingEncode:
+            def encode(self, _clip, _text):
+                raise KeyError("encode failed")
+
+        with self.assertRaisesRegex(KeyError, "encode failed"):
+            invocation._encode_with_comfy_clip(
+                "clip",
+                "prompt",
+                lambda _node_id: FailingEncode,
+            )
 
     def test_signature_filtering_var_kwargs_and_missing_required_are_preserved(self):
         calls = []
@@ -386,18 +438,6 @@ class ComfyRootCompatibilityTests(unittest.TestCase):
                 ("text_encoders", list(nodes.ANIMA_DEFAULT_CLIP_CANDIDATES)),
             ],
         )
-
-        class ClipTextEncode:
-            def encode(self, clip, text):
-                return (f"{clip}:{text}",)
-
-        with patch.object(
-            nodes,
-            "NODE_CLASS_MAPPINGS",
-            {"CLIPTextEncode": ClipTextEncode},
-            create=True,
-        ):
-            self.assertEqual(nodes._encode_with_comfy_clip("clip", "prompt"), "clip:prompt")
 
     def test_adapter_modules_remain_below_production_module_loc_guidance(self):
         for path in (

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -184,6 +184,28 @@ class ComfyHostWiringTests(unittest.TestCase):
             with self.assertRaisesRegex(LookupError, "lookup failed"):
                 require("Custom", "Pack", "Hint")
 
+    def test_retired_clip_invocation_uses_default_provider_before_runtime_install(self):
+        comfy_nodes = types.ModuleType("nodes")
+        comfy_nodes.NODE_CLASS_MAPPINGS = {"CLIPTextEncode": ClipTextEncode}
+
+        def unexpected_fallback(name: str):
+            self.fail(f"retired helper reached root fallback: {name}")
+
+        with patch.dict(sys.modules, {"nodes": comfy_nodes}):
+            encode = resolve_comfy_host_helper(
+                "_encode_with_comfy_clip",
+                unexpected_fallback,
+            )
+
+            self.assertEqual(encode("clip", "prompt"), "clip:prompt")
+            comfy_nodes.NODE_CLASS_MAPPINGS = {}
+            with self.assertRaises(RuntimeError) as missing:
+                encode("clip", "prompt")
+            self.assertEqual(
+                str(missing.exception),
+                "[EasyUseAnima] Could not find ComfyUI CLIPTextEncode.",
+            )
+
     def test_provider_owned_helpers_delegate_to_narrow_methods(self):
         direct = object()
         mapping = object()

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2154,6 +2154,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
         self.assertFalse(hasattr(nodes, "_find_loaded_node_class"))
         self.assertFalse(hasattr(nodes, "_require_custom_node_class"))
         self.assertFalse(hasattr(nodes, "_require_any_custom_node_class"))
+        self.assertFalse(hasattr(nodes, "_encode_with_comfy_clip"))
         for canonical_module, helper_names in self.DIRECT_HELPER_MODULES:
             for helper_name in helper_names:
                 with self.subTest(module=canonical_module.__name__, helper=helper_name):
@@ -2175,6 +2176,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
             self.assertFalse(
                 hasattr(package_nodes, "_require_any_custom_node_class")
             )
+            self.assertFalse(hasattr(package_nodes, "_encode_with_comfy_clip"))
             self.assertFalse(hasattr(package_nodes, "_comfy_checkpoint_names"))
             self.assertFalse(hasattr(package_nodes, "_impact_core_module"))
             self.assertFalse(

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "c25e302b3082a6fcefb4af799508ddc489e53d3d")
-        # B-11c29c retires only the two pure requirement root helpers and
-        # their four adapter imports without changing the public class surface.
-        self.assertEqual(report["top_level"]["function_count"], 3)
+        self.assertEqual(report["git_blob_sha1"], "01eb4cea34d49871d438182bb214f53f755d78d9")
+        # B-11c29d retires only the pure CLIP invocation root helper and its
+        # two adapter imports without changing the public class surface.
+        self.assertEqual(report["top_level"]["function_count"], 2)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_866)
+        self.assertEqual(report["line_count"], 1_860)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1696,6 +1696,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c29b1",
                 "B-11c29b2",
                 "B-11c29c",
+                "B-11c29d",
             ],
         },
         "enums": {
@@ -1708,11 +1709,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 297,
+            "nodes_canonical_bindings": 296,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 3,
+            "root_residual_functions": 2,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,
@@ -2141,6 +2142,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             retired,
             {
                 "_comfy_max_resolution",
+                "_encode_with_comfy_clip",
                 "_find_comfy_node_mapping_class",
                 "_find_loaded_node_class",
                 "_require_any_custom_node_class",
@@ -2155,6 +2157,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             },
             {
                 "_comfy_max_resolution": "_adapter_comfy_max_resolution",
+                "_encode_with_comfy_clip": "_adapter_encode_with_comfy_clip",
                 "_find_comfy_node_mapping_class": None,
                 "_find_loaded_node_class": "_adapter_find_loaded_node_class",
                 "_require_any_custom_node_class": (


### PR DESCRIPTION
## 분류

- Task: B-11c29d
- Owner: #184
- Type: Retirement
- Base: `dev@449d9da6e9f1d296a154a3cb20d9147dfc492467`
- 검증 head: `cc06ca7`
- Contract/Behavior: 포함하지 않음

## 작업 전 symbol/caller/alias/global-state inventory

- symbol: root `_encode_with_comfy_clip(clip, text: str)` 1 definition
- relative/flat alias: `_adapter_encode_with_comfy_clip` 2 imports
- canonical owner:
  `easyuse_anima.infrastructure.comfy.invocation:_encode_with_comfy_clip`
- root dependency: `_find_comfy_node_class`
- production: 6 call-time binders / 28 call sites
  - `easyuse_anima.aio.conditioning`
  - `easyuse_anima.aio.legacy_generation`
  - `easyuse_anima.nodes.prompt_data_nodes`
  - `easyuse_anima.nodes.regional_nodes`
  - `easyuse_anima.nodes.sam3_nodes`
  - `easyuse_anima.prompt.artist_mix`
- exact order:
  1. injected lookup으로 `CLIPTextEncode` 해석
  2. class construction
  3. `encode` attribute read
  4. `encode(clip, text)` 호출
  5. non-empty tuple 검증
  6. `result[0]` 반환
- errors:
  - missing class, missing method, invalid result의 기존 exact `RuntimeError`
  - lookup/constructor/attribute/encode exception은 그대로 전파
- repository root/canonical monkeypatch consumers: 0/0
- confirmed external consumers: 0
- root/canonical mutable state와 import-time call: 없음
- 6 consumer의 binder-owned runtime resolver는 feature use-time에만 helper를
  해석·호출
- ledger: `pure_helper_with_provider_input`, `unsupported_test_only`
- call-time root replacement required: false

## 변경

- root definition과 두 relative/flat adapter import를 제거했습니다.
- installed runtime은 provider-injected canonical invocation helper를
  유지합니다.
- flat pre-bootstrap은 fresh default provider lookup을 call-time에 주입합니다.
- redundant direct root assertion을 제거하고 canonical/flat test로 대체했습니다.
- lookup/construction/method/call/result order, exact errors, success identity,
  raw finder/encode exception 전파를 고정했습니다.
- root/package absence, retired adapter ledger, analyzer/package fixture와
  architecture 문서를 갱신했습니다.

## 금지 경계 확인

- canonical invocation helper와 provider 변경 없음
- 6 production consumer/binder 변경 없음
- general lookup 이동 없음
- schema/workflow/seed/stage/route/persistence/postprocess 변경 없음
- cache/snapshot/mutable override/optional import/canonical root import 추가 없음

## 검증

- focused:
  - canonical/wiring/대표 consumer/root-package/ledger/analyzer 77 tests passed
- official full:
  - `tools/check_custom_node.ps1 -Project <absolute PR worktree> -Profile full`
  - Python 962 tests passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline, G-03 import boundary 6 groups, diff check passed
  - Ruff 113 existing findings, report-only
- `comfy node validate`: passed
- actual `comfy node pack`: 218 entries
  - Python 86/86, analyzer `shipped_python_modules`와 exact match
  - `easyuse_anima/infrastructure/comfy/wiring.py` 포함

## 테스트 표면과 남은 위험

- ComfyUI v0.27.0 Codex test instance: official runner/import/module surface
- live ComfyUI smoke: 미실행
- private unsupported root retirement이므로 workflow/schema 결과 변화는 없습니다.
- 저장소 외 소비자는 확인되지 않았지만 공개 코드 검색은 비포괄적입니다.

## 롤백

root definition, 두 adapter import, flat fallback, ledger/analyzer 상태만 한
단위로 복원합니다.

## 다음 단계

병합 후 B-11c29b3 general node lookup을 별도 retirement 단위로 진행합니다.
