### PR TITLE
B-11c29b3: retire general Comfy node lookup wrapper

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -5,8 +5,8 @@
 - Status: active sequencing addendum
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Snapshot commit: `0bf5229adeda2708426a8d65e75380c9033b1835`
-- Latest integrated slice: B-11c28, PR #322
+- Snapshot commit: `931a80f44bea694f3a91a200fe53123226a70b3a`
+- Latest integrated slice: B-11c29d, PR #333
 - Primary execution issue: [#323](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/323)
 - Parent runtime/lifecycle issue: [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
 - Blocked extraction/final-shim issue: [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184)
@@ -841,7 +841,7 @@ Forbidden:
 
 ### B-11c29d — CLIP invocation wrapper
 
-- **State:** IN PROGRESS in PR #333; precedes B-11c29b3
+- **State:** COMPLETE in PR #333 / `931a80f`; precedes B-11c29b3
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -921,9 +921,95 @@ Forbidden:
   canonical root imports; and
 - changing seed, stage, route, persistence, or postprocess behavior.
 
+#### B-11c29b3 — General node lookup
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Type:** Retirement
+
+Pre-edit inventory at `dev@931a80f44bea694f3a91a200fe53123226a70b3a`:
+
+- root `nodes.py` owns one `_find_comfy_node_class(node_id: str)` definition
+  and imports `_adapter_find_comfy_node_class` in relative and flat modes;
+- its canonical owner is
+  `ComfyHostProvider.find_node_class`, implemented through
+  `easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class`;
+- six call-time production binder modules own 17 lookup call sites:
+  `easyuse_anima.aio.model_preparation` (2), `aio.output` (1),
+  `aio.preview` (1), `aio.resources` (7), `aio.sampling` (4), and
+  `image.sam3` (2);
+- installed runtime already resolves those calls through
+  `ComfyHostProvider.find_node_class`. Repository root replacements,
+  canonical replacements, and confirmed external consumers are all zero;
+- the root wrapper has no mutable state or import-time call. Every consumer
+  keeps its existing binder-owned resolver state and performs lookup only at
+  feature use time;
+- exact lookup order is lazy host `nodes` import, host
+  `NODE_CLASS_MAPPINGS[node_id]`, host attribute `node_id`, then current
+  `sys.modules` order for `NODE_CLASS_MAPPINGS[node_id]`;
+- host mapping and attribute exceptions fall through to the loaded-module scan,
+  the first non-`None` class object is returned unchanged, and a missing class
+  returns `None`;
+- optional custom-node modules are observed only when already loaded and are
+  never imported by this helper; and
+- the ledger classifies the root seam as `provider_owned`,
+  `unsupported_test_only`, with no call-time root replacement requirement.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/infrastructure/comfy/wiring.py
+```
+
+Allowed test, fixture, and documentation files:
+
+```text
+tests/test_comfy_host_wiring.py
+tests/test_comfy_host_provider.py
+tests/test_node_contracts.py
+tests/test_aio_model_preparation.py
+tests/test_aio_output.py
+tests/test_aio_preview.py
+tests/test_aio_resources.py
+tests/test_aio_sampling.py
+tests/test_sam3_nodes.py
+tests/test_python_compatibility_surface.py
+tests/test_nodes_module_analyzer.py
+tests/fixtures/comfy_host_compatibility.v1.json
+tests/fixtures/python_compatibility_surface.v1.json
+tests/fixtures/python_backend_baseline.json
+docs/architecture/*
+```
+
+Exit:
+
+- the root definition and both adapter imports are absent;
+- installed-runtime consumers continue using
+  `ComfyHostProvider.find_node_class`;
+- flat pre-bootstrap calls use a fresh default provider at call time;
+- mapping, attribute, and loaded-module order, exception fallthrough, result
+  identity, missing result, and use-time-only optional dependency behavior
+  remain unchanged;
+- retirement gates reject restored root or adapter bindings; and
+- root residual/analyzer/package closure gates pass.
+
+Forbidden:
+
+- changing `ComfyHostProvider`, its implementation, or the canonical capability
+  helper;
+- changing the six production consumers, binders, schemas, workflows, or
+  feature-selection timing;
+- changing lookup order, exception fallthrough, result identity, missing-result
+  behavior, or optional dependency timing;
+- adding cache, snapshot, mutable override state, optional imports, or
+  canonical root imports; and
+- changing requirement, CLIP, seed, stage, route, persistence, or postprocess
+  behavior.
+
 ### B-11c30 — Runtime binder/resolver migration audit
 
-- **State:** BLOCKED by B-11c29a-d
+- **State:** BLOCKED by B-11c29b3
 - **Owner:** #184/#188
 - **Type:** Contract/gate plus separate cleanup Moves
 
@@ -974,8 +1060,8 @@ COMPLETE: B-11c29a max-resolution wrapper retirement / PR #329
 COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
 COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
 COMPLETE: B-11c29c requirement helper retirement / PR #332
-IN PROGRESS: B-11c29d CLIP wrapper retirement / PR #333
-BLOCKED:  B-11c29b3 general node lookup retirement
+COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
+IN PROGRESS: B-11c29b3 general node lookup retirement
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -923,7 +923,7 @@ Forbidden:
 
 #### B-11c29b3 — General node lookup
 
-- **State:** IN PROGRESS
+- **State:** IN PROGRESS in PR #334
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -1061,7 +1061,7 @@ COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
 COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
 COMPLETE: B-11c29c requirement helper retirement / PR #332
 COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
-IN PROGRESS: B-11c29b3 general node lookup retirement
+IN PROGRESS: B-11c29b3 general node lookup retirement / PR #334
 BLOCKED:  B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29d / PR #333; B-11c29b3 general lookup retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29d / PR #333; B-11c29b3 general lookup retirement in PR #334 | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -338,7 +338,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29d CLIP invocation retirement PR #333; B-11c29b3 general lookup retirement in progress | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29d CLIP invocation retirement PR #333; B-11c29b3 general lookup retirement in PR #334 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `14015769634d387fe5afa6a74a5594007e86346c`
+- Integrated `dev` snapshot commit: `931a80f44bea694f3a91a200fe53123226a70b3a`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29c / PR #332; B-11c29d CLIP invocation retirement in PR #333 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29d / PR #333; B-11c29b3 general lookup retirement in progress | Complete residual owners and binders, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,915
-  lines after E-07b.
-- The mechanical extraction has removed 10,748
-  lines, approximately 84.9% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,860
+  lines after B-11c29d.
+- The mechanical extraction has removed 10,803
+  lines, approximately 85.3% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -95,8 +95,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   loaded, requirement, CLIP, and general lookup retirements remain separate.
   B-11c29b2 retired only the unsupported loaded-node root lookup in PR #331.
   B-11c29c retired the two pure requirement root helpers together in PR #332.
-  B-11c29d next retires the pure CLIP invocation root helper while the general
-  root lookup remains for its final B-11c29b3 unit.
+  B-11c29d retired the pure CLIP invocation root helper in PR #333. B-11c29b3
+  now retires the final general host lookup root wrapper as its own unit.
 
 ### Current quality baseline
 
@@ -338,7 +338,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29d CLIP invocation retirement PR #333; next B-11c29b3 general lookup | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29d CLIP invocation retirement PR #333; B-11c29b3 general lookup retirement in progress | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,9 +8,9 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c29c are integrated. B-11c is split into
+- Current state: B-11a through B-11c29d are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c29d retires the pure CLIP invocation root helper in PR #333.
+  root shim; B-11c29b3 general lookup retirement is in progress.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -668,6 +668,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
   propagation remain unchanged.
 - The provider interface, canonical invocation helper, and six production
   consumers are unchanged. General lookup retires next as B-11c29b3.
+
+### B-11c29b3 general node-lookup retirement
+
+- `_find_comfy_node_class` is an unsupported/test-only provider-owned root seam
+  with six provider-wired production binder modules, 17 lookup call sites, no
+  repository replacement, and no confirmed external consumer.
+- The retirement removes the root definition and both relative/flat
+  `_adapter_find_comfy_node_class` imports.
+- Installed runtime keeps `ComfyHostProvider.find_node_class`; flat
+  pre-bootstrap imports use a fresh default provider at call time.
+- Host mapping, host attribute, and current loaded-module lookup order,
+  exception fallthrough, first non-`None` result identity, missing `None`
+  result, and use-time-only optional dependency behavior remain unchanged.
+- The provider interface, canonical capability helper, six production
+  consumers, and their binder-owned runtime state remain unchanged.
 
 ### `nodes.py` public node-class surface
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -10,7 +10,7 @@
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
 - Current state: B-11a through B-11c29d are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c29b3 general lookup retirement is in progress.
+  root shim; B-11c29b3 general lookup retirement is in PR #334.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 296 in B-11c29d
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 295 in B-11c29b3
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -84,10 +84,10 @@ inferring public support from spelling or test imports:
 - unmapped root classes: `EasyUseAnimaSAM3Context` and
   `EasyUseAnimaSAM3Detailer`; the canonical legacy Extend class remains in its
   owner module without a root alias or backend mapping;
-- root-owned residual implementation: 2 functions, 0 classes, and 26 assigned
-  globals in B-11c29d (41/2/33 at the integrated B-10b20 baseline).
+- root-owned residual implementation: 1 function, 0 classes, and 26 assigned
+  globals in B-11c29b3 (41/2/33 at the integrated B-10b20 baseline).
 - import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 285, including
+- root names reached by those canonical runtime resolvers: 284, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -102,9 +102,10 @@ inferring public support from spelling or test imports:
   the five B-10b15 conditioning aliases, the 12 B-10b16 Prompt Advanced aliases,
   the 12 B-10b17 Regional aliases, the 11 B-10b18 Artist Mix parsing/config
   aliases, the 21 B-10b19 Artist Mix mode/key/tag-position aliases, and the 21
-  B-10b20 Artist Mix conditioning/tensor aliases, plus the B-11c29a-d
+  B-10b20 Artist Mix conditioning/tensor aliases, plus the B-11c29a-d and
+  B-11c29b3
   `_comfy_max_resolution`, direct mapping, loaded lookup, and two requirement
-  root helpers and the CLIP invocation helper; their production
+  root helpers, the CLIP invocation helper, and general node lookup; their production
   consumers import or call the corresponding canonical owners directly;
 - repository test files with a direct `nodes` import: 21, recorded as migration
   consumers rather than public-support evidence.

--- a/easyuse_anima/infrastructure/comfy/wiring.py
+++ b/easyuse_anima/infrastructure/comfy/wiring.py
@@ -19,6 +19,10 @@ def _default_max_resolution() -> int:
     return DefaultComfyHostProvider().max_resolution()
 
 
+def _default_node_class(node_id: str):
+    return DefaultComfyHostProvider().find_node_class(node_id)
+
+
 def _default_node_mapping_class(node_id: str):
     return DefaultComfyHostProvider().find_node_mapping_class(node_id)
 
@@ -86,6 +90,8 @@ def resolve_comfy_host_helper(
         # the remaining B-11 seams keep their existing root resolver.
         if name == "_comfy_max_resolution":
             return _default_max_resolution
+        if name == "_find_comfy_node_class":
+            return _default_node_class
         if name == "_find_comfy_node_mapping_class":
             return _default_node_mapping_class
         if name == "_find_loaded_node_class":

--- a/nodes.py
+++ b/nodes.py
@@ -410,7 +410,6 @@ try:
     from .easyuse_anima.infrastructure.comfy.capabilities import (
         _comfy_sampler_names as _comfy_sampler_names,
         _comfy_scheduler_names as _comfy_scheduler_names,
-        _find_comfy_node_class as _adapter_find_comfy_node_class,
         # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
     )
@@ -969,7 +968,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     from easyuse_anima.infrastructure.comfy.capabilities import (
         _comfy_sampler_names as _comfy_sampler_names,
         _comfy_scheduler_names as _comfy_scheduler_names,
-        _find_comfy_node_class as _adapter_find_comfy_node_class,
         # B-10b4 omits the retired root _impact_core_module alias.
         _impact_scheduler_names as _impact_scheduler_names,
     )
@@ -1617,14 +1615,6 @@ AIO_RESHIFT_DTYPES = ("bf16", "fp32")
 
 
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
-
-
-def _find_comfy_node_class(node_id: str):
-    try:
-        import nodes as comfy_nodes  # type: ignore
-    except Exception:
-        comfy_nodes = None
-    return _adapter_find_comfy_node_class(node_id, comfy_nodes)
 
 
 def _consume_reserved_wildcard_next_seed(

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -165,24 +165,10 @@
     },
     {
       "symbol": "_find_comfy_node_class",
-      "root_signature": {
-        "parameters": [
-          {
-            "name": "node_id",
-            "kind": "positional_or_keyword",
-            "annotation": "str",
-            "default": null
-          }
-        ],
-        "return": null
-      },
-      "adapter_binding": {
-        "alias": "_adapter_find_comfy_node_class",
-        "target": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class"
-      },
-      "root_dependencies": [
-        "_adapter_find_comfy_node_class"
-      ],
+      "root_signature": null,
+      "adapter_binding": null,
+      "retired_adapter_alias": "_adapter_find_comfy_node_class",
+      "root_dependencies": [],
       "canonical_target": "ComfyHostProvider.find_node_class",
       "production_consumers": [
         {
@@ -242,9 +228,9 @@
       "root_seam_classification": "unsupported_test_only",
       "call_time_replacement_required": false,
       "replacement_mechanism": "repository_tests_use_fake_provider_or_explicit_canonical_lookup",
-      "root_removal_gate": "E-07b fake-provider migration and lookup-order parity, then #184 B-11c29b",
+      "root_removal_gate": "completed in #184 B-11c29b3 / PR #334",
       "owner_issue": "#323",
-      "move_owner": "#184 B-11c29b"
+      "move_owner": "#184 B-11c29b3"
     },
     {
       "symbol": "_find_comfy_node_mapping_class",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -22009,37 +22009,6 @@
         "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
       },
       {
-        "alias": "_adapter_find_comfy_node_class",
-        "bound_name": "_adapter_find_comfy_node_class",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_find_comfy_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
-        "kind": "static_from",
-        "line": 410,
-        "name": "_find_comfy_node_class",
-        "optional": false,
-        "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
         "alias": "_impact_scheduler_names",
         "bound_name": "_impact_scheduler_names",
         "branch_context": [
@@ -22092,7 +22061,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22123,7 +22092,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22154,7 +22123,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22185,7 +22154,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 422,
+        "line": 421,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22216,7 +22185,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 425,
+        "line": 424,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22247,7 +22216,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 424,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22278,7 +22247,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 424,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22309,7 +22278,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 424,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22340,7 +22309,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 425,
+        "line": 424,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22371,7 +22340,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22402,7 +22371,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22433,7 +22402,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 437,
+        "line": 436,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
@@ -22464,7 +22433,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 441,
+        "line": 440,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22495,7 +22464,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 441,
+        "line": 440,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22526,7 +22495,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 441,
+        "line": 440,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22557,7 +22526,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22588,7 +22557,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22619,7 +22588,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22650,7 +22619,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22681,7 +22650,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 446,
+        "line": 445,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22712,7 +22681,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 453,
+        "line": 452,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22743,7 +22712,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 453,
+        "line": 452,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22774,7 +22743,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 453,
+        "line": 452,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22805,7 +22774,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 458,
+        "line": 457,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22836,7 +22805,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 458,
+        "line": 457,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22867,7 +22836,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 458,
+        "line": 457,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22898,7 +22867,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 476,
+        "line": 475,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22929,7 +22898,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 476,
+        "line": 475,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22960,7 +22929,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 476,
+        "line": 475,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22991,7 +22960,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 476,
+        "line": 475,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23022,7 +22991,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 476,
+        "line": 475,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23053,7 +23022,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 499,
+        "line": 498,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23084,7 +23053,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 499,
+        "line": 498,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23115,7 +23084,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 503,
+        "line": 502,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23146,7 +23115,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 503,
+        "line": 502,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23177,7 +23146,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23208,7 +23177,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23239,7 +23208,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23270,7 +23239,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23301,7 +23270,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23332,7 +23301,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23363,7 +23332,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23394,7 +23363,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23425,7 +23394,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23456,7 +23425,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23487,7 +23456,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23518,7 +23487,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23549,7 +23518,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23580,7 +23549,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23611,7 +23580,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 508,
+        "line": 507,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23642,7 +23611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23673,7 +23642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23704,7 +23673,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23735,7 +23704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23766,7 +23735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23797,7 +23766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23828,7 +23797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23859,7 +23828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 525,
+        "line": 524,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23890,7 +23859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 535,
+        "line": 534,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23921,7 +23890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 535,
+        "line": 534,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23952,7 +23921,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 539,
+        "line": 538,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23983,7 +23952,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 539,
+        "line": 538,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24014,7 +23983,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 540,
+        "line": 539,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24045,7 +24014,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 541,
+        "line": 540,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24076,7 +24045,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 541,
+        "line": 540,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24107,7 +24076,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 541,
+        "line": 540,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24138,7 +24107,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 546,
+        "line": 545,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24169,7 +24138,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 546,
+        "line": 545,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24200,7 +24169,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24231,7 +24200,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24262,7 +24231,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24293,7 +24262,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24324,7 +24293,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24355,7 +24324,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24386,7 +24355,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24417,7 +24386,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24448,7 +24417,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24479,7 +24448,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24510,7 +24479,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24541,7 +24510,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24572,7 +24541,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24603,7 +24572,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24634,7 +24603,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24665,7 +24634,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24696,7 +24665,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24727,7 +24696,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24758,7 +24727,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 547,
+        "line": 546,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24777,7 +24746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -24792,7 +24761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24811,7 +24780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -24826,7 +24795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24845,7 +24814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -24860,7 +24829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24879,7 +24848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -24894,7 +24863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24913,7 +24882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -24928,7 +24897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24947,7 +24916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -24962,7 +24931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24981,7 +24950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -24996,7 +24965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25015,7 +24984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25030,7 +24999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25049,7 +25018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25064,7 +25033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25083,7 +25052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25098,7 +25067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25117,7 +25086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25132,7 +25101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25151,7 +25120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25166,7 +25135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25185,7 +25154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25200,7 +25169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25219,7 +25188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25234,7 +25203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25253,7 +25222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25268,7 +25237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25287,7 +25256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25302,7 +25271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25321,7 +25290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25336,7 +25305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25355,7 +25324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25370,7 +25339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25389,7 +25358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25404,7 +25373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25423,7 +25392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25438,7 +25407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25457,7 +25426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25472,7 +25441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25491,7 +25460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25506,7 +25475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25525,7 +25494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25540,7 +25509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25559,7 +25528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25574,7 +25543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25593,7 +25562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25608,7 +25577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25627,7 +25596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25642,7 +25611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25661,7 +25630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25676,7 +25645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25695,7 +25664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25710,7 +25679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25729,7 +25698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25744,7 +25713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25763,7 +25732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25778,7 +25747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25797,7 +25766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25812,7 +25781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25831,7 +25800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25846,7 +25815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25865,7 +25834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25880,7 +25849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 608,
+        "line": 607,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25899,7 +25868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25914,7 +25883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 611,
+        "line": 610,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25933,7 +25902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25948,7 +25917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 611,
+        "line": 610,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25967,7 +25936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -25982,7 +25951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 611,
+        "line": 610,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26001,7 +25970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26016,7 +25985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26035,7 +26004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26050,7 +26019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26069,7 +26038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26084,7 +26053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26103,7 +26072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26118,7 +26087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26137,7 +26106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26152,7 +26121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26171,7 +26140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26186,7 +26155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26205,7 +26174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26220,7 +26189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26239,7 +26208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26254,7 +26223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26273,7 +26242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26288,7 +26257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26307,7 +26276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26322,7 +26291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26341,7 +26310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26356,7 +26325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26375,7 +26344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26390,7 +26359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26409,7 +26378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26424,7 +26393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26443,7 +26412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26458,7 +26427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26477,7 +26446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26492,7 +26461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26511,7 +26480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26526,7 +26495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26545,7 +26514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26560,7 +26529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26579,7 +26548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26594,7 +26563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26613,7 +26582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26628,7 +26597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26647,7 +26616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26662,7 +26631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26681,7 +26650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26696,7 +26665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26715,7 +26684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26730,7 +26699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26749,7 +26718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26764,7 +26733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26783,7 +26752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26798,7 +26767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26817,7 +26786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26832,7 +26801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26851,7 +26820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26866,7 +26835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26885,7 +26854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26900,7 +26869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26919,7 +26888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26934,7 +26903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26953,7 +26922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -26968,7 +26937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26987,7 +26956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27002,7 +26971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27021,7 +26990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27036,7 +27005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27055,7 +27024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27070,7 +27039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27089,7 +27058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27104,7 +27073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27123,7 +27092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27138,7 +27107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27157,7 +27126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27172,7 +27141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27191,7 +27160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27206,7 +27175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27225,7 +27194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27240,7 +27209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27259,7 +27228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27274,7 +27243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27293,7 +27262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27308,7 +27277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27327,7 +27296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27342,7 +27311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27361,7 +27330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27376,7 +27345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27395,7 +27364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27410,7 +27379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27429,7 +27398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27444,7 +27413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27463,7 +27432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27478,7 +27447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27497,7 +27466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27512,7 +27481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27531,7 +27500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27546,7 +27515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27565,7 +27534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27580,7 +27549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27599,7 +27568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27614,7 +27583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27633,7 +27602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27648,7 +27617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27667,7 +27636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27682,7 +27651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27701,7 +27670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27716,7 +27685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27735,7 +27704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27750,7 +27719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27769,7 +27738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27784,7 +27753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27803,7 +27772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27818,7 +27787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27837,7 +27806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27852,7 +27821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27871,7 +27840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27886,7 +27855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27905,7 +27874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27920,7 +27889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27939,7 +27908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27954,7 +27923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27973,7 +27942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -27988,7 +27957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28007,7 +27976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28022,7 +27991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28041,7 +28010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28056,7 +28025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28075,7 +28044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28090,7 +28059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28109,7 +28078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28124,7 +28093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28143,7 +28112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28158,7 +28127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28177,7 +28146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28192,7 +28161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28211,7 +28180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28226,7 +28195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28245,7 +28214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28260,7 +28229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28279,7 +28248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28294,7 +28263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28313,7 +28282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28328,7 +28297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28347,7 +28316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28362,7 +28331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28381,7 +28350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28396,7 +28365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 700,
+        "line": 699,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28415,7 +28384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28430,7 +28399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 700,
+        "line": 699,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28449,7 +28418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28464,7 +28433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 700,
+        "line": 699,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28483,7 +28452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28498,7 +28467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28517,7 +28486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28532,7 +28501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28551,7 +28520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28566,7 +28535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28585,7 +28554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28600,7 +28569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28619,7 +28588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28634,7 +28603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28653,7 +28622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28668,7 +28637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 712,
+        "line": 711,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28687,7 +28656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28702,7 +28671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28721,7 +28690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28736,7 +28705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28755,7 +28724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28770,7 +28739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28789,7 +28758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28804,7 +28773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28823,7 +28792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28838,7 +28807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28857,7 +28826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28872,7 +28841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28891,7 +28860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28906,7 +28875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28925,7 +28894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28940,7 +28909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28959,7 +28928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -28974,7 +28943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28993,7 +28962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29008,7 +28977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29027,7 +28996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29042,7 +29011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29061,7 +29030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29076,7 +29045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29095,7 +29064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29110,7 +29079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29129,7 +29098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29144,7 +29113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29163,7 +29132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29178,7 +29147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29197,7 +29166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29212,7 +29181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29231,7 +29200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29246,7 +29215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29265,7 +29234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29280,7 +29249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29299,7 +29268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29314,7 +29283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29333,7 +29302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29348,7 +29317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29367,7 +29336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29382,7 +29351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29401,7 +29370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29416,7 +29385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29435,7 +29404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29450,7 +29419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29469,7 +29438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29484,7 +29453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29503,7 +29472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29518,7 +29487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29537,7 +29506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29552,7 +29521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29571,7 +29540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29586,7 +29555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29605,7 +29574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29620,7 +29589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29639,7 +29608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29654,7 +29623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29673,7 +29642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29688,7 +29657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29707,7 +29676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29722,7 +29691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29741,7 +29710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29756,7 +29725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29775,7 +29744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29790,7 +29759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29809,7 +29778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29824,7 +29793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29843,7 +29812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29858,7 +29827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29877,7 +29846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29892,7 +29861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29911,7 +29880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29926,7 +29895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29945,7 +29914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29960,7 +29929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29979,7 +29948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -29994,7 +29963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30013,7 +29982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30028,7 +29997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30047,7 +30016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30062,7 +30031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30081,7 +30050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30096,7 +30065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30115,7 +30084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30130,7 +30099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30149,7 +30118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30164,7 +30133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30183,7 +30152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30198,7 +30167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30217,7 +30186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30232,7 +30201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30251,7 +30220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30266,7 +30235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30285,7 +30254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30300,7 +30269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30319,7 +30288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30334,7 +30303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30353,7 +30322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30368,7 +30337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30387,7 +30356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30402,7 +30371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30421,7 +30390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30436,7 +30405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30455,7 +30424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30470,7 +30439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30489,7 +30458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30504,7 +30473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30523,7 +30492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30538,7 +30507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30557,7 +30526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30572,7 +30541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30591,7 +30560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30606,7 +30575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30625,7 +30594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30640,7 +30609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30659,7 +30628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30674,7 +30643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30693,7 +30662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30708,7 +30677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30727,7 +30696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30742,7 +30711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30761,7 +30730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30776,7 +30745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30795,7 +30764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30810,7 +30779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30829,7 +30798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30844,7 +30813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30863,7 +30832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30878,7 +30847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30897,7 +30866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30912,7 +30881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30931,7 +30900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30946,7 +30915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30965,7 +30934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -30980,7 +30949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30999,7 +30968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31014,7 +30983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31033,7 +31002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31048,7 +31017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31067,7 +31036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31082,7 +31051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31101,7 +31070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31116,7 +31085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31135,7 +31104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31150,7 +31119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31169,7 +31138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31184,7 +31153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31203,7 +31172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31218,7 +31187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31237,7 +31206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31252,7 +31221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31271,7 +31240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31286,7 +31255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31305,7 +31274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31320,7 +31289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31339,7 +31308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31354,7 +31323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31373,7 +31342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31388,7 +31357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31407,7 +31376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31422,7 +31391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31441,7 +31410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31456,7 +31425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31475,7 +31444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31490,7 +31459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31509,7 +31478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31524,7 +31493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31543,7 +31512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31558,7 +31527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31577,7 +31546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31592,7 +31561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31611,7 +31580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31626,7 +31595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31645,7 +31614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31660,7 +31629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31679,7 +31648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31694,7 +31663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31713,7 +31682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31728,7 +31697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31747,7 +31716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31762,7 +31731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31781,7 +31750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31796,7 +31765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31815,7 +31784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31830,7 +31799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31849,7 +31818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31864,7 +31833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31883,7 +31852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31898,7 +31867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31917,7 +31886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31932,7 +31901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 917,
+        "line": 916,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31951,7 +31920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -31966,7 +31935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 917,
+        "line": 916,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31985,7 +31954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32000,7 +31969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 917,
+        "line": 916,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32019,7 +31988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32034,7 +32003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32053,7 +32022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32068,7 +32037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32087,7 +32056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32102,7 +32071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32121,7 +32090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32136,7 +32105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32155,7 +32124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32170,7 +32139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32189,7 +32158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32204,7 +32173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32223,7 +32192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32238,7 +32207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32257,7 +32226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32272,7 +32241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32291,7 +32260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32306,7 +32275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32325,7 +32294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32340,7 +32309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32359,7 +32328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32374,7 +32343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 937,
+        "line": 936,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32393,7 +32362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32408,7 +32377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 937,
+        "line": 936,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32427,7 +32396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32442,7 +32411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 937,
+        "line": 936,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32461,7 +32430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32476,7 +32445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "name": "_bind_sam3_runtime",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32495,7 +32464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32510,7 +32479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32529,7 +32498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32544,7 +32513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32563,7 +32532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32578,7 +32547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32597,7 +32566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32612,7 +32581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32631,7 +32600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32646,7 +32615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32665,7 +32634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32680,7 +32649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 968,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32699,7 +32668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32714,42 +32683,8 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 968,
         "name": "_comfy_scheduler_names",
-        "optional": false,
-        "requested": "easyuse_anima.infrastructure.comfy.capabilities",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "alias": "_adapter_find_comfy_node_class",
-        "bound_name": "_adapter_find_comfy_node_class",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 568,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_adapter_find_comfy_node_class",
-          "target": "easyuse_anima/infrastructure/comfy/capabilities.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
-        "kind": "static_from",
-        "line": 969,
-        "name": "_find_comfy_node_class",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
         "role": "compatibility_fallback",
@@ -32767,7 +32702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32782,7 +32717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 968,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32801,7 +32736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32816,7 +32751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32835,7 +32770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32850,7 +32785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32869,7 +32804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32884,7 +32819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32903,7 +32838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32918,7 +32853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 981,
+        "line": 979,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -32937,7 +32872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32952,7 +32887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32971,7 +32906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -32986,7 +32921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33005,7 +32940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33020,7 +32955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33039,7 +32974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33054,7 +32989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33073,7 +33008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33088,7 +33023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33107,7 +33042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33122,7 +33057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33141,7 +33076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33156,7 +33091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33175,7 +33110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33190,7 +33125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 996,
+        "line": 994,
         "name": "_bind_impact_detailer_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.impact_detailer_nodes",
@@ -33209,7 +33144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33224,7 +33159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33243,7 +33178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33258,7 +33193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33277,7 +33212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33292,7 +33227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33311,7 +33246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33326,7 +33261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33345,7 +33280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33360,7 +33295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33379,7 +33314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33394,7 +33329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33413,7 +33348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33428,7 +33363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33447,7 +33382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33462,7 +33397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33481,7 +33416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33496,7 +33431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1010,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33515,7 +33450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33530,7 +33465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1010,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33549,7 +33484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33564,7 +33499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1010,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33583,7 +33518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33598,7 +33533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33617,7 +33552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33632,7 +33567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33651,7 +33586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33666,7 +33601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33685,7 +33620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33700,7 +33635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33719,7 +33654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33734,7 +33669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33753,7 +33688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33768,7 +33703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33787,7 +33722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33802,7 +33737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33821,7 +33756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33836,7 +33771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33855,7 +33790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33870,7 +33805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1056,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33889,7 +33824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33904,7 +33839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1056,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33923,7 +33858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33938,7 +33873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1060,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33957,7 +33892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -33972,7 +33907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1060,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33991,7 +33926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34006,7 +33941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34025,7 +33960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34040,7 +33975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34059,7 +33994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34074,7 +34009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34093,7 +34028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34108,7 +34043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34127,7 +34062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34142,7 +34077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34161,7 +34096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34176,7 +34111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34195,7 +34130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34210,7 +34145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34229,7 +34164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34244,7 +34179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34263,7 +34198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34278,7 +34213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34297,7 +34232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34312,7 +34247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34331,7 +34266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34346,7 +34281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34365,7 +34300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34380,7 +34315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34399,7 +34334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34414,7 +34349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34433,7 +34368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34448,7 +34383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34467,7 +34402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34482,7 +34417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34501,7 +34436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34516,7 +34451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34535,7 +34470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34550,7 +34485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34569,7 +34504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34584,7 +34519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34603,7 +34538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34618,7 +34553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34637,7 +34572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34652,7 +34587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34671,7 +34606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34686,7 +34621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34705,7 +34640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34720,7 +34655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34739,7 +34674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34754,7 +34689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34773,7 +34708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34788,7 +34723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34807,7 +34742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34822,7 +34757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34841,7 +34776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34856,7 +34791,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34875,7 +34810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34890,7 +34825,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34909,7 +34844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34924,7 +34859,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34943,7 +34878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34958,7 +34893,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34977,7 +34912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -34992,7 +34927,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35011,7 +34946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35026,7 +34961,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35045,7 +34980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35060,7 +34995,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35079,7 +35014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35094,7 +35029,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35113,7 +35048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35128,7 +35063,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35147,7 +35082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35162,7 +35097,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35181,7 +35116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35196,7 +35131,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35215,7 +35150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35230,7 +35165,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35249,7 +35184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35264,7 +35199,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35283,7 +35218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35298,7 +35233,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35317,7 +35252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35332,7 +35267,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35351,7 +35286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35366,7 +35301,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35385,7 +35320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35400,7 +35335,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35419,7 +35354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35434,7 +35369,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35453,7 +35388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35468,7 +35403,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35487,7 +35422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35502,7 +35437,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35521,7 +35456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35536,7 +35471,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35555,7 +35490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35570,7 +35505,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35589,7 +35524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35604,7 +35539,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35623,7 +35558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35638,7 +35573,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35657,7 +35592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35672,7 +35607,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35691,7 +35626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35706,7 +35641,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35725,7 +35660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -35740,7 +35675,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35748,31 +35683,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "wildcard_engine.py"
-      },
-      {
-        "alias": "comfy_nodes",
-        "bound_name": "comfy_nodes",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1623
-          }
-        ],
-        "classification": "external",
-        "column": 8,
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1624,
-        "name": null,
-        "optional": true,
-        "requested": "nodes",
-        "role": "optional_dependency",
-        "scope": "_find_comfy_node_class",
-        "source": "nodes.py"
       },
       {
         "alias": null,
@@ -39080,13 +38990,13 @@
       },
       {
         "is_package": false,
-        "loc": 125,
+        "loc": 131,
         "module": "easyuse_anima.infrastructure.comfy.wiring",
-        "normalized_git_blob_sha1": "cb1ca27943e3938a8dfdd001e55741a0826ebae7",
+        "normalized_git_blob_sha1": "1c85416ba8e8385f497e4d2ae3567d9830a8d248",
         "path": "easyuse_anima/infrastructure/comfy/wiring.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 7,
+          "function_count": 8,
           "global_count": 1
         }
       },
@@ -39488,13 +39398,13 @@
       },
       {
         "is_package": false,
-        "loc": 1860,
+        "loc": 1850,
         "module": "nodes",
-        "normalized_git_blob_sha1": "01eb4cea34d49871d438182bb214f53f755d78d9",
+        "normalized_git_blob_sha1": "7ed2145d779e4069da1f8a6629e172dda9778262",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 2,
+          "function_count": 1,
           "global_count": 26
         }
       },
@@ -40854,7 +40764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -40863,7 +40773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40877,7 +40787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -40886,7 +40796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40900,7 +40810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -40909,7 +40819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40923,7 +40833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -40932,7 +40842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40946,7 +40856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -40955,7 +40865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40969,7 +40879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -40978,7 +40888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40992,7 +40902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41001,7 +40911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41015,7 +40925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41024,7 +40934,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 569,
+        "line": 568,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41038,7 +40948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41047,7 +40957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41061,7 +40971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41070,7 +40980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41084,7 +40994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41093,7 +41003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41107,7 +41017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41116,7 +41026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41130,7 +41040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41139,7 +41049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41153,7 +41063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41162,7 +41072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41176,7 +41086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41185,7 +41095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41199,7 +41109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41208,7 +41118,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 580,
+        "line": 579,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41222,7 +41132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41231,7 +41141,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41245,7 +41155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41254,7 +41164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41268,7 +41178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41277,7 +41187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41291,7 +41201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41300,7 +41210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41314,7 +41224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41323,7 +41233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41337,7 +41247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41346,7 +41256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41360,7 +41270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41369,7 +41279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41383,7 +41293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41392,7 +41302,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41406,7 +41316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41415,7 +41325,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41429,7 +41339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41438,7 +41348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41452,7 +41362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41461,7 +41371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41475,7 +41385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41484,7 +41394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41498,7 +41408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41507,7 +41417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41521,7 +41431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41530,7 +41440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41544,7 +41454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41553,7 +41463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41567,7 +41477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41576,7 +41486,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 590,
+        "line": 589,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41590,7 +41500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41599,7 +41509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 608,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41613,7 +41523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41622,7 +41532,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 611,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41636,7 +41546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41645,7 +41555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 611,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41659,7 +41569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41668,7 +41578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 611,
+        "line": 610,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41682,7 +41592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41691,7 +41601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41705,7 +41615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41714,7 +41624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41728,7 +41638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41737,7 +41647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41751,7 +41661,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41760,7 +41670,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41774,7 +41684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41783,7 +41693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 616,
+        "line": 615,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41797,7 +41707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41806,7 +41716,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41820,7 +41730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41829,7 +41739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41843,7 +41753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41852,7 +41762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41866,7 +41776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41875,7 +41785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 623,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41889,7 +41799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41898,7 +41808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41912,7 +41822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41921,7 +41831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41935,7 +41845,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41944,7 +41854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41958,7 +41868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41967,7 +41877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41981,7 +41891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -41990,7 +41900,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42004,7 +41914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42013,7 +41923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42027,7 +41937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42036,7 +41946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42050,7 +41960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42059,7 +41969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42073,7 +41983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42082,7 +41992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42096,7 +42006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42105,7 +42015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42119,7 +42029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42128,7 +42038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42142,7 +42052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42151,7 +42061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42165,7 +42075,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42174,7 +42084,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 629,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42188,7 +42098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42197,7 +42107,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42211,7 +42121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42220,7 +42130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42234,7 +42144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42243,7 +42153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42257,7 +42167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42266,7 +42176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42280,7 +42190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42289,7 +42199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42303,7 +42213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42312,7 +42222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42326,7 +42236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42335,7 +42245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42349,7 +42259,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42358,7 +42268,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42372,7 +42282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42381,7 +42291,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42395,7 +42305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42404,7 +42314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42418,7 +42328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42427,7 +42337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42441,7 +42351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42450,7 +42360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 644,
+        "line": 643,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42464,7 +42374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42473,7 +42383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42487,7 +42397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42496,7 +42406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42510,7 +42420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42519,7 +42429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42533,7 +42443,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42542,7 +42452,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42556,7 +42466,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42565,7 +42475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42579,7 +42489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42588,7 +42498,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42602,7 +42512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42611,7 +42521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42625,7 +42535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42634,7 +42544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42648,7 +42558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42657,7 +42567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42671,7 +42581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42680,7 +42590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 658,
+        "line": 657,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42694,7 +42604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42703,7 +42613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42717,7 +42627,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42726,7 +42636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42740,7 +42650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42749,7 +42659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42763,7 +42673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42772,7 +42682,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42786,7 +42696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42795,7 +42705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42809,7 +42719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42818,7 +42728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42832,7 +42742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42841,7 +42751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42855,7 +42765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42864,7 +42774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42878,7 +42788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42887,7 +42797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42901,7 +42811,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42910,7 +42820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 670,
+        "line": 669,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42924,7 +42834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42933,7 +42843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42947,7 +42857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42956,7 +42866,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42970,7 +42880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -42979,7 +42889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42993,7 +42903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43002,7 +42912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43016,7 +42926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43025,7 +42935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43039,7 +42949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43048,7 +42958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43062,7 +42972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43071,7 +42981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43085,7 +42995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43094,7 +43004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43108,7 +43018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43117,7 +43027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43131,7 +43041,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43140,7 +43050,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43154,7 +43064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43163,7 +43073,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43177,7 +43087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43186,7 +43096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43200,7 +43110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43209,7 +43119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43223,7 +43133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43232,7 +43142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43246,7 +43156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43255,7 +43165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43269,7 +43179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43278,7 +43188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 682,
+        "line": 681,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43292,7 +43202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43301,7 +43211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 700,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43315,7 +43225,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43324,7 +43234,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 700,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43338,7 +43248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43347,7 +43257,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 700,
+        "line": 699,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43361,7 +43271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43370,7 +43280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43384,7 +43294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43393,7 +43303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43407,7 +43317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43416,7 +43326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43430,7 +43340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43439,7 +43349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43453,7 +43363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43462,7 +43372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 705,
+        "line": 704,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43476,7 +43386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43485,7 +43395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 712,
+        "line": 711,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43499,7 +43409,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43508,7 +43418,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43522,7 +43432,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43531,7 +43441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43545,7 +43455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43554,7 +43464,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43568,7 +43478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43577,7 +43487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 713,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43591,7 +43501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43600,7 +43510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43614,7 +43524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43623,7 +43533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43637,7 +43547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43646,7 +43556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43660,7 +43570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43669,7 +43579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43683,7 +43593,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43692,7 +43602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43706,7 +43616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43715,7 +43625,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43729,7 +43639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43738,7 +43648,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43752,7 +43662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43761,7 +43671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43775,7 +43685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43784,7 +43694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43798,7 +43708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43807,7 +43717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 719,
+        "line": 718,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43821,7 +43731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43830,7 +43740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43844,7 +43754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43853,7 +43763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43867,7 +43777,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43876,7 +43786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43890,7 +43800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43899,7 +43809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43913,7 +43823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43922,7 +43832,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43936,7 +43846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43945,7 +43855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43959,7 +43869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43968,7 +43878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 733,
+        "line": 732,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43982,7 +43892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -43991,7 +43901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44005,7 +43915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44014,7 +43924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44028,7 +43938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44037,7 +43947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44051,7 +43961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44060,7 +43970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44074,7 +43984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44083,7 +43993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44097,7 +44007,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44106,7 +44016,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44120,7 +44030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44129,7 +44039,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44143,7 +44053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44152,7 +44062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44166,7 +44076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44175,7 +44085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44189,7 +44099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44198,7 +44108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44212,7 +44122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44221,7 +44131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44235,7 +44145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44244,7 +44154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44258,7 +44168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44267,7 +44177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44281,7 +44191,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44290,7 +44200,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44304,7 +44214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44313,7 +44223,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44327,7 +44237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44336,7 +44246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44350,7 +44260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44359,7 +44269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44373,7 +44283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44382,7 +44292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44396,7 +44306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44405,7 +44315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44419,7 +44329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44428,7 +44338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44442,7 +44352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44451,7 +44361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44465,7 +44375,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44474,7 +44384,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 751,
+        "line": 750,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44488,7 +44398,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44497,7 +44407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44511,7 +44421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44520,7 +44430,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44534,7 +44444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44543,7 +44453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44557,7 +44467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44566,7 +44476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44580,7 +44490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44589,7 +44499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44603,7 +44513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44612,7 +44522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44626,7 +44536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44635,7 +44545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44649,7 +44559,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44658,7 +44568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44672,7 +44582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44681,7 +44591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44695,7 +44605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44704,7 +44614,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44718,7 +44628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44727,7 +44637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44741,7 +44651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44750,7 +44660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44764,7 +44674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44773,7 +44683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44787,7 +44697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44796,7 +44706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 787,
+        "line": 786,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44810,7 +44720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44819,7 +44729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44833,7 +44743,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44842,7 +44752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44856,7 +44766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44865,7 +44775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44879,7 +44789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44888,7 +44798,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44902,7 +44812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44911,7 +44821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44925,7 +44835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44934,7 +44844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44948,7 +44858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44957,7 +44867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44971,7 +44881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -44980,7 +44890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44994,7 +44904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45003,7 +44913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 815,
+        "line": 814,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45017,7 +44927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45026,7 +44936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45040,7 +44950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45049,7 +44959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45063,7 +44973,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45072,7 +44982,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45086,7 +44996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45095,7 +45005,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45109,7 +45019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45118,7 +45028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45132,7 +45042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45141,7 +45051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45155,7 +45065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45164,7 +45074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45178,7 +45088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45187,7 +45097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45201,7 +45111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45210,7 +45120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45224,7 +45134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45233,7 +45143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45247,7 +45157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45256,7 +45166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45270,7 +45180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45279,7 +45189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45293,7 +45203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45302,7 +45212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45316,7 +45226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45325,7 +45235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45339,7 +45249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45348,7 +45258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45362,7 +45272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45371,7 +45281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45385,7 +45295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45394,7 +45304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45408,7 +45318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45417,7 +45327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45431,7 +45341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45440,7 +45350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45454,7 +45364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45463,7 +45373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45477,7 +45387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45486,7 +45396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45500,7 +45410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45509,7 +45419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45523,7 +45433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45532,7 +45442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45546,7 +45456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45555,7 +45465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45569,7 +45479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45578,7 +45488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 831,
+        "line": 830,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45592,7 +45502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45601,7 +45511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45615,7 +45525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45624,7 +45534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45638,7 +45548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45647,7 +45557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45661,7 +45571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45670,7 +45580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 911,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45684,7 +45594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45693,7 +45603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 917,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45707,7 +45617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45716,7 +45626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 917,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45730,7 +45640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45739,7 +45649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 917,
+        "line": 916,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45753,7 +45663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45762,7 +45672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45776,7 +45686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45785,7 +45695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45799,7 +45709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45808,7 +45718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 922,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45822,7 +45732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45831,7 +45741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45845,7 +45755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45854,7 +45764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45868,7 +45778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45877,7 +45787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45891,7 +45801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45900,7 +45810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45914,7 +45824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45923,7 +45833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45937,7 +45847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45946,7 +45856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45960,7 +45870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45969,7 +45879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 928,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45983,7 +45893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -45992,7 +45902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 937,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46006,7 +45916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46015,7 +45925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 937,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46029,7 +45939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46038,7 +45948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 937,
+        "line": 936,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46052,7 +45962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46061,7 +45971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46075,7 +45985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46084,7 +45994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46098,7 +46008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46107,7 +46017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46121,7 +46031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46130,7 +46040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 948,
+        "line": 947,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46144,7 +46054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46153,7 +46063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46167,7 +46077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46176,7 +46086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 961,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46190,7 +46100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46199,7 +46109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46213,7 +46123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46222,7 +46132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46236,30 +46146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class",
-        "kind": "static_from",
-        "line": 969,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46268,7 +46155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 969,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46282,7 +46169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46291,7 +46178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46305,7 +46192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46314,7 +46201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46328,7 +46215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46337,7 +46224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 976,
+        "line": 974,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46351,7 +46238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46360,7 +46247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 981,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46374,7 +46261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46383,7 +46270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46397,7 +46284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46406,7 +46293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46420,7 +46307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46429,7 +46316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46443,7 +46330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46452,7 +46339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46466,7 +46353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46475,7 +46362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 984,
+        "line": 982,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46489,7 +46376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46498,7 +46385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46512,7 +46399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46521,7 +46408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 992,
+        "line": 990,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46535,7 +46422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46544,7 +46431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
         "kind": "static_from",
-        "line": 996,
+        "line": 994,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46558,7 +46445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46567,7 +46454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46581,7 +46468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46590,7 +46477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46604,7 +46491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46613,7 +46500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
         "kind": "static_from",
-        "line": 1000,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46627,7 +46514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46636,7 +46523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46650,7 +46537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46659,7 +46546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46673,7 +46560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46682,7 +46569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46696,7 +46583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46705,7 +46592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46719,7 +46606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46728,7 +46615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1005,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46742,7 +46629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46751,7 +46638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46765,7 +46652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46774,7 +46661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46788,7 +46675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46797,7 +46684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1012,
+        "line": 1010,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46811,7 +46698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46820,7 +46707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46834,7 +46721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46843,7 +46730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46857,7 +46744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46866,7 +46753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1017,
+        "line": 1015,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46880,7 +46767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46889,7 +46776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46903,7 +46790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46912,7 +46799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46926,7 +46813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46935,7 +46822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46949,7 +46836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46958,7 +46845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46972,7 +46859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -46981,7 +46868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1035,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46995,7 +46882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47004,7 +46891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47018,7 +46905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47027,7 +46914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1058,
+        "line": 1056,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47041,7 +46928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47050,7 +46937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47064,7 +46951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47073,7 +46960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1062,
+        "line": 1060,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47087,7 +46974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47096,7 +46983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47110,7 +46997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47119,7 +47006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47133,7 +47020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47142,7 +47029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47156,7 +47043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47165,7 +47052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47179,7 +47066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47188,7 +47075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47202,7 +47089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47211,7 +47098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47225,7 +47112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47234,7 +47121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47248,7 +47135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47257,7 +47144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47271,7 +47158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47280,7 +47167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47294,7 +47181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47303,7 +47190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47317,7 +47204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47326,7 +47213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47340,7 +47227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47349,7 +47236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47363,7 +47250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47372,7 +47259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47386,7 +47273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47395,7 +47282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47409,7 +47296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47418,7 +47305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1065,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47432,7 +47319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47441,7 +47328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47455,7 +47342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47464,7 +47351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47478,7 +47365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47487,7 +47374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47501,7 +47388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47510,7 +47397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47524,7 +47411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47533,7 +47420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47547,7 +47434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47556,7 +47443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47570,7 +47457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47579,7 +47466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47593,7 +47480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47602,7 +47489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1082,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47616,7 +47503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47625,7 +47512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47639,7 +47526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47648,7 +47535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1094,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47662,7 +47549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47671,7 +47558,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47685,7 +47572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47694,7 +47581,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1096,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47708,7 +47595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47717,7 +47604,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1099,
+        "line": 1097,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47731,7 +47618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47740,7 +47627,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47754,7 +47641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47763,7 +47650,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47777,7 +47664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47786,7 +47673,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1100,
+        "line": 1098,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47800,7 +47687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47809,7 +47696,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47823,7 +47710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47832,7 +47719,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1105,
+        "line": 1103,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47846,7 +47733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47855,7 +47742,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47869,7 +47756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47878,7 +47765,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47892,7 +47779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47901,7 +47788,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47915,7 +47802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47924,7 +47811,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47938,7 +47825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47947,7 +47834,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47961,7 +47848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47970,7 +47857,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47984,7 +47871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -47993,7 +47880,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48007,7 +47894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48016,7 +47903,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48030,7 +47917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48039,7 +47926,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48053,7 +47940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48062,7 +47949,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48076,7 +47963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48085,7 +47972,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48099,7 +47986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48108,7 +47995,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48122,7 +48009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48131,7 +48018,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48145,7 +48032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48154,7 +48041,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48168,7 +48055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48177,7 +48064,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48191,7 +48078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48200,7 +48087,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48214,7 +48101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48223,7 +48110,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48237,7 +48124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48246,7 +48133,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48260,7 +48147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 568,
+            "handler_line": 567,
             "kind": "try",
             "line": 9
           }
@@ -48269,7 +48156,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1106,
+        "line": 1104,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -52208,25 +52095,6 @@
         "source": "nodes.py"
       },
       {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1623
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1624,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
-      },
-      {
         "branch_context": [],
         "classification": "external",
         "conditional": false,
@@ -53607,25 +53475,6 @@
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": false,
-            "kind": "try",
-            "line": 1623
-          }
-        ],
-        "classification": "external",
-        "conditional": true,
-        "imported": "nodes",
-        "kind": "static_import",
-        "line": 1624,
-        "optional": true,
-        "role": "optional_dependency",
-        "source": "nodes.py"
       },
       {
         "branch_context": [
@@ -55098,7 +54947,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1128,
+        "line": 1126,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55107,7 +54956,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1711,
+        "line": 1701,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55116,7 +54965,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1714,
+        "line": 1704,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55125,7 +54974,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1720,
+        "line": 1710,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55134,7 +54983,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1726,
+        "line": 1716,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55143,7 +54992,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1729,
+        "line": 1719,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55152,7 +55001,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1732,
+        "line": 1722,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55161,7 +55010,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1738,
+        "line": 1728,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55170,7 +55019,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1744,
+        "line": 1734,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55179,7 +55028,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1750,
+        "line": 1740,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55188,7 +55037,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1756,
+        "line": 1746,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55197,7 +55046,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1762,
+        "line": 1752,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55206,7 +55055,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1768,
+        "line": 1758,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55215,7 +55064,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1774,
+        "line": 1764,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55224,7 +55073,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1780,
+        "line": 1770,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55233,7 +55082,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1786,
+        "line": 1776,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55242,7 +55091,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1789,
+        "line": 1779,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55251,7 +55100,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1796,
+        "line": 1786,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55260,7 +55109,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1799,
+        "line": 1789,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55269,7 +55118,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1803,
+        "line": 1793,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55278,7 +55127,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1806,
+        "line": 1796,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55287,7 +55136,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1813,
+        "line": 1803,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55296,7 +55145,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1819,
+        "line": 1809,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55305,7 +55154,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1825,
+        "line": 1815,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55314,7 +55163,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1828,
+        "line": 1818,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55323,7 +55172,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1831,
+        "line": 1821,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55332,7 +55181,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1834,
+        "line": 1824,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55341,7 +55190,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1841,
+        "line": 1831,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55350,7 +55199,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1847,
+        "line": 1837,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55359,7 +55208,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1852,
+        "line": 1842,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55368,7 +55217,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1856,
+        "line": 1846,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55882,13 +55731,13 @@
       },
       {
         "kind": "dict",
-        "line": 1190,
+        "line": 1188,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1179,
+        "line": 1177,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -63,7 +63,8 @@
       "B-11c29b1",
       "B-11c29b2",
       "B-11c29c",
-      "B-11c29d"
+      "B-11c29d",
+      "B-11c29b3"
     ]
   },
   "enums": {
@@ -98,11 +99,11 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 296,
+    "nodes_canonical_bindings": 295,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
-    "root_residual_functions": 2,
+    "root_residual_functions": 1,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
     "runtime_binders": 30,
@@ -721,14 +722,6 @@
       "easyuse_anima.nodes.prompt_nodes",
       "easyuse_anima.prompt.advanced",
       "easyuse_anima.prompt.regional"
-    ],
-    "_find_comfy_node_class": [
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.aio.output",
-      "easyuse_anima.aio.preview",
-      "easyuse_anima.aio.resources",
-      "easyuse_anima.aio.sampling",
-      "easyuse_anima.image.sam3"
     ],
     "_find_spectrum_anima_mod_guidance_class": [
       "easyuse_anima.prompt.conditioning"
@@ -2674,7 +2667,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.infrastructure.comfy.capabilities:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_adapter_find_comfy_node_class": "_find_comfy_node_class",
         "_comfy_sampler_names": "_comfy_sampler_names",
         "_comfy_scheduler_names": "_comfy_scheduler_names",
         "_impact_scheduler_names": "_impact_scheduler_names"
@@ -2689,12 +2681,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.nodes.impact_detailer_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.nodes.impact_detailer_nodes string runtime lookup"
       ],
@@ -4223,8 +4213,7 @@
       "surface": "nodes_root_residuals",
       "kind": "functions",
       "symbols": {
-        "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed",
-        "_find_comfy_node_class": "_find_comfy_node_class"
+        "_consume_reserved_wildcard_next_seed": "_consume_reserved_wildcard_next_seed"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",

--- a/tests/test_comfy_host_provider.py
+++ b/tests/test_comfy_host_provider.py
@@ -65,6 +65,27 @@ class DefaultComfyHostProviderTests(unittest.TestCase):
             self.assertIs(self.provider.find_node_class(attribute_id), attribute_class)
             self.assertIs(self.provider.find_node_class(loaded_id), loaded_class)
 
+    def test_node_lookup_falls_through_host_errors_to_loaded_modules(self):
+        node_id = "EasyUseAnimaProviderHostErrorNode"
+        loaded_class = type("LoadedAfterHostError", (), {})
+
+        class FailingMapping:
+            def get(self, _node_id):
+                raise LookupError("mapping failed")
+
+        host = self.host_module(NODE_CLASS_MAPPINGS=FailingMapping())
+        loaded_module = types.ModuleType("easyuse_anima_provider_host_error")
+        loaded_module.NODE_CLASS_MAPPINGS = {node_id: loaded_class}
+
+        with patch.dict(
+            sys.modules,
+            {
+                "nodes": host,
+                loaded_module.__name__: loaded_module,
+            },
+        ):
+            self.assertIs(self.provider.find_node_class(node_id), loaded_class)
+
     def test_mapping_lookup_uses_only_the_host_mapping(self):
         node_id = "EasyUseAnimaProviderMappingOnlyNode"
         mapping_class = type("MappingOnlyNode", (), {})

--- a/tests/test_comfy_host_wiring.py
+++ b/tests/test_comfy_host_wiring.py
@@ -52,16 +52,36 @@ class ComfyHostWiringTests(unittest.TestCase):
             },
         )
 
-    def test_known_helper_uses_flat_import_fallback_before_runtime_install(self):
-        helper = resolve_comfy_host_helper(
-            "_find_comfy_node_class",
-            self._fallback,
-        )
+    def test_retired_general_lookup_uses_default_provider_before_runtime_install(self):
+        mapping_class = object()
+        attribute_class = object()
+        loaded_class = object()
+        comfy_nodes = types.ModuleType("nodes")
+        comfy_nodes.NODE_CLASS_MAPPINGS = {"Mapping": mapping_class}
+        comfy_nodes.Attribute = attribute_class
+        loaded_nodes = types.ModuleType("easyuse_anima_test_general_lookup")
+        loaded_nodes.NODE_CLASS_MAPPINGS = {"Loaded": loaded_class}
 
-        self.assertEqual(
-            helper("Example"),
-            ("_find_comfy_node_class", ("Example",)),
-        )
+        def unexpected_fallback(name: str):
+            self.fail(f"retired helper reached root fallback: {name}")
+
+        with patch.dict(
+            sys.modules,
+            {
+                "nodes": comfy_nodes,
+                loaded_nodes.__name__: loaded_nodes,
+            },
+        ):
+            helper = resolve_comfy_host_helper(
+                "_find_comfy_node_class",
+                unexpected_fallback,
+            )
+
+            self.assertIs(helper("Mapping"), mapping_class)
+            self.assertIs(helper("Attribute"), attribute_class)
+            self.assertIs(helper("Loaded"), loaded_class)
+            loaded_nodes.NODE_CLASS_MAPPINGS = {}
+            self.assertIsNone(helper("Missing"))
 
     def test_retired_max_resolution_uses_default_provider_before_runtime_install(self):
         comfy_nodes = types.ModuleType("nodes")

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2150,6 +2150,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
 
     def test_root_nodes_comfy_aliases_are_canonical_objects(self):
         self.assertFalse(hasattr(nodes, "_comfy_max_resolution"))
+        self.assertFalse(hasattr(nodes, "_find_comfy_node_class"))
         self.assertFalse(hasattr(nodes, "_find_comfy_node_mapping_class"))
         self.assertFalse(hasattr(nodes, "_find_loaded_node_class"))
         self.assertFalse(hasattr(nodes, "_require_custom_node_class"))
@@ -2166,6 +2167,7 @@ class ComfyAdapterMoveContractTests(unittest.TestCase):
     def test_package_nodes_comfy_aliases_are_canonical_objects(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
             self.assertFalse(hasattr(package_nodes, "_comfy_max_resolution"))
+            self.assertFalse(hasattr(package_nodes, "_find_comfy_node_class"))
             self.assertFalse(
                 hasattr(package_nodes, "_find_comfy_node_mapping_class")
             )

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,13 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "01eb4cea34d49871d438182bb214f53f755d78d9")
-        # B-11c29d retires only the pure CLIP invocation root helper and its
-        # two adapter imports without changing the public class surface.
-        self.assertEqual(report["top_level"]["function_count"], 2)
+        self.assertEqual(report["git_blob_sha1"], "7ed2145d779e4069da1f8a6629e172dda9778262")
+        # B-11c29b3 retires only the provider-owned general node lookup root
+        # helper and its two adapter imports without changing the public class
+        # surface.
+        self.assertEqual(report["top_level"]["function_count"], 1)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_860)
+        self.assertEqual(report["line_count"], 1_850)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -1697,6 +1697,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c29b2",
                 "B-11c29c",
                 "B-11c29d",
+                "B-11c29b3",
             ],
         },
         "enums": {
@@ -1709,11 +1710,11 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 296,
+            "nodes_canonical_bindings": 295,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
-            "root_residual_functions": 2,
+            "root_residual_functions": 1,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
             "runtime_binders": 30,
@@ -2143,6 +2144,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             {
                 "_comfy_max_resolution",
                 "_encode_with_comfy_clip",
+                "_find_comfy_node_class",
                 "_find_comfy_node_mapping_class",
                 "_find_loaded_node_class",
                 "_require_any_custom_node_class",
@@ -2158,6 +2160,7 @@ class ComfyHostCompatibilityLedgerTests(unittest.TestCase):
             {
                 "_comfy_max_resolution": "_adapter_comfy_max_resolution",
                 "_encode_with_comfy_clip": "_adapter_encode_with_comfy_clip",
+                "_find_comfy_node_class": "_adapter_find_comfy_node_class",
                 "_find_comfy_node_mapping_class": None,
                 "_find_loaded_node_class": "_adapter_find_loaded_node_class",
                 "_require_any_custom_node_class": (


### PR DESCRIPTION
## 분류

- Task: B-11c29b3
- Owner: #184
- Type: Retirement
- Base: `dev@931a80f44bea694f3a91a200fe53123226a70b3a`
- 검증 head: `7db5701eebf9532e8409bc54895a1d8bd15cdd24`
- Contract/Behavior: 포함하지 않음

## 작업 전 symbol/caller/alias/global-state inventory

- root symbol: `nodes.py:_find_comfy_node_class(node_id: str)` 1 definition
- relative/flat alias: `_adapter_find_comfy_node_class` 2 imports
- canonical owner: `ComfyHostProvider.find_node_class`
- canonical implementation:
  `easyuse_anima.infrastructure.comfy.capabilities:_find_comfy_node_class`
- production: 6개 call-time binder module / lookup 17곳
  - `easyuse_anima.aio.model_preparation` 2곳
  - `easyuse_anima.aio.output` 1곳
  - `easyuse_anima.aio.preview` 1곳
  - `easyuse_anima.aio.resources` 7곳
  - `easyuse_anima.aio.sampling` 4곳
  - `easyuse_anima.image.sam3` 2곳
- repository root/canonical monkeypatch consumers: 0/0
- confirmed external consumers: 0
- root mutable state/import-time call: 없음
- caller state: 각 binder의 기존 runtime resolver state만 유지하며 feature
  use time에 lookup
- lookup order: host `NODE_CLASS_MAPPINGS[node_id]` → host attribute
  `node_id` → 현재 `sys.modules` 순서의 `NODE_CLASS_MAPPINGS[node_id]`
- contract: host mapping/attribute 예외는 loaded-module scan으로 fall through,
  첫 non-`None` 객체 identity 보존, 미발견 시 `None`
- optional dependency: 이미 로드된 모듈만 관찰하며 optional pack을 import하지
  않음
- ledger: `provider_owned`, root seam `unsupported_test_only`, call-time root
  replacement 불필요

## 변경

- root `_find_comfy_node_class` definition과 두 relative/flat adapter import를
  제거했습니다.
- installed runtime의 `ComfyHostProvider.find_node_class` 경로는 그대로
  유지했습니다.
- runtime이 설치되지 않은 flat pre-bootstrap 경로는 fresh default provider를
  call time에 사용합니다.
- root/package symbol absence, retired adapter ledger, compatibility/analyzer
  fixture를 갱신했습니다.
- host mapping 예외 fallthrough와 mapping/attribute/loaded/missing 순서를
  focused test로 고정했습니다.
- production consumer와 binder는 변경하지 않았습니다.

## Allowed boundary

Production:

- `nodes.py`
- `easyuse_anima/infrastructure/comfy/wiring.py`

Tests/fixtures/docs:

- `tests/test_comfy_host_wiring.py`
- `tests/test_comfy_host_provider.py`
- `tests/test_node_contracts.py`
- `tests/test_aio_model_preparation.py`
- `tests/test_aio_output.py`
- `tests/test_aio_preview.py`
- `tests/test_aio_resources.py`
- `tests/test_aio_sampling.py`
- `tests/test_sam3_nodes.py`
- `tests/test_python_compatibility_surface.py`
- `tests/test_nodes_module_analyzer.py`
- `tests/fixtures/comfy_host_compatibility.v1.json`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/*`

## 금지 경계 확인

- provider interface/implementation과 canonical capability helper 변경 없음
- 6개 production consumer/binder 변경 없음
- schema/workflow/feature 선택 timing 변경 없음
- lookup order, exception fallthrough, identity, missing-result 변경 없음
- cache/snapshot/mutable override/optional import/canonical root import 추가 없음
- requirement, CLIP, seed, stage, route, persistence, postprocess behavior 변경
  없음

## 검증

- focused:
  - wiring/provider/canonical adapter/root-package/ledger/analyzer와 6개 대표
    consumer module 121 tests passed
- official full:
  - `tools/check_custom_node.ps1 -Project <absolute PR worktree> -Profile full`
  - Python 963 tests passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline, G-03 import boundary 6 groups, diff check passed
  - Ruff 113 existing findings, report-only
- `comfy node validate`: passed
- actual `comfy node pack`: 218 entries
  - Python 86/86, analyzer `shipped_python_modules`와 exact match
  - `easyuse_anima/infrastructure/comfy/wiring.py` 포함

## 테스트 표면과 남은 위험

- ComfyUI v0.27.0 Codex test instance: official runner/import/module surface
- live ComfyUI smoke: 미실행
- private unsupported root retirement이므로 workflow/schema 결과 변화는
  없습니다.
- 저장소 외 소비자는 확인되지 않았지만 공개 코드 검색은 비포괄적입니다.

## 롤백

root definition, 두 adapter import, flat fallback, ledger/analyzer 상태만 한
단위로 복원합니다.

## 다음 단계

병합 후 B-11c30 runtime binder/resolver migration audit를 Contract/gate 단위로
시작합니다. 이 PR에는 binder cleanup Move를 포함하지 않습니다.

Closes no issue. Parent: #184. Runtime bridge: #323.
