### PR TITLE
B-11c30: audit runtime binder and resolver ownership

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1009,7 +1009,7 @@ Forbidden:
 
 ### B-11c30 — Runtime binder/resolver migration audit
 
-- **State:** IN PROGRESS
+- **State:** IN PROGRESS in PR #336
 - **Owner:** #184/#188
 - **Type:** Contract/gate
 - **Production changes:** none
@@ -1129,7 +1129,7 @@ COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
 COMPLETE: B-11c29c requirement helper retirement / PR #332
 COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
 COMPLETE: B-11c29b3 general node lookup retirement / PR #334
-IN PROGRESS: B-11c30 binder/resolver migration audit
+IN PROGRESS: B-11c30 binder/resolver migration audit / PR #336
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -5,8 +5,8 @@
 - Status: active sequencing addendum
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Snapshot commit: `931a80f44bea694f3a91a200fe53123226a70b3a`
-- Latest integrated slice: B-11c29d, PR #333
+- Snapshot commit: `53d92aa944663a18ee593c027b90fa0b8e9444be`
+- Latest integrated slice: B-11c29b3, PR #334
 - Primary execution issue: [#323](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/323)
 - Parent runtime/lifecycle issue: [#187](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/187)
 - Blocked extraction/final-shim issue: [#184](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/184)
@@ -923,7 +923,7 @@ Forbidden:
 
 #### B-11c29b3 — General node lookup
 
-- **State:** IN PROGRESS in PR #334
+- **State:** COMPLETE in PR #334 / `53d92aa`
 - **Owner:** #184
 - **Type:** Retirement
 
@@ -1009,20 +1009,87 @@ Forbidden:
 
 ### B-11c30 — Runtime binder/resolver migration audit
 
-- **State:** BLOCKED by B-11c29b3
+- **State:** IN PROGRESS
 - **Owner:** #184/#188
-- **Type:** Contract/gate plus separate cleanup Moves
+- **Type:** Contract/gate
+- **Production changes:** none
 
-Inventory all remaining `_bind_*_runtime` calls and resolver names. For each:
+Pre-edit inventory at `dev@53d92aa944663a18ee593c027b90fa0b8e9444be`:
 
-- migrate host capability access to the provider;
-- keep feature-specific transitional seams only when their owner still requires
-  them;
-- prevent a provider bridge from becoming a generic string-key service locator;
-- update the machine-readable compatibility surface; and
-- split removal by owner family.
+- root `nodes.py` invokes exactly 30 canonical `_bind_*_runtime` functions;
+- 15 binders use the provider-aware resolver followed by root fallback, 13 use
+  root `globals()` resolution only, and two receive explicit root callbacks;
+- the canonical modules resolve 295 unique names: 288 current root names and
+  seven provider virtual seams that no longer exist as root symbols;
+- the 288 root names consist of the existing 284 compatibility/residual
+  resolver names plus the four preamble dependencies `ceil`, `json`, `random`,
+  and `sqrt`;
+- all seven provider seams remain active in 22 consumer slots across 15 modules;
+  they are not generic provider operations and retain the E-07 narrow provider
+  decisions;
+- binder calls also pass 14 unique direct root dependencies in 32 slots;
+- repository tests replace 165 root names across 20 files. This is migration
+  cost evidence, not supported-public compatibility evidence;
+- every string resolver observes the root at call time; the two explicit
+  callback binders receive root-calling closures, so their target lookup also
+  remains use-time; and
+- no binder, resolver, provider, consumer, node/workflow schema, or runtime
+  state changes in this Contract/gate.
 
-Do not collapse 30 binders in one PR.
+Machine-readable owner families:
+
+| Family | Binders | Root name slots | Provider slots | Direct slots | Test-replaced names |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| AiO | 12 | 260 | 13 | 8 | 133 |
+| Image/SAM3/Impact | 3 | 3 | 5 | 3 | 2 |
+| Prompt/Regional | 10 | 154 | 4 | 7 | 37 |
+| Wildcard/NAIA | 2 | 0 | 0 | 9 | 5 |
+| LoRA | 3 | 25 | 0 | 5 | 14 |
+
+Allowed files:
+
+```text
+tests/test_python_compatibility_surface.py
+tests/fixtures/python_compatibility_surface.v1.json
+docs/architecture/*
+```
+
+Exit:
+
+- every binder has one canonical module, one owner family, exact bound globals,
+  root call keywords, direct dependencies, resolver names, provider names, and
+  repository replacement evidence;
+- new or returned provider virtual names, unknown direct resolver names,
+  binder/family drift, and root/provider count drift fail deterministically;
+- the provider remains restricted to the seven E-07 decisions and is not a
+  generic string-key service locator;
+- production code and behavior are unchanged; and
+- the first cleanup candidate can be selected without combining owner families.
+
+Forbidden:
+
+- changing `nodes.py`, any binder, runtime consumer, provider, wiring, schema,
+  workflow, seed, stage, cache, route, persistence, or optional dependency;
+- treating repository test replacement as public support evidence;
+- deleting aliases or rewriting tests before the owning family Move; and
+- collapsing 30 binders or multiple owner families into one cleanup PR.
+
+Planned cleanup sequence:
+
+1. **B-11c30a Image/SAM3/Impact:** three binders, five provider slots, three
+   root-name slots, and two test-replaced names. This is the smallest
+   provider-bearing family and the first focused implementation candidate.
+2. **B-11c30b LoRA:** three non-provider binders with 25 root-name slots;
+   preserve logger proxy, prompt-token callback, input-type identity, and
+   bind-time object installation.
+3. **B-11c30c Prompt/Regional:** ten binders; split service and node-adapter
+   subunits before implementation because 154 root-name slots and 37
+   test-replaced names exceed one rollback unit.
+4. **B-11c30d AiO:** twelve binders; split support/service and node-adapter
+   subunits and retain #169 behavior ownership. Do not migrate 260 root-name
+   slots in one PR.
+5. **B-11c30e Wildcard/NAIA:** two explicit-callback binders; keep separate from
+   D-12 seed/Wildcard behavior and legacy engine consolidation.
 
 ### B-11d — Final root shim
 
@@ -1061,8 +1128,8 @@ COMPLETE: B-11c29b1 direct mapping lookup retirement / PR #330
 COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
 COMPLETE: B-11c29c requirement helper retirement / PR #332
 COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
-IN PROGRESS: B-11c29b3 general node lookup retirement / PR #334
-BLOCKED:  B-11c30 binder/resolver migration audit
+COMPLETE: B-11c29b3 general node lookup retirement / PR #334
+IN PROGRESS: B-11c30 binder/resolver migration audit
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -5,7 +5,7 @@
 - Status: operational execution runbook
 - Snapshot date: 2026-07-23
 - Snapshot branch: `dev`
-- Integrated `dev` snapshot commit: `931a80f44bea694f3a91a200fe53123226a70b3a`
+- Integrated `dev` snapshot commit: `53d92aa944663a18ee593c027b90fa0b8e9444be`
 - Scope: Python backend only
 - Target architecture: [`python-backend.md`](python-backend.md)
 - Architecture decisions: [ADR-001](adr-001-modular-monolith.md) and
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29d / PR #333; B-11c29b3 general lookup retirement in PR #334 | Complete residual owners and binders, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29b3 / PR #334; B-11c30 binder/resolver audit in progress | Complete binder families, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -42,10 +42,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 ### Measured Phase B progress
 
 - The Phase A baseline recorded root `nodes.py` at 12,663 lines.
-- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,860
-  lines after B-11c29d.
-- The mechanical extraction has removed 10,803
-  lines, approximately 85.3% of the Phase A baseline, while preserving the root
+- Against the integrated `dev` snapshot above, root `nodes.py` measures 1,850
+  lines after B-11c29b3.
+- The mechanical extraction has removed 10,813
+  lines, approximately 85.4% of the Phase A baseline, while preserving the root
   compatibility surface.
 - B-01 through B-09b2 are integrated. The latest completed implementation slice
   is the AiO generator adapter Move in PR #270.
@@ -96,7 +96,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c29b2 retired only the unsupported loaded-node root lookup in PR #331.
   B-11c29c retired the two pure requirement root helpers together in PR #332.
   B-11c29d retired the pure CLIP invocation root helper in PR #333. B-11c29b3
-  now retires the final general host lookup root wrapper as its own unit.
+  retired the final general host lookup root wrapper in PR #334. B-11c30 now
+  inventories the remaining binder/resolver families without production
+  changes before any cleanup Move starts.
 
 ### Current quality baseline
 
@@ -338,7 +340,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29d CLIP invocation retirement PR #333; B-11c29b3 general lookup retirement in PR #334 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b3 general lookup retirement PR #334; B-11c30 binder/resolver Contract audit in progress | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29b3 / PR #334; B-11c30 binder/resolver audit in progress | Complete binder families, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c29b3 / PR #334; B-11c30 binder/resolver audit in PR #336 | Complete binder families, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -340,7 +340,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b3 general lookup retirement PR #334; B-11c30 binder/resolver Contract audit in progress | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b3 general lookup retirement PR #334; B-11c30 binder/resolver Contract audit in PR #336 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -10,7 +10,7 @@
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
 - Current state: B-11a through B-11c29b3 are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c30 binder/resolver Contract audit is in progress.
+  root shim; B-11c30 binder/resolver Contract audit is in PR #336.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,9 +8,9 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c29d are integrated. B-11c is split into
+- Current state: B-11a through B-11c29b3 are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c29b3 general lookup retirement is in PR #334.
+  root shim; B-11c30 binder/resolver Contract audit is in progress.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -684,6 +684,27 @@ convenience-node compatibility; it remains unmapped and is not public support.
   result, and use-time-only optional dependency behavior remain unchanged.
 - The provider interface, canonical capability helper, six production
   consumers, and their binder-owned runtime state remain unchanged.
+
+### B-11c30 runtime binder/resolver audit
+
+- Production files are unchanged. The machine-readable compatibility surface
+  now records every root binder call, canonical target module, owner family,
+  root keyword, bound global, direct root dependency, string resolver name,
+  provider virtual name, call-time observation mode, and repository replacement
+  file.
+- The exact baseline is 30 binders in five owner families: AiO 12,
+  Image/SAM3/Impact 3, Prompt/Regional 10, Wildcard/NAIA 2, and LoRA 3.
+- Resolution modes are 15 provider-then-root, 13 root-only, and two explicit
+  callback binders. There are 295 unique resolved names: 288 root names and all
+  seven E-07 provider virtual seams.
+- Provider use remains 22 slots in 15 canonical modules. The provider does not
+  accept arbitrary feature names; every non-provider name remains classified
+  as a root compatibility/residual or preamble dependency.
+- Repository tests replace 165 root names in 20 files. This is exact migration
+  impact evidence, not external/public support evidence.
+- Cleanup proceeds by owner family. Image/SAM3/Impact is the first candidate;
+  Prompt/Regional and AiO require further sub-splitting, while Wildcard/NAIA
+  remains separate from D-12 behavior.
 
 ### `nodes.py` public node-class surface
 

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -64,7 +64,8 @@
       "B-11c29b2",
       "B-11c29c",
       "B-11c29d",
-      "B-11c29b3"
+      "B-11c29b3",
+      "B-11c30"
     ]
   },
   "enums": {
@@ -1176,6 +1177,2999 @@
     "wildcard_sources_signature": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.regional_nodes"
+    ]
+  },
+  "runtime_binder_audit": {
+    "summary": {
+      "binder_count": 30,
+      "family_count": 5,
+      "mode_counts": {
+        "comfy_provider_then_root": 15,
+        "root_globals": 13,
+        "explicit_callbacks": 2
+      },
+      "unique_resolver_names": 295,
+      "unique_root_resolver_names": 288,
+      "unique_provider_resolver_names": 7,
+      "unique_direct_root_dependencies": 14,
+      "direct_root_dependency_slots": 32,
+      "provider_consumer_slots": 22,
+      "provider_consumer_modules": 15,
+      "repository_replacement_names": 165,
+      "repository_replacement_files": 20
+    },
+    "families": {
+      "aio": [
+        "_bind_aio_first_pass_cache_runtime",
+        "_bind_aio_legacy_generation_runtime",
+        "_bind_aio_generation_normalization_runtime",
+        "_bind_aio_usdu_planning_runtime",
+        "_bind_aio_postprocess_runtime",
+        "_bind_aio_resource_runtime",
+        "_bind_aio_model_preparation_runtime",
+        "_bind_aio_sampling_runtime",
+        "_bind_aio_preview_runtime",
+        "_bind_aio_output_runtime",
+        "_bind_aio_conditioning_runtime",
+        "_bind_aio_node_runtime"
+      ],
+      "image_sam3_impact": [
+        "_bind_sam3_runtime",
+        "_bind_impact_detailer_node_runtime",
+        "_bind_sam3_node_runtime"
+      ],
+      "prompt_regional": [
+        "_bind_regional_runtime",
+        "_bind_regional_node_runtime",
+        "_bind_advanced_runtime",
+        "_bind_prompt_advanced_node_runtime",
+        "_bind_conditioning_runtime",
+        "_bind_artist_mix_runtime",
+        "_bind_prompt_data_node_runtime",
+        "_bind_prompt_fields_runtime",
+        "_bind_prompt_correction_runtime",
+        "_bind_prompt_node_runtime"
+      ],
+      "wildcard_naia": [
+        "_bind_wildcard_node_runtime",
+        "_bind_naia_node_runtime"
+      ],
+      "lora": [
+        "_bind_lora_metadata_runtime",
+        "_bind_lora_preset_runtime",
+        "_bind_lora_node_runtime"
+      ]
+    },
+    "root_resolver_names": [
+      "AIO_FINAL_FIT_MODES",
+      "AIO_FINAL_UPSCALE_BACKENDS",
+      "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+      "AIO_GENERATION_DEFAULT_SETTINGS",
+      "AIO_GENERATION_SETTINGS_SCHEMA",
+      "AIO_GENERATION_SETTINGS_VERSION",
+      "AIO_INPUT_DEFAULT_SETTINGS",
+      "AIO_PREVIEW_CACHE_FORMAT",
+      "AIO_PREVIEW_CACHE_QUALITY",
+      "AIO_PREVIEW_EVENT",
+      "AIO_PREVIEW_STAGE_LABELS",
+      "AIO_RESHIFT_DTYPES",
+      "AIO_RESHIFT_SCALES",
+      "AIO_SPECIAL_SEEDS",
+      "AIO_SPECIAL_SEED_DECREMENT",
+      "AIO_USDU_MODE_TYPES",
+      "AIO_USDU_PROMPT_FULL",
+      "AIO_USDU_PROMPT_MODES",
+      "AIO_USDU_PROMPT_NO_GENERAL",
+      "AIO_USDU_SEAM_FIX_MODES",
+      "ANIMA_CLIP_DEVICES",
+      "ANIMA_CLIP_TYPES",
+      "ANIMA_DEFAULT_CLIP_CANDIDATES",
+      "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+      "ANIMA_DEFAULT_VAE_CANDIDATES",
+      "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+      "ANIMA_MOD_GUIDANCE_MODES",
+      "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
+      "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+      "ANIMA_UNET_WEIGHT_DTYPES",
+      "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
+      "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
+      "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
+      "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
+      "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
+      "ARTIST_MIX_DEFAULT_START_PERCENT",
+      "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
+      "ARTIST_MIX_DEFAULT_STYLE_GAIN",
+      "ARTIST_MIX_INPUT_MODES",
+      "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
+      "EASY_USE_ANIMA_INPUT_SCHEMA",
+      "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+      "EASY_USE_ANIMA_INPUT_TYPE",
+      "EasyUseAnimaImageScaleByMultiple",
+      "EasyUseAnimaNAIARandomPrompt",
+      "EasyUseAnimaSAM3Detailer",
+      "IMAGE_SCALE_MULTIPLES",
+      "IMAGE_UPSCALE_METHODS",
+      "LATENT_ALIGN",
+      "MAX_SEED",
+      "PROMPT_DATA_TYPE",
+      "SEED_CONTROL_FIXED",
+      "SEED_CONTROL_MODES",
+      "_AIO_DETAILER_CUSTOM_RE",
+      "_AIO_DETAILER_RESERVED_KEYS",
+      "_AIO_FIRST_PASS_CACHE",
+      "_AIO_FIRST_PASS_CACHE_ORDER",
+      "_HASH_COMMENT_RE",
+      "_INLINE_SPACE_RE",
+      "_TRIGGER_WORD_KEYS",
+      "_WEIGHTED_TOKEN_RE",
+      "_adapter_comfy_clip_loader_types",
+      "_adapter_comfy_diffusion_model_names",
+      "_adapter_comfy_text_encoder_names",
+      "_adapter_comfy_vae_names",
+      "_advanced_artist_field_prompt",
+      "_advanced_default_fields",
+      "_advanced_enabled_naia_panes",
+      "_advanced_enabled_pane_fields",
+      "_advanced_field_input_values",
+      "_advanced_field_socket_name",
+      "_advanced_fields_json",
+      "_advanced_has_enabled_naia",
+      "_advanced_outputs_from_prompt_data",
+      "_advanced_prompt_with_artist_override",
+      "_advanced_resolution_from_selection",
+      "_advanced_uses_naia_resolution",
+      "_aio_detailer_has_enabled_targets",
+      "_aio_detailer_target_defaults",
+      "_aio_detailer_target_order",
+      "_aio_final_fit_size",
+      "_aio_first_pass_cache_key",
+      "_aio_generation_settings_json",
+      "_aio_highres_effective_backend",
+      "_aio_image_saver_additional_hashes",
+      "_aio_image_saver_civitai_hash_fetcher_entries",
+      "_aio_input_settings_json",
+      "_aio_lora_metadata_name",
+      "_aio_lora_stack_signature",
+      "_aio_preview_base_directory",
+      "_aio_preview_file_size_bytes",
+      "_aio_prompt_data_fields_for_usdu",
+      "_aio_prompt_with_lora_metadata",
+      "_aio_save_filename_prefix",
+      "_aio_stage_sampler_settings",
+      "_aio_usdu_auto_tile_dimension",
+      "_aio_usdu_conditioning",
+      "_aio_usdu_prompt_without_general",
+      "_aio_usdu_tile_plan",
+      "_align_down",
+      "_align_nearest",
+      "_apply_advanced_field_inputs",
+      "_apply_aio_anima_dave_patch",
+      "_apply_aio_final_fit",
+      "_apply_aio_kj_model_patches",
+      "_apply_aio_lora_stack",
+      "_apply_aio_model_patches",
+      "_apply_aio_safe_pag_patch",
+      "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+      "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+      "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+      "_apply_lora_syntax_format",
+      "_apply_prompt_data_overrides",
+      "_apply_regional_field_inputs",
+      "_apply_spectrum_anima_mod_guidance",
+      "_artist_mix_inline_prompt",
+      "_artist_mix_mode_tooltip",
+      "_artist_prompt_with_position",
+      "_artist_tags_from_prompt",
+      "_as_advanced_height",
+      "_as_bool",
+      "_as_float",
+      "_as_int",
+      "_blend_conditionings",
+      "_bounded_artist_mix_float",
+      "_bounded_artist_mix_int",
+      "_build_advanced_prompt_data",
+      "_build_advanced_prompts",
+      "_build_regional_outputs",
+      "_call_with_supported_kwargs",
+      "_choice",
+      "_cleanup_aio_ephemeral_model",
+      "_clone_advanced_fields",
+      "_clone_aio_cache_value",
+      "_clone_regional_fields",
+      "_comfy_clip_loader_types",
+      "_comfy_diffusion_model_names",
+      "_comfy_sampler_names",
+      "_comfy_scheduler_names",
+      "_comfy_text_encoder_names",
+      "_comfy_vae_names",
+      "_common_upscale_image",
+      "_conditioning_set_values",
+      "_consume_reserved_wildcard_next_seed",
+      "_context_value",
+      "_copy_prompt_data_for_update",
+      "_correct_advanced_field_sequence",
+      "_correct_builder_prompt",
+      "_correct_style_prompt",
+      "_decode_latent_with_comfy",
+      "_dedupe_text_values",
+      "_easy_use_anima_input_signature",
+      "_encode_artist_clustered",
+      "_encode_artist_delta_rms",
+      "_encode_image_with_comfy_vae",
+      "_encode_prompt_data_positive_conditioning",
+      "_expand_advanced_wildcard_fields",
+      "_fallback_lora_path",
+      "_filter_metadata_prompt",
+      "_find_spectrum_anima_mod_guidance_class",
+      "_folder_path_names",
+      "_format_strength",
+      "_generate_empty_latent_with_comfy",
+      "_get_aio_first_pass_cache",
+      "_get_lora_info",
+      "_get_lora_manager_trigger_words",
+      "_get_loras_list",
+      "_get_workflow_node",
+      "_image_tensor_size",
+      "_impact_scheduler_names",
+      "_is_aio_detailer_target_name",
+      "_join_artist_mix_source_prompts",
+      "_join_prompt_tokens",
+      "_json_clone",
+      "_json_object",
+      "_load_aio_resources_from_input_context",
+      "_load_aio_sam3_context",
+      "_load_checkpoint_with_comfy",
+      "_load_clip_with_comfy",
+      "_load_diffusion_model_with_comfy",
+      "_load_lora_manager_metadata",
+      "_load_profile_data",
+      "_load_upscale_model_with_comfy",
+      "_load_vae_with_comfy",
+      "_lora_combo_values",
+      "_lora_manager_trigger_words_from_metadata",
+      "_lora_model_exists",
+      "_lora_stack_name",
+      "_merge_versioned_settings",
+      "_metadata_filter_key",
+      "_metadata_filter_keys",
+      "_metadata_json_paths_for_lora",
+      "_missing_lora_display_name",
+      "_new_aio_random_seed",
+      "_node_output_tuple",
+      "_normalize_advanced_fields",
+      "_normalize_aio_civitai_hash_fetchers",
+      "_normalize_aio_dit_corrections_settings",
+      "_normalize_aio_generation_settings",
+      "_normalize_aio_hash_bundles",
+      "_normalize_aio_input_settings",
+      "_normalize_aio_lora_stack",
+      "_normalize_aio_seed",
+      "_normalize_aio_spectrum_settings",
+      "_normalize_anima_mod_guidance_profile",
+      "_normalize_artist_mix_mode",
+      "_normalize_artist_tag_position",
+      "_normalize_mask_ids",
+      "_normalize_prompt_data",
+      "_normalize_prompt_studio_wildcard_seed_control",
+      "_normalize_regional_config",
+      "_normalize_regional_fields",
+      "_normalize_resolution_bucket",
+      "_parse_artist_mix_items",
+      "_parse_json_object",
+      "_parse_random_response",
+      "_patch_model_sampling_aura_flow",
+      "_post_random",
+      "_preferred_checkpoint_default",
+      "_preferred_clip_type_default",
+      "_preferred_name_default",
+      "_profile_key",
+      "_prompt_data_json_safe",
+      "_prompt_data_parameter_snapshot",
+      "_prompt_tokens",
+      "_prompt_translation_change_key",
+      "_put_aio_first_pass_cache",
+      "_raise_missing_loras",
+      "_ratio_label",
+      "_regional_config_json",
+      "_regional_fields_json",
+      "_regional_mask_bounds_area",
+      "_regional_payload_canvas",
+      "_regional_union_mask_for_ids",
+      "_require_easy_use_anima_input",
+      "_resize_image_to_size_if_needed",
+      "_resolution_label",
+      "_resolve_aio_runtime_seed",
+      "_resolve_anima_mod_guidance_enabled",
+      "_resolve_naia_resolution",
+      "_round_trip_aio_generation_settings",
+      "_run_aio_detailer_stage",
+      "_run_aio_detailer_target",
+      "_run_aio_highres_stage",
+      "_run_aio_legacy_generation",
+      "_run_aio_postprocess_stage",
+      "_run_aio_resshift_upscale_stage",
+      "_run_aio_upscale_stage",
+      "_run_aio_usdu_upscale_stage",
+      "_sam3_context",
+      "_sample_latent_with_aio_backend",
+      "_sample_latent_with_comfy",
+      "_sample_latent_with_spectrum_mod_guidance_advanced",
+      "_sample_latent_with_spectrum_spd",
+      "_save_aio_temp_preview_image",
+      "_save_image_with_comfy",
+      "_save_image_with_image_saver",
+      "_segs_has_items",
+      "_select_profile_values",
+      "_send_aio_preview_event",
+      "_set_naia_field_text",
+      "_single_value",
+      "_split_tag_text",
+      "_stable_change_key",
+      "_tag_aio_preview_images",
+      "_translate_prompt_fields",
+      "_translate_prompt_text",
+      "_trigger_words_from_value",
+      "_wrap_profile_index",
+      "ceil",
+      "correct_prompt",
+      "expand_wildcard_texts",
+      "has_prompt_translation_markers",
+      "has_wildcard_syntax",
+      "json",
+      "load_knowledge_base",
+      "logger",
+      "next_seed",
+      "normalize_prompt_studio_wildcard_mode",
+      "normalize_seed",
+      "parse_prompt",
+      "random",
+      "resolve_metadata_filter_words",
+      "resolve_naia_settings",
+      "resolve_prompt_translation_settings",
+      "sqrt",
+      "translate_prompt_markers",
+      "wildcard_sources_signature"
+    ],
+    "provider_resolver_names": [
+      "_comfy_max_resolution",
+      "_encode_with_comfy_clip",
+      "_find_comfy_node_class",
+      "_find_comfy_node_mapping_class",
+      "_find_loaded_node_class",
+      "_require_any_custom_node_class",
+      "_require_custom_node_class"
+    ],
+    "repository_root_replacements": {
+      "AIO_FIRST_PASS_CACHE_MAX_ENTRIES": [
+        "tests/test_aio_first_pass_cache.py"
+      ],
+      "AIO_GENERATION_DEFAULT_SETTINGS": [
+        "tests/test_aio_output.py",
+        "tests/test_node_contracts.py"
+      ],
+      "AIO_INPUT_DEFAULT_SETTINGS": [
+        "tests/test_node_contracts.py"
+      ],
+      "AIO_PREVIEW_CACHE_FORMAT": [
+        "tests/test_aio_preview.py"
+      ],
+      "AIO_PREVIEW_CACHE_QUALITY": [
+        "tests/test_aio_preview.py"
+      ],
+      "AIO_PREVIEW_EVENT": [
+        "tests/test_aio_preview.py"
+      ],
+      "AIO_SPECIAL_SEEDS": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "AIO_SPECIAL_SEED_DECREMENT": [
+        "tests/test_node_contracts.py"
+      ],
+      "ANIMA_CLIP_DEVICES": [
+        "tests/test_node_contracts.py"
+      ],
+      "ANIMA_CLIP_TYPES": [
+        "tests/test_node_contracts.py"
+      ],
+      "ANIMA_DEFAULT_CLIP_CANDIDATES": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "ANIMA_DEFAULT_VAE_CANDIDATES": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "ANIMA_UNET_WEIGHT_DTYPES": [
+        "tests/test_node_contracts.py"
+      ],
+      "EASY_USE_ANIMA_INPUT_SCHEMA": [
+        "tests/test_node_contracts.py"
+      ],
+      "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION": [
+        "tests/test_node_contracts.py"
+      ],
+      "EASY_USE_ANIMA_INPUT_TYPE": [
+        "tests/test_aio_nodes.py"
+      ],
+      "EasyUseAnimaNAIARandomPrompt": [
+        "tests/test_node_contracts.py"
+      ],
+      "LATENT_ALIGN": [
+        "tests/test_node_contracts.py"
+      ],
+      "MAX_SEED": [
+        "tests/test_node_contracts.py"
+      ],
+      "PROMPT_DATA_TYPE": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_AIO_DETAILER_CUSTOM_RE": [
+        "tests/test_node_contracts.py"
+      ],
+      "_AIO_DETAILER_RESERVED_KEYS": [
+        "tests/test_node_contracts.py"
+      ],
+      "_AIO_FIRST_PASS_CACHE": [
+        "tests/test_aio_first_pass_cache.py"
+      ],
+      "_AIO_FIRST_PASS_CACHE_ORDER": [
+        "tests/test_aio_first_pass_cache.py"
+      ],
+      "_TRIGGER_WORD_KEYS": [
+        "tests/test_lora_preset.py"
+      ],
+      "_adapter_comfy_clip_loader_types": [
+        "tests/test_node_contracts.py"
+      ],
+      "_adapter_comfy_diffusion_model_names": [
+        "tests/test_node_contracts.py"
+      ],
+      "_adapter_comfy_text_encoder_names": [
+        "tests/test_node_contracts.py"
+      ],
+      "_adapter_comfy_vae_names": [
+        "tests/test_node_contracts.py"
+      ],
+      "_advanced_outputs_from_prompt_data": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_aio_detailer_has_enabled_targets": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_aio_detailer_target_order": [
+        "tests/test_node_contracts.py"
+      ],
+      "_aio_final_fit_size": [
+        "tests/test_node_contracts.py"
+      ],
+      "_aio_first_pass_cache_key": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_aio_generation_settings_json": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_aio_highres_effective_backend": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_aio_image_saver_additional_hashes": [
+        "tests/test_aio_output.py"
+      ],
+      "_aio_image_saver_civitai_hash_fetcher_entries": [
+        "tests/test_aio_output.py"
+      ],
+      "_aio_input_settings_json": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_aio_lora_metadata_name": [
+        "tests/test_aio_output.py"
+      ],
+      "_aio_lora_stack_signature": [
+        "tests/test_aio_first_pass_cache.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_aio_preview_base_directory": [
+        "tests/test_aio_preview.py"
+      ],
+      "_aio_preview_file_size_bytes": [
+        "tests/test_aio_preview.py"
+      ],
+      "_aio_prompt_with_lora_metadata": [
+        "tests/test_aio_output.py"
+      ],
+      "_aio_save_filename_prefix": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_aio_usdu_auto_tile_dimension": [
+        "tests/test_node_contracts.py"
+      ],
+      "_aio_usdu_prompt_without_general": [
+        "tests/test_aio_conditioning.py"
+      ],
+      "_align_down": [
+        "tests/test_node_contracts.py"
+      ],
+      "_align_nearest": [
+        "tests/test_node_contracts.py"
+      ],
+      "_apply_aio_anima_dave_patch": [
+        "tests/test_aio_model_preparation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_apply_aio_final_fit": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_apply_aio_kj_model_patches": [
+        "tests/test_aio_model_preparation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_apply_aio_lora_stack": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_apply_aio_model_patches": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_apply_aio_safe_pag_patch": [
+        "tests/test_aio_model_preparation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_apply_aio_spectrum_correction_patch_for_comfy_sampler": [
+        "tests/test_aio_model_preparation.py"
+      ],
+      "_apply_aio_spectrum_forecast_patch_for_comfy_sampler": [
+        "tests/test_aio_model_preparation.py"
+      ],
+      "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_apply_lora_syntax_format": [
+        "tests/test_lora_preset.py"
+      ],
+      "_apply_spectrum_anima_mod_guidance": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_as_bool": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_output.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_as_float": [
+        "tests/test_aio_output.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_as_int": [
+        "tests/test_node_contracts.py"
+      ],
+      "_blend_conditionings": [
+        "tests/test_prompt_corrector.py"
+      ],
+      "_choice": [
+        "tests/test_aio_generation_settings.py",
+        "tests/test_aio_resources.py",
+        "tests/test_aio_schema_contract.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_cleanup_aio_ephemeral_model": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_clone_aio_cache_value": [
+        "tests/test_aio_first_pass_cache.py"
+      ],
+      "_comfy_clip_loader_types": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_comfy_diffusion_model_names": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_comfy_sampler_names": [
+        "tests/test_aio_generation_migrations.py",
+        "tests/test_aio_generation_settings.py",
+        "tests/test_aio_schema_contract.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_comfy_scheduler_names": [
+        "tests/test_aio_generation_migrations.py",
+        "tests/test_aio_generation_settings.py",
+        "tests/test_aio_nodes.py",
+        "tests/test_aio_schema_contract.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_comfy_text_encoder_names": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_comfy_vae_names": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_common_upscale_image": [
+        "tests/test_node_contracts.py"
+      ],
+      "_copy_prompt_data_for_update": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_correct_builder_prompt": [
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_corrector.py"
+      ],
+      "_correct_style_prompt": [
+        "tests/test_lora_preset.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_decode_latent_with_comfy": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_easy_use_anima_input_signature": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_encode_artist_clustered": [
+        "tests/test_prompt_corrector.py"
+      ],
+      "_encode_artist_delta_rms": [
+        "tests/test_prompt_corrector.py"
+      ],
+      "_encode_image_with_comfy_vae": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_encode_prompt_data_positive_conditioning": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_fallback_lora_path": [
+        "tests/test_lora_preset.py"
+      ],
+      "_filter_metadata_prompt": [
+        "tests/test_node_contracts.py"
+      ],
+      "_find_spectrum_anima_mod_guidance_class": [
+        "tests/test_prompt_corrector.py"
+      ],
+      "_folder_path_names": [
+        "tests/test_comfy_adapters.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_format_strength": [
+        "tests/test_aio_output.py"
+      ],
+      "_generate_empty_latent_with_comfy": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py",
+        "tests/test_prompt_corrector.py"
+      ],
+      "_get_aio_first_pass_cache": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_get_lora_info": [
+        "tests/test_lora_preset.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_get_workflow_node": [
+        "tests/test_node_contracts.py"
+      ],
+      "_image_tensor_size": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_preview.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_impact_scheduler_names": [
+        "tests/test_aio_generation_migrations.py",
+        "tests/test_aio_generation_settings.py",
+        "tests/test_aio_schema_contract.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_is_aio_detailer_target_name": [
+        "tests/test_node_contracts.py"
+      ],
+      "_join_prompt_tokens": [
+        "tests/test_node_contracts.py"
+      ],
+      "_json_clone": [
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_load_aio_resources_from_input_context": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_load_aio_sam3_context": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_load_checkpoint_with_comfy": [
+        "tests/test_aio_resources.py",
+        "tests/test_sam3_nodes.py"
+      ],
+      "_load_clip_with_comfy": [
+        "tests/test_aio_resources.py"
+      ],
+      "_load_diffusion_model_with_comfy": [
+        "tests/test_aio_resources.py"
+      ],
+      "_load_upscale_model_with_comfy": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_load_vae_with_comfy": [
+        "tests/test_aio_resources.py"
+      ],
+      "_lora_combo_values": [
+        "tests/test_node_contracts.py"
+      ],
+      "_lora_model_exists": [
+        "tests/test_lora_preset.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_merge_versioned_settings": [
+        "tests/test_node_contracts.py"
+      ],
+      "_new_aio_random_seed": [
+        "tests/test_node_contracts.py"
+      ],
+      "_node_output_tuple": [
+        "tests/test_aio_resources.py"
+      ],
+      "_normalize_aio_generation_settings": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_normalize_aio_hash_bundles": [
+        "tests/test_aio_output.py"
+      ],
+      "_normalize_aio_input_settings": [
+        "tests/test_aio_nodes.py",
+        "tests/test_aio_resources.py"
+      ],
+      "_normalize_aio_lora_stack": [
+        "tests/test_node_contracts.py"
+      ],
+      "_normalize_aio_seed": [
+        "tests/test_node_contracts.py"
+      ],
+      "_normalize_anima_mod_guidance_profile": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_normalize_prompt_data": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_patch_model_sampling_aura_flow": [
+        "tests/test_aio_model_preparation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_post_random": [
+        "tests/test_naia_settings.py",
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_corrector.py"
+      ],
+      "_preferred_clip_type_default": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_preferred_name_default": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_prompt_data_json_safe": [
+        "tests/test_aio_first_pass_cache.py",
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py",
+        "tests/test_aio_preview.py"
+      ],
+      "_prompt_tokens": [
+        "tests/test_node_contracts.py"
+      ],
+      "_prompt_translation_change_key": [
+        "tests/test_node_contracts.py"
+      ],
+      "_put_aio_first_pass_cache": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_require_easy_use_anima_input": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_resize_image_to_size_if_needed": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_resolve_aio_runtime_seed": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py",
+        "tests/test_aio_output.py",
+        "tests/test_aio_sampling.py"
+      ],
+      "_resolve_anima_mod_guidance_enabled": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_run_aio_detailer_stage": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_run_aio_detailer_target": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_run_aio_highres_stage": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_run_aio_legacy_generation": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_run_aio_postprocess_stage": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_run_aio_upscale_stage": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_sam3_context": [
+        "tests/test_aio_resources.py"
+      ],
+      "_sample_latent_with_aio_backend": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_sample_latent_with_comfy": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_sample_latent_with_spectrum_mod_guidance_advanced": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_sample_latent_with_spectrum_spd": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_save_aio_temp_preview_image": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_save_image_with_comfy": [
+        "tests/test_aio_legacy_generation.py"
+      ],
+      "_save_image_with_image_saver": [
+        "tests/test_aio_nodes.py"
+      ],
+      "_send_aio_preview_event": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_nodes.py"
+      ],
+      "_single_value": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_preview.py"
+      ],
+      "_stable_change_key": [
+        "tests/test_aio_first_pass_cache.py",
+        "tests/test_aio_nodes.py",
+        "tests/test_node_contracts.py"
+      ],
+      "_tag_aio_preview_images": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_aio_preview.py"
+      ],
+      "_translate_prompt_text": [
+        "tests/test_node_contracts.py"
+      ],
+      "ceil": [
+        "tests/test_node_contracts.py"
+      ],
+      "correct_prompt": [
+        "tests/test_node_contracts.py"
+      ],
+      "expand_wildcard_texts": [
+        "tests/test_wildcards.py"
+      ],
+      "expand_wildcards": [
+        "tests/test_wildcards.py"
+      ],
+      "has_prompt_translation_markers": [
+        "tests/test_node_contracts.py"
+      ],
+      "json": [
+        "tests/test_node_contracts.py"
+      ],
+      "load_knowledge_base": [
+        "tests/test_node_contracts.py"
+      ],
+      "logger": [
+        "tests/test_node_contracts.py"
+      ],
+      "next_seed": [
+        "tests/test_prompt_studio_regional.py"
+      ],
+      "parse_prompt": [
+        "tests/test_node_contracts.py"
+      ],
+      "random": [
+        "tests/test_aio_legacy_generation.py",
+        "tests/test_node_contracts.py"
+      ],
+      "resolve_metadata_filter_words": [
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_corrector.py"
+      ],
+      "resolve_naia_settings": [
+        "tests/test_naia_settings.py",
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_corrector.py"
+      ],
+      "resolve_prompt_translation_settings": [
+        "tests/test_node_contracts.py",
+        "tests/test_prompt_corrector.py"
+      ],
+      "sqrt": [
+        "tests/test_node_contracts.py"
+      ],
+      "translate_prompt_markers": [
+        "tests/test_node_contracts.py"
+      ],
+      "wildcard_sources_signature": [
+        "tests/test_node_contracts.py"
+      ]
+    },
+    "entries": [
+      {
+        "binder": "_bind_aio_first_pass_cache_runtime",
+        "module": "easyuse_anima.aio.first_pass_cache",
+        "family": "aio",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+          "_AIO_FIRST_PASS_CACHE",
+          "_AIO_FIRST_PASS_CACHE_ORDER",
+          "_aio_lora_stack_signature",
+          "_clone_aio_cache_value",
+          "_prompt_data_json_safe",
+          "_stable_change_key"
+        ],
+        "root_resolver_names": [
+          "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+          "_AIO_FIRST_PASS_CACHE",
+          "_AIO_FIRST_PASS_CACHE_ORDER",
+          "_aio_lora_stack_signature",
+          "_clone_aio_cache_value",
+          "_prompt_data_json_safe",
+          "_stable_change_key"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
+          "_AIO_FIRST_PASS_CACHE",
+          "_AIO_FIRST_PASS_CACHE_ORDER",
+          "_aio_lora_stack_signature",
+          "_clone_aio_cache_value",
+          "_prompt_data_json_safe",
+          "_stable_change_key"
+        ]
+      },
+      {
+        "binder": "_bind_aio_legacy_generation_runtime",
+        "module": "easyuse_anima.aio.legacy_generation",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "AIO_USDU_PROMPT_FULL",
+          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+          "EasyUseAnimaImageScaleByMultiple",
+          "EasyUseAnimaSAM3Detailer",
+          "_advanced_outputs_from_prompt_data",
+          "_aio_detailer_has_enabled_targets",
+          "_aio_detailer_target_order",
+          "_aio_first_pass_cache_key",
+          "_aio_highres_effective_backend",
+          "_aio_save_filename_prefix",
+          "_aio_stage_sampler_settings",
+          "_aio_usdu_conditioning",
+          "_aio_usdu_tile_plan",
+          "_apply_aio_lora_stack",
+          "_apply_aio_model_patches",
+          "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+          "_apply_spectrum_anima_mod_guidance",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_cleanup_aio_ephemeral_model",
+          "_context_value",
+          "_decode_latent_with_comfy",
+          "_encode_image_with_comfy_vae",
+          "_encode_prompt_data_positive_conditioning",
+          "_encode_with_comfy_clip",
+          "_generate_empty_latent_with_comfy",
+          "_get_aio_first_pass_cache",
+          "_image_tensor_size",
+          "_load_aio_resources_from_input_context",
+          "_load_aio_sam3_context",
+          "_load_upscale_model_with_comfy",
+          "_node_output_tuple",
+          "_normalize_aio_generation_settings",
+          "_normalize_anima_mod_guidance_profile",
+          "_normalize_prompt_data",
+          "_prompt_data_json_safe",
+          "_put_aio_first_pass_cache",
+          "_require_custom_node_class",
+          "_require_easy_use_anima_input",
+          "_resize_image_to_size_if_needed",
+          "_resolve_aio_runtime_seed",
+          "_resolve_anima_mod_guidance_enabled",
+          "_run_aio_detailer_stage",
+          "_run_aio_detailer_target",
+          "_run_aio_highres_stage",
+          "_run_aio_postprocess_stage",
+          "_run_aio_resshift_upscale_stage",
+          "_run_aio_upscale_stage",
+          "_run_aio_usdu_upscale_stage",
+          "_sample_latent_with_aio_backend",
+          "_save_aio_temp_preview_image",
+          "_save_image_with_comfy",
+          "_save_image_with_image_saver",
+          "_segs_has_items",
+          "_send_aio_preview_event",
+          "_single_value",
+          "_tag_aio_preview_images",
+          "json",
+          "logger",
+          "random"
+        ],
+        "root_resolver_names": [
+          "AIO_USDU_PROMPT_FULL",
+          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+          "EasyUseAnimaImageScaleByMultiple",
+          "EasyUseAnimaSAM3Detailer",
+          "_advanced_outputs_from_prompt_data",
+          "_aio_detailer_has_enabled_targets",
+          "_aio_detailer_target_order",
+          "_aio_first_pass_cache_key",
+          "_aio_highres_effective_backend",
+          "_aio_save_filename_prefix",
+          "_aio_stage_sampler_settings",
+          "_aio_usdu_conditioning",
+          "_aio_usdu_tile_plan",
+          "_apply_aio_lora_stack",
+          "_apply_aio_model_patches",
+          "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+          "_apply_spectrum_anima_mod_guidance",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_cleanup_aio_ephemeral_model",
+          "_context_value",
+          "_decode_latent_with_comfy",
+          "_encode_image_with_comfy_vae",
+          "_encode_prompt_data_positive_conditioning",
+          "_generate_empty_latent_with_comfy",
+          "_get_aio_first_pass_cache",
+          "_image_tensor_size",
+          "_load_aio_resources_from_input_context",
+          "_load_aio_sam3_context",
+          "_load_upscale_model_with_comfy",
+          "_node_output_tuple",
+          "_normalize_aio_generation_settings",
+          "_normalize_anima_mod_guidance_profile",
+          "_normalize_prompt_data",
+          "_prompt_data_json_safe",
+          "_put_aio_first_pass_cache",
+          "_require_easy_use_anima_input",
+          "_resize_image_to_size_if_needed",
+          "_resolve_aio_runtime_seed",
+          "_resolve_anima_mod_guidance_enabled",
+          "_run_aio_detailer_stage",
+          "_run_aio_detailer_target",
+          "_run_aio_highres_stage",
+          "_run_aio_postprocess_stage",
+          "_run_aio_resshift_upscale_stage",
+          "_run_aio_upscale_stage",
+          "_run_aio_usdu_upscale_stage",
+          "_sample_latent_with_aio_backend",
+          "_save_aio_temp_preview_image",
+          "_save_image_with_comfy",
+          "_save_image_with_image_saver",
+          "_segs_has_items",
+          "_send_aio_preview_event",
+          "_single_value",
+          "_tag_aio_preview_images",
+          "json",
+          "logger",
+          "random"
+        ],
+        "provider_resolver_names": [
+          "_encode_with_comfy_clip",
+          "_require_custom_node_class"
+        ],
+        "repository_replacement_names": [
+          "_advanced_outputs_from_prompt_data",
+          "_aio_detailer_has_enabled_targets",
+          "_aio_detailer_target_order",
+          "_aio_first_pass_cache_key",
+          "_aio_highres_effective_backend",
+          "_aio_save_filename_prefix",
+          "_apply_aio_lora_stack",
+          "_apply_aio_model_patches",
+          "_apply_aio_spectrum_model_patches_for_comfy_sampler",
+          "_apply_spectrum_anima_mod_guidance",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_cleanup_aio_ephemeral_model",
+          "_decode_latent_with_comfy",
+          "_encode_image_with_comfy_vae",
+          "_encode_prompt_data_positive_conditioning",
+          "_generate_empty_latent_with_comfy",
+          "_get_aio_first_pass_cache",
+          "_image_tensor_size",
+          "_load_aio_resources_from_input_context",
+          "_load_aio_sam3_context",
+          "_load_upscale_model_with_comfy",
+          "_node_output_tuple",
+          "_normalize_aio_generation_settings",
+          "_normalize_anima_mod_guidance_profile",
+          "_normalize_prompt_data",
+          "_prompt_data_json_safe",
+          "_put_aio_first_pass_cache",
+          "_require_easy_use_anima_input",
+          "_resize_image_to_size_if_needed",
+          "_resolve_aio_runtime_seed",
+          "_resolve_anima_mod_guidance_enabled",
+          "_run_aio_detailer_stage",
+          "_run_aio_detailer_target",
+          "_run_aio_highres_stage",
+          "_run_aio_postprocess_stage",
+          "_run_aio_upscale_stage",
+          "_sample_latent_with_aio_backend",
+          "_save_aio_temp_preview_image",
+          "_save_image_with_comfy",
+          "_save_image_with_image_saver",
+          "_send_aio_preview_event",
+          "_single_value",
+          "_tag_aio_preview_images",
+          "json",
+          "logger",
+          "random"
+        ]
+      },
+      {
+        "binder": "_bind_aio_generation_normalization_runtime",
+        "module": "easyuse_anima.aio.generation_normalization",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "AIO_FINAL_FIT_MODES",
+          "AIO_FINAL_UPSCALE_BACKENDS",
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "AIO_GENERATION_SETTINGS_SCHEMA",
+          "AIO_GENERATION_SETTINGS_VERSION",
+          "AIO_RESHIFT_DTYPES",
+          "AIO_RESHIFT_SCALES",
+          "AIO_SPECIAL_SEED_DECREMENT",
+          "AIO_USDU_MODE_TYPES",
+          "AIO_USDU_PROMPT_MODES",
+          "AIO_USDU_PROMPT_NO_GENERAL",
+          "AIO_USDU_SEAM_FIX_MODES",
+          "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+          "ANIMA_MOD_GUIDANCE_MODES",
+          "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
+          "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
+          "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
+          "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
+          "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
+          "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
+          "ARTIST_MIX_DEFAULT_START_PERCENT",
+          "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
+          "ARTIST_MIX_DEFAULT_STYLE_GAIN",
+          "ARTIST_MIX_INPUT_MODES",
+          "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
+          "IMAGE_SCALE_MULTIPLES",
+          "IMAGE_UPSCALE_METHODS",
+          "MAX_SEED",
+          "SEED_CONTROL_FIXED",
+          "SEED_CONTROL_MODES",
+          "_AIO_DETAILER_CUSTOM_RE",
+          "_AIO_DETAILER_RESERVED_KEYS",
+          "_aio_detailer_target_defaults",
+          "_aio_detailer_target_order",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_choice",
+          "_comfy_max_resolution",
+          "_comfy_sampler_names",
+          "_comfy_scheduler_names",
+          "_impact_scheduler_names",
+          "_is_aio_detailer_target_name",
+          "_json_clone",
+          "_json_object",
+          "_normalize_aio_civitai_hash_fetchers",
+          "_normalize_aio_dit_corrections_settings",
+          "_normalize_aio_hash_bundles",
+          "_normalize_aio_seed",
+          "_normalize_aio_spectrum_settings",
+          "_normalize_anima_mod_guidance_profile",
+          "_prompt_data_json_safe",
+          "_round_trip_aio_generation_settings"
+        ],
+        "root_resolver_names": [
+          "AIO_FINAL_FIT_MODES",
+          "AIO_FINAL_UPSCALE_BACKENDS",
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "AIO_GENERATION_SETTINGS_SCHEMA",
+          "AIO_GENERATION_SETTINGS_VERSION",
+          "AIO_RESHIFT_DTYPES",
+          "AIO_RESHIFT_SCALES",
+          "AIO_SPECIAL_SEED_DECREMENT",
+          "AIO_USDU_MODE_TYPES",
+          "AIO_USDU_PROMPT_MODES",
+          "AIO_USDU_PROMPT_NO_GENERAL",
+          "AIO_USDU_SEAM_FIX_MODES",
+          "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+          "ANIMA_MOD_GUIDANCE_MODES",
+          "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
+          "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
+          "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
+          "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
+          "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
+          "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
+          "ARTIST_MIX_DEFAULT_START_PERCENT",
+          "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
+          "ARTIST_MIX_DEFAULT_STYLE_GAIN",
+          "ARTIST_MIX_INPUT_MODES",
+          "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
+          "IMAGE_SCALE_MULTIPLES",
+          "IMAGE_UPSCALE_METHODS",
+          "MAX_SEED",
+          "SEED_CONTROL_FIXED",
+          "SEED_CONTROL_MODES",
+          "_AIO_DETAILER_CUSTOM_RE",
+          "_AIO_DETAILER_RESERVED_KEYS",
+          "_aio_detailer_target_defaults",
+          "_aio_detailer_target_order",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_choice",
+          "_comfy_sampler_names",
+          "_comfy_scheduler_names",
+          "_impact_scheduler_names",
+          "_is_aio_detailer_target_name",
+          "_json_clone",
+          "_json_object",
+          "_normalize_aio_civitai_hash_fetchers",
+          "_normalize_aio_dit_corrections_settings",
+          "_normalize_aio_hash_bundles",
+          "_normalize_aio_seed",
+          "_normalize_aio_spectrum_settings",
+          "_normalize_anima_mod_guidance_profile",
+          "_prompt_data_json_safe",
+          "_round_trip_aio_generation_settings"
+        ],
+        "provider_resolver_names": [
+          "_comfy_max_resolution"
+        ],
+        "repository_replacement_names": [
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "AIO_SPECIAL_SEED_DECREMENT",
+          "MAX_SEED",
+          "_AIO_DETAILER_CUSTOM_RE",
+          "_AIO_DETAILER_RESERVED_KEYS",
+          "_aio_detailer_target_order",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_choice",
+          "_comfy_sampler_names",
+          "_comfy_scheduler_names",
+          "_impact_scheduler_names",
+          "_is_aio_detailer_target_name",
+          "_json_clone",
+          "_normalize_aio_hash_bundles",
+          "_normalize_aio_seed",
+          "_normalize_anima_mod_guidance_profile",
+          "_prompt_data_json_safe"
+        ]
+      },
+      {
+        "binder": "_bind_aio_usdu_planning_runtime",
+        "module": "easyuse_anima.aio.usdu",
+        "family": "aio",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "_aio_usdu_auto_tile_dimension",
+          "_align_nearest",
+          "_as_bool",
+          "_as_int",
+          "_image_tensor_size",
+          "ceil"
+        ],
+        "root_resolver_names": [
+          "_aio_usdu_auto_tile_dimension",
+          "_align_nearest",
+          "_as_bool",
+          "_as_int",
+          "_image_tensor_size",
+          "ceil"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_aio_usdu_auto_tile_dimension",
+          "_align_nearest",
+          "_as_bool",
+          "_as_int",
+          "_image_tensor_size",
+          "ceil"
+        ]
+      },
+      {
+        "binder": "_bind_aio_postprocess_runtime",
+        "module": "easyuse_anima.aio.postprocess",
+        "family": "aio",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "LATENT_ALIGN",
+          "_aio_final_fit_size",
+          "_align_down",
+          "_apply_aio_final_fit",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_common_upscale_image",
+          "_image_tensor_size",
+          "_resize_image_to_size_if_needed",
+          "logger",
+          "sqrt"
+        ],
+        "root_resolver_names": [
+          "LATENT_ALIGN",
+          "_aio_final_fit_size",
+          "_align_down",
+          "_apply_aio_final_fit",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_common_upscale_image",
+          "_image_tensor_size",
+          "_resize_image_to_size_if_needed",
+          "logger",
+          "sqrt"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "LATENT_ALIGN",
+          "_aio_final_fit_size",
+          "_align_down",
+          "_apply_aio_final_fit",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_common_upscale_image",
+          "_image_tensor_size",
+          "_resize_image_to_size_if_needed",
+          "logger",
+          "sqrt"
+        ]
+      },
+      {
+        "binder": "_bind_aio_resource_runtime",
+        "module": "easyuse_anima.aio.resources",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "AIO_INPUT_DEFAULT_SETTINGS",
+          "ANIMA_CLIP_DEVICES",
+          "ANIMA_CLIP_TYPES",
+          "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "ANIMA_UNET_WEIGHT_DTYPES",
+          "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "_adapter_comfy_clip_loader_types",
+          "_adapter_comfy_diffusion_model_names",
+          "_adapter_comfy_text_encoder_names",
+          "_adapter_comfy_vae_names",
+          "_as_int",
+          "_choice",
+          "_find_comfy_node_class",
+          "_folder_path_names",
+          "_load_checkpoint_with_comfy",
+          "_load_clip_with_comfy",
+          "_load_diffusion_model_with_comfy",
+          "_load_vae_with_comfy",
+          "_merge_versioned_settings",
+          "_node_output_tuple",
+          "_normalize_aio_input_settings",
+          "_sam3_context"
+        ],
+        "root_resolver_names": [
+          "AIO_INPUT_DEFAULT_SETTINGS",
+          "ANIMA_CLIP_DEVICES",
+          "ANIMA_CLIP_TYPES",
+          "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "ANIMA_UNET_WEIGHT_DTYPES",
+          "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "_adapter_comfy_clip_loader_types",
+          "_adapter_comfy_diffusion_model_names",
+          "_adapter_comfy_text_encoder_names",
+          "_adapter_comfy_vae_names",
+          "_as_int",
+          "_choice",
+          "_folder_path_names",
+          "_load_checkpoint_with_comfy",
+          "_load_clip_with_comfy",
+          "_load_diffusion_model_with_comfy",
+          "_load_vae_with_comfy",
+          "_merge_versioned_settings",
+          "_node_output_tuple",
+          "_normalize_aio_input_settings",
+          "_sam3_context"
+        ],
+        "provider_resolver_names": [
+          "_find_comfy_node_class"
+        ],
+        "repository_replacement_names": [
+          "AIO_INPUT_DEFAULT_SETTINGS",
+          "ANIMA_CLIP_DEVICES",
+          "ANIMA_CLIP_TYPES",
+          "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "ANIMA_UNET_WEIGHT_DTYPES",
+          "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "_adapter_comfy_clip_loader_types",
+          "_adapter_comfy_diffusion_model_names",
+          "_adapter_comfy_text_encoder_names",
+          "_adapter_comfy_vae_names",
+          "_as_int",
+          "_choice",
+          "_folder_path_names",
+          "_load_checkpoint_with_comfy",
+          "_load_clip_with_comfy",
+          "_load_diffusion_model_with_comfy",
+          "_load_vae_with_comfy",
+          "_merge_versioned_settings",
+          "_node_output_tuple",
+          "_normalize_aio_input_settings",
+          "_sam3_context"
+        ]
+      },
+      {
+        "binder": "_bind_aio_model_preparation_runtime",
+        "module": "easyuse_anima.aio.model_preparation",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "_apply_aio_anima_dave_patch",
+          "_apply_aio_kj_model_patches",
+          "_apply_aio_safe_pag_patch",
+          "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+          "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_call_with_supported_kwargs",
+          "_find_comfy_node_class",
+          "_lora_stack_name",
+          "_node_output_tuple",
+          "_normalize_aio_lora_stack",
+          "_patch_model_sampling_aura_flow",
+          "_require_any_custom_node_class",
+          "_require_custom_node_class",
+          "logger"
+        ],
+        "root_resolver_names": [
+          "_apply_aio_anima_dave_patch",
+          "_apply_aio_kj_model_patches",
+          "_apply_aio_safe_pag_patch",
+          "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+          "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_call_with_supported_kwargs",
+          "_lora_stack_name",
+          "_node_output_tuple",
+          "_normalize_aio_lora_stack",
+          "_patch_model_sampling_aura_flow",
+          "logger"
+        ],
+        "provider_resolver_names": [
+          "_find_comfy_node_class",
+          "_require_any_custom_node_class",
+          "_require_custom_node_class"
+        ],
+        "repository_replacement_names": [
+          "_apply_aio_anima_dave_patch",
+          "_apply_aio_kj_model_patches",
+          "_apply_aio_safe_pag_patch",
+          "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
+          "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_node_output_tuple",
+          "_normalize_aio_lora_stack",
+          "_patch_model_sampling_aura_flow",
+          "logger"
+        ]
+      },
+      {
+        "binder": "_bind_aio_sampling_runtime",
+        "module": "easyuse_anima.aio.sampling",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "AIO_SPECIAL_SEEDS",
+          "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+          "MAX_SEED",
+          "SEED_CONTROL_FIXED",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_call_with_supported_kwargs",
+          "_find_comfy_node_class",
+          "_json_clone",
+          "_new_aio_random_seed",
+          "_node_output_tuple",
+          "_normalize_aio_seed",
+          "_normalize_anima_mod_guidance_profile",
+          "_require_custom_node_class",
+          "_resolve_aio_runtime_seed",
+          "_sample_latent_with_comfy",
+          "_sample_latent_with_spectrum_mod_guidance_advanced",
+          "_sample_latent_with_spectrum_spd",
+          "random"
+        ],
+        "root_resolver_names": [
+          "AIO_SPECIAL_SEEDS",
+          "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
+          "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
+          "MAX_SEED",
+          "SEED_CONTROL_FIXED",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_call_with_supported_kwargs",
+          "_json_clone",
+          "_new_aio_random_seed",
+          "_node_output_tuple",
+          "_normalize_aio_seed",
+          "_normalize_anima_mod_guidance_profile",
+          "_resolve_aio_runtime_seed",
+          "_sample_latent_with_comfy",
+          "_sample_latent_with_spectrum_mod_guidance_advanced",
+          "_sample_latent_with_spectrum_spd",
+          "random"
+        ],
+        "provider_resolver_names": [
+          "_find_comfy_node_class",
+          "_require_custom_node_class"
+        ],
+        "repository_replacement_names": [
+          "AIO_SPECIAL_SEEDS",
+          "MAX_SEED",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_json_clone",
+          "_new_aio_random_seed",
+          "_node_output_tuple",
+          "_normalize_aio_seed",
+          "_normalize_anima_mod_guidance_profile",
+          "_resolve_aio_runtime_seed",
+          "_sample_latent_with_comfy",
+          "_sample_latent_with_spectrum_mod_guidance_advanced",
+          "_sample_latent_with_spectrum_spd",
+          "random"
+        ]
+      },
+      {
+        "binder": "_bind_aio_preview_runtime",
+        "module": "easyuse_anima.aio.preview",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "AIO_PREVIEW_CACHE_FORMAT",
+          "AIO_PREVIEW_CACHE_QUALITY",
+          "AIO_PREVIEW_EVENT",
+          "AIO_PREVIEW_STAGE_LABELS",
+          "_aio_preview_base_directory",
+          "_aio_preview_file_size_bytes",
+          "_find_comfy_node_class",
+          "_image_tensor_size",
+          "_prompt_data_json_safe",
+          "_single_value",
+          "_tag_aio_preview_images",
+          "logger"
+        ],
+        "root_resolver_names": [
+          "AIO_PREVIEW_CACHE_FORMAT",
+          "AIO_PREVIEW_CACHE_QUALITY",
+          "AIO_PREVIEW_EVENT",
+          "AIO_PREVIEW_STAGE_LABELS",
+          "_aio_preview_base_directory",
+          "_aio_preview_file_size_bytes",
+          "_image_tensor_size",
+          "_prompt_data_json_safe",
+          "_single_value",
+          "_tag_aio_preview_images",
+          "logger"
+        ],
+        "provider_resolver_names": [
+          "_find_comfy_node_class"
+        ],
+        "repository_replacement_names": [
+          "AIO_PREVIEW_CACHE_FORMAT",
+          "AIO_PREVIEW_CACHE_QUALITY",
+          "AIO_PREVIEW_EVENT",
+          "_aio_preview_base_directory",
+          "_aio_preview_file_size_bytes",
+          "_image_tensor_size",
+          "_prompt_data_json_safe",
+          "_single_value",
+          "_tag_aio_preview_images",
+          "logger"
+        ]
+      },
+      {
+        "binder": "_bind_aio_output_runtime",
+        "module": "easyuse_anima.aio.output",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "_aio_image_saver_additional_hashes",
+          "_aio_image_saver_civitai_hash_fetcher_entries",
+          "_aio_lora_metadata_name",
+          "_aio_prompt_with_lora_metadata",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_find_comfy_node_class",
+          "_format_strength",
+          "_normalize_aio_civitai_hash_fetchers",
+          "_normalize_aio_hash_bundles",
+          "_require_custom_node_class",
+          "_resolve_aio_runtime_seed",
+          "_single_value",
+          "logger"
+        ],
+        "root_resolver_names": [
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "_aio_image_saver_additional_hashes",
+          "_aio_image_saver_civitai_hash_fetcher_entries",
+          "_aio_lora_metadata_name",
+          "_aio_prompt_with_lora_metadata",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_format_strength",
+          "_normalize_aio_civitai_hash_fetchers",
+          "_normalize_aio_hash_bundles",
+          "_resolve_aio_runtime_seed",
+          "_single_value",
+          "logger"
+        ],
+        "provider_resolver_names": [
+          "_find_comfy_node_class",
+          "_require_custom_node_class"
+        ],
+        "repository_replacement_names": [
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "_aio_image_saver_additional_hashes",
+          "_aio_image_saver_civitai_hash_fetcher_entries",
+          "_aio_lora_metadata_name",
+          "_aio_prompt_with_lora_metadata",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_format_strength",
+          "_normalize_aio_hash_bundles",
+          "_resolve_aio_runtime_seed",
+          "_single_value",
+          "logger"
+        ]
+      },
+      {
+        "binder": "_bind_aio_conditioning_runtime",
+        "module": "easyuse_anima.aio.conditioning",
+        "family": "aio",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "AIO_USDU_PROMPT_FULL",
+          "AIO_USDU_PROMPT_NO_GENERAL",
+          "_advanced_artist_field_prompt",
+          "_advanced_enabled_pane_fields",
+          "_aio_prompt_data_fields_for_usdu",
+          "_aio_usdu_prompt_without_general",
+          "_as_bool",
+          "_correct_advanced_field_sequence",
+          "_encode_with_comfy_clip",
+          "_normalize_advanced_fields",
+          "_normalize_prompt_data"
+        ],
+        "root_resolver_names": [
+          "AIO_USDU_PROMPT_FULL",
+          "AIO_USDU_PROMPT_NO_GENERAL",
+          "_advanced_artist_field_prompt",
+          "_advanced_enabled_pane_fields",
+          "_aio_prompt_data_fields_for_usdu",
+          "_aio_usdu_prompt_without_general",
+          "_as_bool",
+          "_correct_advanced_field_sequence",
+          "_normalize_advanced_fields",
+          "_normalize_prompt_data"
+        ],
+        "provider_resolver_names": [
+          "_encode_with_comfy_clip"
+        ],
+        "repository_replacement_names": [
+          "_aio_usdu_prompt_without_general",
+          "_as_bool",
+          "_normalize_prompt_data"
+        ]
+      },
+      {
+        "binder": "_bind_sam3_runtime",
+        "module": "easyuse_anima.image.sam3",
+        "family": "image_sam3_impact",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_find_comfy_node_class",
+          "_find_comfy_node_mapping_class"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "_find_comfy_node_class",
+          "_find_comfy_node_mapping_class"
+        ],
+        "root_resolver_names": [],
+        "provider_resolver_names": [
+          "_find_comfy_node_class",
+          "_find_comfy_node_mapping_class"
+        ],
+        "repository_replacement_names": []
+      },
+      {
+        "binder": "_bind_impact_detailer_node_runtime",
+        "module": "easyuse_anima.nodes.impact_detailer_nodes",
+        "family": "image_sam3_impact",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_comfy_max_resolution",
+          "_impact_scheduler_names"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "_comfy_max_resolution",
+          "_impact_scheduler_names"
+        ],
+        "root_resolver_names": [
+          "_impact_scheduler_names"
+        ],
+        "provider_resolver_names": [
+          "_comfy_max_resolution"
+        ],
+        "repository_replacement_names": [
+          "_impact_scheduler_names"
+        ]
+      },
+      {
+        "binder": "_bind_sam3_node_runtime",
+        "module": "easyuse_anima.nodes.sam3_nodes",
+        "family": "image_sam3_impact",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_comfy_max_resolution",
+          "_encode_with_comfy_clip",
+          "_load_checkpoint_with_comfy",
+          "_preferred_checkpoint_default"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "_comfy_max_resolution",
+          "_encode_with_comfy_clip",
+          "_load_checkpoint_with_comfy",
+          "_preferred_checkpoint_default"
+        ],
+        "root_resolver_names": [
+          "_load_checkpoint_with_comfy",
+          "_preferred_checkpoint_default"
+        ],
+        "provider_resolver_names": [
+          "_comfy_max_resolution",
+          "_encode_with_comfy_clip"
+        ],
+        "repository_replacement_names": [
+          "_load_checkpoint_with_comfy"
+        ]
+      },
+      {
+        "binder": "_bind_regional_runtime",
+        "module": "easyuse_anima.prompt.regional",
+        "family": "prompt_regional",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_advanced_default_fields",
+          "_advanced_field_input_values",
+          "_advanced_field_socket_name",
+          "_as_advanced_height",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_correct_advanced_field_sequence",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_ratio_label",
+          "_single_value",
+          "resolve_metadata_filter_words"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "_advanced_default_fields",
+          "_advanced_field_input_values",
+          "_advanced_field_socket_name",
+          "_as_advanced_height",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_correct_advanced_field_sequence",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_ratio_label",
+          "_single_value",
+          "resolve_metadata_filter_words"
+        ],
+        "root_resolver_names": [
+          "_advanced_default_fields",
+          "_advanced_field_input_values",
+          "_advanced_field_socket_name",
+          "_as_advanced_height",
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_correct_advanced_field_sequence",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_ratio_label",
+          "_single_value",
+          "resolve_metadata_filter_words"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_as_bool",
+          "_as_float",
+          "_as_int",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_single_value",
+          "resolve_metadata_filter_words"
+        ]
+      },
+      {
+        "binder": "_bind_regional_node_runtime",
+        "module": "easyuse_anima.nodes.regional_nodes",
+        "family": "prompt_regional",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "flexible_optional_input_type",
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_FlexibleOptionalInputType",
+          "_advanced_field_input_values",
+          "_advanced_resolution_from_selection",
+          "_apply_regional_field_inputs",
+          "_as_bool",
+          "_as_float",
+          "_build_regional_outputs",
+          "_clone_regional_fields",
+          "_conditioning_set_values",
+          "_consume_reserved_wildcard_next_seed",
+          "_encode_with_comfy_clip",
+          "_expand_advanced_wildcard_fields",
+          "_get_workflow_node",
+          "_normalize_mask_ids",
+          "_normalize_prompt_studio_wildcard_seed_control",
+          "_normalize_regional_config",
+          "_normalize_regional_fields",
+          "_parse_json_object",
+          "_prompt_translation_change_key",
+          "_regional_config_json",
+          "_regional_fields_json",
+          "_regional_mask_bounds_area",
+          "_regional_payload_canvas",
+          "_regional_union_mask_for_ids",
+          "_single_value",
+          "_stable_change_key",
+          "_translate_prompt_fields",
+          "next_seed",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words",
+          "wildcard_sources_signature"
+        ],
+        "direct_root_dependencies": [
+          "_FlexibleOptionalInputType",
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "_advanced_field_input_values",
+          "_advanced_resolution_from_selection",
+          "_apply_regional_field_inputs",
+          "_as_bool",
+          "_as_float",
+          "_build_regional_outputs",
+          "_clone_regional_fields",
+          "_conditioning_set_values",
+          "_consume_reserved_wildcard_next_seed",
+          "_encode_with_comfy_clip",
+          "_expand_advanced_wildcard_fields",
+          "_get_workflow_node",
+          "_normalize_mask_ids",
+          "_normalize_prompt_studio_wildcard_seed_control",
+          "_normalize_regional_config",
+          "_normalize_regional_fields",
+          "_parse_json_object",
+          "_prompt_translation_change_key",
+          "_regional_config_json",
+          "_regional_fields_json",
+          "_regional_mask_bounds_area",
+          "_regional_payload_canvas",
+          "_regional_union_mask_for_ids",
+          "_single_value",
+          "_stable_change_key",
+          "_translate_prompt_fields",
+          "next_seed",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words",
+          "wildcard_sources_signature"
+        ],
+        "root_resolver_names": [
+          "_advanced_field_input_values",
+          "_advanced_resolution_from_selection",
+          "_apply_regional_field_inputs",
+          "_as_bool",
+          "_as_float",
+          "_build_regional_outputs",
+          "_clone_regional_fields",
+          "_conditioning_set_values",
+          "_consume_reserved_wildcard_next_seed",
+          "_expand_advanced_wildcard_fields",
+          "_get_workflow_node",
+          "_normalize_mask_ids",
+          "_normalize_prompt_studio_wildcard_seed_control",
+          "_normalize_regional_config",
+          "_normalize_regional_fields",
+          "_parse_json_object",
+          "_prompt_translation_change_key",
+          "_regional_config_json",
+          "_regional_fields_json",
+          "_regional_mask_bounds_area",
+          "_regional_payload_canvas",
+          "_regional_union_mask_for_ids",
+          "_single_value",
+          "_stable_change_key",
+          "_translate_prompt_fields",
+          "next_seed",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words",
+          "wildcard_sources_signature"
+        ],
+        "provider_resolver_names": [
+          "_encode_with_comfy_clip"
+        ],
+        "repository_replacement_names": [
+          "_as_bool",
+          "_as_float",
+          "_get_workflow_node",
+          "_prompt_translation_change_key",
+          "_single_value",
+          "_stable_change_key",
+          "next_seed",
+          "resolve_metadata_filter_words",
+          "wildcard_sources_signature"
+        ]
+      },
+      {
+        "binder": "_bind_advanced_runtime",
+        "module": "easyuse_anima.prompt.advanced",
+        "family": "prompt_regional",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "_artist_mix_inline_prompt",
+          "_artist_tags_from_prompt",
+          "_as_bool",
+          "_as_int",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_correct_builder_prompt",
+          "_filter_metadata_prompt",
+          "_join_artist_mix_source_prompts",
+          "_join_prompt_tokens",
+          "_normalize_artist_mix_mode",
+          "_normalize_resolution_bucket",
+          "_parse_artist_mix_items",
+          "_single_value",
+          "_translate_prompt_text",
+          "expand_wildcard_texts",
+          "has_prompt_translation_markers",
+          "has_wildcard_syntax",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words"
+        ],
+        "root_resolver_names": [
+          "_artist_mix_inline_prompt",
+          "_artist_tags_from_prompt",
+          "_as_bool",
+          "_as_int",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_correct_builder_prompt",
+          "_filter_metadata_prompt",
+          "_join_artist_mix_source_prompts",
+          "_join_prompt_tokens",
+          "_normalize_artist_mix_mode",
+          "_normalize_resolution_bucket",
+          "_parse_artist_mix_items",
+          "_single_value",
+          "_translate_prompt_text",
+          "expand_wildcard_texts",
+          "has_prompt_translation_markers",
+          "has_wildcard_syntax",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_as_bool",
+          "_as_int",
+          "_correct_builder_prompt",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_single_value",
+          "_translate_prompt_text",
+          "expand_wildcard_texts",
+          "has_prompt_translation_markers",
+          "resolve_metadata_filter_words"
+        ]
+      },
+      {
+        "binder": "_bind_prompt_advanced_node_runtime",
+        "module": "easyuse_anima.nodes.prompt_advanced_nodes",
+        "family": "prompt_regional",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "flexible_optional_input_type",
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_FlexibleOptionalInputType",
+          "_RUNTIME_RESOLVER",
+          "_advanced_enabled_naia_panes",
+          "_advanced_field_input_values",
+          "_advanced_fields_json",
+          "_advanced_has_enabled_naia",
+          "_advanced_resolution_from_selection",
+          "_advanced_uses_naia_resolution",
+          "_apply_advanced_field_inputs",
+          "_artist_mix_mode_tooltip",
+          "_as_bool",
+          "_as_int",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_build_advanced_prompt_data",
+          "_build_advanced_prompts",
+          "_clone_advanced_fields",
+          "_consume_reserved_wildcard_next_seed",
+          "_expand_advanced_wildcard_fields",
+          "_get_workflow_node",
+          "_normalize_advanced_fields",
+          "_normalize_artist_mix_mode",
+          "_normalize_prompt_studio_wildcard_seed_control",
+          "_parse_random_response",
+          "_post_random",
+          "_prompt_data_parameter_snapshot",
+          "_prompt_translation_change_key",
+          "_resolution_label",
+          "_resolve_naia_resolution",
+          "_set_naia_field_text",
+          "_single_value",
+          "_stable_change_key",
+          "_translate_prompt_fields",
+          "_translate_prompt_text",
+          "next_seed",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words",
+          "resolve_naia_settings",
+          "wildcard_sources_signature"
+        ],
+        "direct_root_dependencies": [
+          "_FlexibleOptionalInputType"
+        ],
+        "resolver_names": [
+          "EasyUseAnimaNAIARandomPrompt",
+          "_advanced_enabled_naia_panes",
+          "_advanced_field_input_values",
+          "_advanced_fields_json",
+          "_advanced_has_enabled_naia",
+          "_advanced_resolution_from_selection",
+          "_advanced_uses_naia_resolution",
+          "_apply_advanced_field_inputs",
+          "_artist_mix_mode_tooltip",
+          "_as_bool",
+          "_as_int",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_build_advanced_prompt_data",
+          "_build_advanced_prompts",
+          "_clone_advanced_fields",
+          "_consume_reserved_wildcard_next_seed",
+          "_expand_advanced_wildcard_fields",
+          "_get_workflow_node",
+          "_normalize_advanced_fields",
+          "_normalize_artist_mix_mode",
+          "_normalize_prompt_studio_wildcard_seed_control",
+          "_parse_random_response",
+          "_post_random",
+          "_prompt_data_parameter_snapshot",
+          "_prompt_translation_change_key",
+          "_resolution_label",
+          "_resolve_naia_resolution",
+          "_set_naia_field_text",
+          "_single_value",
+          "_stable_change_key",
+          "_translate_prompt_fields",
+          "_translate_prompt_text",
+          "next_seed",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words",
+          "resolve_naia_settings",
+          "wildcard_sources_signature"
+        ],
+        "root_resolver_names": [
+          "EasyUseAnimaNAIARandomPrompt",
+          "_advanced_enabled_naia_panes",
+          "_advanced_field_input_values",
+          "_advanced_fields_json",
+          "_advanced_has_enabled_naia",
+          "_advanced_resolution_from_selection",
+          "_advanced_uses_naia_resolution",
+          "_apply_advanced_field_inputs",
+          "_artist_mix_mode_tooltip",
+          "_as_bool",
+          "_as_int",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_build_advanced_prompt_data",
+          "_build_advanced_prompts",
+          "_clone_advanced_fields",
+          "_consume_reserved_wildcard_next_seed",
+          "_expand_advanced_wildcard_fields",
+          "_get_workflow_node",
+          "_normalize_advanced_fields",
+          "_normalize_artist_mix_mode",
+          "_normalize_prompt_studio_wildcard_seed_control",
+          "_parse_random_response",
+          "_post_random",
+          "_prompt_data_parameter_snapshot",
+          "_prompt_translation_change_key",
+          "_resolution_label",
+          "_resolve_naia_resolution",
+          "_set_naia_field_text",
+          "_single_value",
+          "_stable_change_key",
+          "_translate_prompt_fields",
+          "_translate_prompt_text",
+          "next_seed",
+          "normalize_prompt_studio_wildcard_mode",
+          "normalize_seed",
+          "resolve_metadata_filter_words",
+          "resolve_naia_settings",
+          "wildcard_sources_signature"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "EasyUseAnimaNAIARandomPrompt",
+          "_as_bool",
+          "_as_int",
+          "_get_workflow_node",
+          "_post_random",
+          "_prompt_translation_change_key",
+          "_single_value",
+          "_stable_change_key",
+          "_translate_prompt_text",
+          "next_seed",
+          "resolve_metadata_filter_words",
+          "resolve_naia_settings",
+          "wildcard_sources_signature"
+        ]
+      },
+      {
+        "binder": "_bind_aio_node_runtime",
+        "module": "easyuse_anima.nodes.aio_nodes",
+        "family": "aio",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "AIO_INPUT_DEFAULT_SETTINGS",
+          "AIO_SPECIAL_SEEDS",
+          "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "EASY_USE_ANIMA_INPUT_TYPE",
+          "PROMPT_DATA_TYPE",
+          "_aio_generation_settings_json",
+          "_aio_input_settings_json",
+          "_aio_lora_stack_signature",
+          "_comfy_clip_loader_types",
+          "_comfy_diffusion_model_names",
+          "_comfy_text_encoder_names",
+          "_comfy_vae_names",
+          "_copy_prompt_data_for_update",
+          "_easy_use_anima_input_signature",
+          "_json_clone",
+          "_normalize_aio_generation_settings",
+          "_normalize_aio_input_settings",
+          "_normalize_prompt_data",
+          "_preferred_clip_type_default",
+          "_preferred_name_default",
+          "_prompt_data_json_safe",
+          "_resolve_aio_runtime_seed",
+          "_run_aio_legacy_generation",
+          "_stable_change_key",
+          "json"
+        ],
+        "root_resolver_names": [
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "AIO_INPUT_DEFAULT_SETTINGS",
+          "AIO_SPECIAL_SEEDS",
+          "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "EASY_USE_ANIMA_INPUT_TYPE",
+          "PROMPT_DATA_TYPE",
+          "_aio_generation_settings_json",
+          "_aio_input_settings_json",
+          "_aio_lora_stack_signature",
+          "_comfy_clip_loader_types",
+          "_comfy_diffusion_model_names",
+          "_comfy_text_encoder_names",
+          "_comfy_vae_names",
+          "_copy_prompt_data_for_update",
+          "_easy_use_anima_input_signature",
+          "_json_clone",
+          "_normalize_aio_generation_settings",
+          "_normalize_aio_input_settings",
+          "_normalize_prompt_data",
+          "_preferred_clip_type_default",
+          "_preferred_name_default",
+          "_prompt_data_json_safe",
+          "_resolve_aio_runtime_seed",
+          "_run_aio_legacy_generation",
+          "_stable_change_key",
+          "json"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "AIO_GENERATION_DEFAULT_SETTINGS",
+          "AIO_INPUT_DEFAULT_SETTINGS",
+          "AIO_SPECIAL_SEEDS",
+          "ANIMA_DEFAULT_CLIP_CANDIDATES",
+          "ANIMA_DEFAULT_DIFFUSION_MODEL_CANDIDATES",
+          "ANIMA_DEFAULT_VAE_CANDIDATES",
+          "EASY_USE_ANIMA_INPUT_SCHEMA",
+          "EASY_USE_ANIMA_INPUT_SETTINGS_VERSION",
+          "EASY_USE_ANIMA_INPUT_TYPE",
+          "PROMPT_DATA_TYPE",
+          "_aio_generation_settings_json",
+          "_aio_input_settings_json",
+          "_aio_lora_stack_signature",
+          "_comfy_clip_loader_types",
+          "_comfy_diffusion_model_names",
+          "_comfy_text_encoder_names",
+          "_comfy_vae_names",
+          "_copy_prompt_data_for_update",
+          "_easy_use_anima_input_signature",
+          "_json_clone",
+          "_normalize_aio_generation_settings",
+          "_normalize_aio_input_settings",
+          "_normalize_prompt_data",
+          "_preferred_clip_type_default",
+          "_preferred_name_default",
+          "_prompt_data_json_safe",
+          "_resolve_aio_runtime_seed",
+          "_run_aio_legacy_generation",
+          "_stable_change_key",
+          "json"
+        ]
+      },
+      {
+        "binder": "_bind_conditioning_runtime",
+        "module": "easyuse_anima.prompt.conditioning",
+        "family": "prompt_regional",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper",
+          "resolve_logger"
+        ],
+        "bound_globals": [
+          "_RUNTIME_LOGGER_RESOLVER",
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper",
+          "logger"
+        ],
+        "resolver_names": [
+          "_find_loaded_node_class",
+          "_find_spectrum_anima_mod_guidance_class"
+        ],
+        "root_resolver_names": [
+          "_find_spectrum_anima_mod_guidance_class"
+        ],
+        "provider_resolver_names": [
+          "_find_loaded_node_class"
+        ],
+        "repository_replacement_names": [
+          "_find_spectrum_anima_mod_guidance_class",
+          "logger"
+        ]
+      },
+      {
+        "binder": "_bind_artist_mix_runtime",
+        "module": "easyuse_anima.prompt.artist_mix",
+        "family": "prompt_regional",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "_advanced_enabled_pane_fields",
+          "_advanced_prompt_with_artist_override",
+          "_blend_conditionings",
+          "_correct_builder_prompt",
+          "_encode_artist_clustered",
+          "_encode_artist_delta_rms",
+          "_encode_with_comfy_clip",
+          "_join_prompt_tokens",
+          "_normalize_advanced_fields"
+        ],
+        "root_resolver_names": [
+          "_advanced_enabled_pane_fields",
+          "_advanced_prompt_with_artist_override",
+          "_blend_conditionings",
+          "_correct_builder_prompt",
+          "_encode_artist_clustered",
+          "_encode_artist_delta_rms",
+          "_join_prompt_tokens",
+          "_normalize_advanced_fields"
+        ],
+        "provider_resolver_names": [
+          "_encode_with_comfy_clip"
+        ],
+        "repository_replacement_names": [
+          "_blend_conditionings",
+          "_correct_builder_prompt",
+          "_encode_artist_clustered",
+          "_encode_artist_delta_rms",
+          "_join_prompt_tokens"
+        ]
+      },
+      {
+        "binder": "_bind_prompt_data_node_runtime",
+        "module": "easyuse_anima.nodes.prompt_data_nodes",
+        "family": "prompt_regional",
+        "mode": "comfy_provider_then_root",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_RESOLVER"
+        ],
+        "direct_root_dependencies": [
+          "_resolve_comfy_host_helper"
+        ],
+        "resolver_names": [
+          "_advanced_outputs_from_prompt_data",
+          "_apply_prompt_data_overrides",
+          "_apply_spectrum_anima_mod_guidance",
+          "_artist_mix_inline_prompt",
+          "_artist_mix_mode_tooltip",
+          "_artist_prompt_with_position",
+          "_as_bool",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_encode_prompt_data_positive_conditioning",
+          "_encode_with_comfy_clip",
+          "_generate_empty_latent_with_comfy",
+          "_join_artist_mix_source_prompts",
+          "_join_prompt_tokens",
+          "_normalize_anima_mod_guidance_profile",
+          "_normalize_artist_mix_mode",
+          "_normalize_artist_tag_position",
+          "_normalize_prompt_data",
+          "_resolve_anima_mod_guidance_enabled",
+          "_stable_change_key"
+        ],
+        "root_resolver_names": [
+          "_advanced_outputs_from_prompt_data",
+          "_apply_prompt_data_overrides",
+          "_apply_spectrum_anima_mod_guidance",
+          "_artist_mix_inline_prompt",
+          "_artist_mix_mode_tooltip",
+          "_artist_prompt_with_position",
+          "_as_bool",
+          "_bounded_artist_mix_float",
+          "_bounded_artist_mix_int",
+          "_encode_prompt_data_positive_conditioning",
+          "_generate_empty_latent_with_comfy",
+          "_join_artist_mix_source_prompts",
+          "_join_prompt_tokens",
+          "_normalize_anima_mod_guidance_profile",
+          "_normalize_artist_mix_mode",
+          "_normalize_artist_tag_position",
+          "_normalize_prompt_data",
+          "_resolve_anima_mod_guidance_enabled",
+          "_stable_change_key"
+        ],
+        "provider_resolver_names": [
+          "_encode_with_comfy_clip"
+        ],
+        "repository_replacement_names": [
+          "_advanced_outputs_from_prompt_data",
+          "_apply_spectrum_anima_mod_guidance",
+          "_as_bool",
+          "_encode_prompt_data_positive_conditioning",
+          "_generate_empty_latent_with_comfy",
+          "_join_prompt_tokens",
+          "_normalize_anima_mod_guidance_profile",
+          "_normalize_prompt_data",
+          "_resolve_anima_mod_guidance_enabled",
+          "_stable_change_key"
+        ]
+      },
+      {
+        "binder": "_bind_prompt_fields_runtime",
+        "module": "easyuse_anima.prompt.fields",
+        "family": "prompt_regional",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_RUNTIME_HELPER_RESOLVER"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "_HASH_COMMENT_RE",
+          "_INLINE_SPACE_RE",
+          "_WEIGHTED_TOKEN_RE",
+          "_metadata_filter_key",
+          "_metadata_filter_keys",
+          "_prompt_tokens",
+          "correct_prompt",
+          "load_knowledge_base",
+          "parse_prompt"
+        ],
+        "root_resolver_names": [
+          "_HASH_COMMENT_RE",
+          "_INLINE_SPACE_RE",
+          "_WEIGHTED_TOKEN_RE",
+          "_metadata_filter_key",
+          "_metadata_filter_keys",
+          "_prompt_tokens",
+          "correct_prompt",
+          "load_knowledge_base",
+          "parse_prompt"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_prompt_tokens",
+          "correct_prompt",
+          "load_knowledge_base",
+          "parse_prompt"
+        ]
+      },
+      {
+        "binder": "_bind_prompt_correction_runtime",
+        "module": "easyuse_anima.prompt.correction",
+        "family": "prompt_regional",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "has_prompt_translation_markers",
+          "resolve_prompt_translation_settings",
+          "translate_prompt_markers"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "has_prompt_translation_markers",
+          "resolve_prompt_translation_settings",
+          "translate_prompt_markers"
+        ],
+        "root_resolver_names": [
+          "has_prompt_translation_markers",
+          "resolve_prompt_translation_settings",
+          "translate_prompt_markers"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "has_prompt_translation_markers",
+          "resolve_prompt_translation_settings",
+          "translate_prompt_markers"
+        ]
+      },
+      {
+        "binder": "_bind_prompt_node_runtime",
+        "module": "easyuse_anima.nodes.prompt_nodes",
+        "family": "prompt_regional",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_as_bool",
+          "_correct_builder_prompt",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_prompt_translation_change_key",
+          "_split_tag_text",
+          "_stable_change_key",
+          "_translate_prompt_text",
+          "correct_prompt",
+          "load_knowledge_base",
+          "resolve_metadata_filter_words"
+        ],
+        "direct_root_dependencies": [],
+        "resolver_names": [
+          "_as_bool",
+          "_correct_builder_prompt",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_prompt_translation_change_key",
+          "_split_tag_text",
+          "_stable_change_key",
+          "_translate_prompt_text",
+          "correct_prompt",
+          "load_knowledge_base",
+          "resolve_metadata_filter_words"
+        ],
+        "root_resolver_names": [
+          "_as_bool",
+          "_correct_builder_prompt",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_prompt_translation_change_key",
+          "_split_tag_text",
+          "_stable_change_key",
+          "_translate_prompt_text",
+          "correct_prompt",
+          "load_knowledge_base",
+          "resolve_metadata_filter_words"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_as_bool",
+          "_correct_builder_prompt",
+          "_filter_metadata_prompt",
+          "_join_prompt_tokens",
+          "_prompt_translation_change_key",
+          "_stable_change_key",
+          "_translate_prompt_text",
+          "correct_prompt",
+          "load_knowledge_base",
+          "resolve_metadata_filter_words"
+        ]
+      },
+      {
+        "binder": "_bind_wildcard_node_runtime",
+        "module": "easyuse_anima.nodes.wildcard_nodes",
+        "family": "wildcard_naia",
+        "mode": "explicit_callbacks",
+        "root_observation": "call_time_callback",
+        "root_keywords": [
+          "expand",
+          "get_workflow_node",
+          "normalize_mode",
+          "normalize_seed_value",
+          "sources_signature"
+        ],
+        "bound_globals": [
+          "_get_workflow_node",
+          "expand_wildcards",
+          "normalize_seed",
+          "normalize_wildcard_mode",
+          "wildcard_sources_signature"
+        ],
+        "direct_root_dependencies": [
+          "_get_workflow_node",
+          "expand_wildcards",
+          "normalize_seed",
+          "normalize_wildcard_mode",
+          "wildcard_sources_signature"
+        ],
+        "resolver_names": [],
+        "root_resolver_names": [],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_get_workflow_node",
+          "expand_wildcards",
+          "wildcard_sources_signature"
+        ]
+      },
+      {
+        "binder": "_bind_naia_node_runtime",
+        "module": "easyuse_anima.nodes.naia_nodes",
+        "family": "wildcard_naia",
+        "mode": "explicit_callbacks",
+        "root_observation": "call_time_callback",
+        "root_keywords": [
+          "get_workflow_node",
+          "parse_random_response",
+          "post_random",
+          "resolve_settings"
+        ],
+        "bound_globals": [
+          "_get_workflow_node",
+          "_parse_random_response",
+          "_post_random",
+          "resolve_naia_settings"
+        ],
+        "direct_root_dependencies": [
+          "_get_workflow_node",
+          "_parse_random_response",
+          "_post_random",
+          "resolve_naia_settings"
+        ],
+        "resolver_names": [],
+        "root_resolver_names": [],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_get_workflow_node",
+          "_post_random",
+          "resolve_naia_settings"
+        ]
+      },
+      {
+        "binder": "_bind_lora_metadata_runtime",
+        "module": "easyuse_anima.lora.metadata",
+        "family": "lora",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "prompt_tokens",
+          "resolve_helper",
+          "resolve_logger"
+        ],
+        "bound_globals": [
+          "_prompt_tokens",
+          "_resolve_helper",
+          "logger"
+        ],
+        "direct_root_dependencies": [
+          "_prompt_tokens",
+          "logger"
+        ],
+        "resolver_names": [
+          "_TRIGGER_WORD_KEYS",
+          "_dedupe_text_values",
+          "_fallback_lora_path",
+          "_get_lora_manager_trigger_words",
+          "_load_lora_manager_metadata",
+          "_lora_manager_trigger_words_from_metadata",
+          "_metadata_json_paths_for_lora",
+          "_trigger_words_from_value"
+        ],
+        "root_resolver_names": [
+          "_TRIGGER_WORD_KEYS",
+          "_dedupe_text_values",
+          "_fallback_lora_path",
+          "_get_lora_manager_trigger_words",
+          "_load_lora_manager_metadata",
+          "_lora_manager_trigger_words_from_metadata",
+          "_metadata_json_paths_for_lora",
+          "_trigger_words_from_value"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_TRIGGER_WORD_KEYS",
+          "_fallback_lora_path",
+          "_prompt_tokens",
+          "logger"
+        ]
+      },
+      {
+        "binder": "_bind_lora_preset_runtime",
+        "module": "easyuse_anima.lora.preset",
+        "family": "lora",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "correct_builder_prompt",
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_correct_builder_prompt",
+          "_resolve_helper"
+        ],
+        "direct_root_dependencies": [
+          "_correct_builder_prompt"
+        ],
+        "resolver_names": [
+          "_as_int",
+          "_get_loras_list",
+          "_load_profile_data",
+          "_profile_key",
+          "_wrap_profile_index"
+        ],
+        "root_resolver_names": [
+          "_as_int",
+          "_get_loras_list",
+          "_load_profile_data",
+          "_profile_key",
+          "_wrap_profile_index"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_as_int",
+          "_correct_builder_prompt"
+        ]
+      },
+      {
+        "binder": "_bind_lora_node_runtime",
+        "module": "easyuse_anima.nodes.lora_nodes",
+        "family": "lora",
+        "mode": "root_globals",
+        "root_observation": "call_time_resolver",
+        "root_keywords": [
+          "any_type",
+          "flexible_optional_input_type",
+          "resolve_helper"
+        ],
+        "bound_globals": [
+          "_ANY_TYPE",
+          "_FlexibleOptionalInputType",
+          "_apply_lora_syntax_format",
+          "_as_bool",
+          "_correct_style_prompt",
+          "_format_strength",
+          "_get_lora_info",
+          "_lora_combo_values",
+          "_lora_model_exists",
+          "_lora_stack_name",
+          "_missing_lora_display_name",
+          "_raise_missing_loras",
+          "_select_profile_values",
+          "_stable_change_key"
+        ],
+        "direct_root_dependencies": [
+          "_ANY_TYPE",
+          "_FlexibleOptionalInputType"
+        ],
+        "resolver_names": [
+          "_apply_lora_syntax_format",
+          "_as_bool",
+          "_correct_style_prompt",
+          "_format_strength",
+          "_get_lora_info",
+          "_lora_combo_values",
+          "_lora_model_exists",
+          "_lora_stack_name",
+          "_missing_lora_display_name",
+          "_raise_missing_loras",
+          "_select_profile_values",
+          "_stable_change_key"
+        ],
+        "root_resolver_names": [
+          "_apply_lora_syntax_format",
+          "_as_bool",
+          "_correct_style_prompt",
+          "_format_strength",
+          "_get_lora_info",
+          "_lora_combo_values",
+          "_lora_model_exists",
+          "_lora_stack_name",
+          "_missing_lora_display_name",
+          "_raise_missing_loras",
+          "_select_profile_values",
+          "_stable_change_key"
+        ],
+        "provider_resolver_names": [],
+        "repository_replacement_names": [
+          "_apply_lora_syntax_format",
+          "_as_bool",
+          "_correct_style_prompt",
+          "_format_strength",
+          "_get_lora_info",
+          "_lora_combo_values",
+          "_lora_model_exists",
+          "_stable_change_key"
+        ]
+      }
     ]
   },
   "documented_transitional_aliases": {

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -38,6 +38,13 @@ COMFY_HOST_CLASSIFICATIONS = (
     "supported_public",
 )
 COMFY_HOST_ROOT_TEST_ALIASES = {"easy_nodes", "nodes", "root_module"}
+ROOT_COMPAT_TEST_ALIASES = {
+    "easy_nodes",
+    "nodes",
+    "nodes_module",
+    "package_nodes",
+    "root_module",
+}
 CLASSIFICATIONS = (
     "permanent_entrypoint",
     "supported_public_reexport",
@@ -74,6 +81,48 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "logging": "logging:logging",
     "random": "random:random",
     "sqrt": "math:sqrt",
+}
+RUNTIME_BINDER_FAMILIES = {
+    "aio": (
+        "_bind_aio_first_pass_cache_runtime",
+        "_bind_aio_legacy_generation_runtime",
+        "_bind_aio_generation_normalization_runtime",
+        "_bind_aio_usdu_planning_runtime",
+        "_bind_aio_postprocess_runtime",
+        "_bind_aio_resource_runtime",
+        "_bind_aio_model_preparation_runtime",
+        "_bind_aio_sampling_runtime",
+        "_bind_aio_preview_runtime",
+        "_bind_aio_output_runtime",
+        "_bind_aio_conditioning_runtime",
+        "_bind_aio_node_runtime",
+    ),
+    "image_sam3_impact": (
+        "_bind_sam3_runtime",
+        "_bind_impact_detailer_node_runtime",
+        "_bind_sam3_node_runtime",
+    ),
+    "prompt_regional": (
+        "_bind_regional_runtime",
+        "_bind_regional_node_runtime",
+        "_bind_advanced_runtime",
+        "_bind_prompt_advanced_node_runtime",
+        "_bind_conditioning_runtime",
+        "_bind_artist_mix_runtime",
+        "_bind_prompt_data_node_runtime",
+        "_bind_prompt_fields_runtime",
+        "_bind_prompt_correction_runtime",
+        "_bind_prompt_node_runtime",
+    ),
+    "wildcard_naia": (
+        "_bind_wildcard_node_runtime",
+        "_bind_naia_node_runtime",
+    ),
+    "lora": (
+        "_bind_lora_metadata_runtime",
+        "_bind_lora_preset_runtime",
+        "_bind_lora_node_runtime",
+    ),
 }
 RETIRED_ARTIST_MIX_MODE_BINDINGS = (
     "ARTIST_MIX_CONTROL_KEY",
@@ -903,7 +952,10 @@ def _module_path(module: str) -> Path:
     raise AssertionError(f"canonical runtime binder module is missing: {module}")
 
 
-def _resolver_names_from_module(module: str, available: set[str]) -> set[str]:
+def _resolver_names_from_module(
+    module: str,
+    available: set[str] | None,
+) -> set[str]:
     tree = _read_tree(_module_path(module))
     names: set[str] = set()
     assignment_values: dict[str, ast.AST] = {}
@@ -952,7 +1004,7 @@ def _resolver_names_from_module(module: str, available: set[str]) -> set[str]:
                 for value in ast.walk(assigned)
                 if isinstance(value, ast.Constant) and isinstance(value.value, str)
             )
-    return names.intersection(available)
+    return names if available is None else names.intersection(available)
 
 
 def _runtime_resolver_consumers(
@@ -967,6 +1019,21 @@ def _runtime_resolver_consumers(
     return {
         name: sorted(modules)
         for name, modules in sorted(consumers.items())
+    }
+
+
+def _direct_runtime_lookup_names(module: str) -> set[str]:
+    tree = _read_tree(_module_path(module))
+    return {
+        node.args[0].value
+        for node in ast.walk(tree)
+        if (
+            isinstance(node, ast.Call)
+            and node.args
+            and _call_name(node.func) in RUNTIME_LOOKUP_CALLS | {"resolve_helper"}
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        )
     }
 
 
@@ -1348,6 +1415,338 @@ def _runtime_binders(tree: ast.Module) -> list[str]:
     return binders
 
 
+def _runtime_binder_call_modes(tree: ast.Module) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        if not (
+            isinstance(call.func, ast.Name)
+            and call.func.id.startswith("_bind_")
+            and call.func.id.endswith("_runtime")
+        ):
+            continue
+        keywords = {
+            keyword.arg: keyword.value
+            for keyword in call.keywords
+            if keyword.arg is not None
+        }
+        resolver = keywords.get("resolve_helper")
+        if resolver is None:
+            mode = "explicit_callbacks"
+        elif any(
+            isinstance(value, ast.Name)
+            and value.id == "_resolve_comfy_host_helper"
+            for value in ast.walk(resolver)
+        ):
+            mode = "comfy_provider_then_root"
+        elif any(
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "globals"
+            for value in ast.walk(resolver)
+        ):
+            mode = "root_globals"
+        else:
+            raise AssertionError(
+                f"unknown runtime binder resolver mode: {call.func.id}"
+            )
+        result[call.func.id] = {
+            "mode": mode,
+            "root_keywords": sorted(keywords),
+            "root_name_candidates": sorted(
+                {
+                    value.id
+                    for keyword_value in keywords.values()
+                    for value in ast.walk(keyword_value)
+                    if isinstance(value, ast.Name)
+                    and isinstance(value.ctx, ast.Load)
+                }
+            ),
+        }
+    return result
+
+
+def _binder_global_names(module: str, binder_name: str) -> list[str]:
+    tree = _read_tree(_module_path(module))
+    binders = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == binder_name
+    ]
+    if len(binders) != 1:
+        raise AssertionError(f"{module}:{binder_name} must have exactly one binder")
+    module_globals = {
+        target.id
+        for node in tree.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        for target in (
+            node.targets
+            if isinstance(node, ast.Assign)
+            else [node.target]
+        )
+        if isinstance(target, ast.Name)
+    }
+    return sorted(
+        {
+            name
+            for node in ast.walk(binders[0])
+            if isinstance(node, ast.Global)
+            for name in node.names
+        }
+        | {
+            node.value
+            for node in ast.walk(binders[0])
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and node.value in module_globals
+            )
+        }
+    )
+
+
+def _repository_root_replacements(
+    symbols: set[str],
+) -> dict[str, list[str]]:
+    consumers: dict[str, set[str]] = defaultdict(set)
+    for path in sorted((ROOT / "tests").glob("test_*.py")):
+        tree = _read_tree(path)
+        relative = path.relative_to(ROOT).as_posix()
+        literal_dicts: dict[str, set[str]] = defaultdict(set)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if not isinstance(node.value, ast.Dict):
+                continue
+            names = {
+                key.value
+                for key in node.value.keys
+                if (
+                    isinstance(key, ast.Constant)
+                    and isinstance(key.value, str)
+                    and key.value in symbols
+                )
+            }
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    literal_dicts[target.id].update(names)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if (
+                    isinstance(node.func, ast.Name)
+                    and node.func.id == "patch"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)
+                    and node.args[0].value.startswith("nodes.")
+                ):
+                    name = node.args[0].value.rsplit(".", 1)[-1]
+                    if name in symbols:
+                        consumers[name].add(relative)
+                if (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "object"
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "patch"
+                    and len(node.args) >= 2
+                    and ast.unparse(node.args[0]) in ROOT_COMPAT_TEST_ALIASES
+                    and isinstance(node.args[1], ast.Constant)
+                    and node.args[1].value in symbols
+                ):
+                    consumers[node.args[1].value].add(relative)
+                if (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "multiple"
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "patch"
+                    and node.args
+                    and ast.unparse(node.args[0]) in ROOT_COMPAT_TEST_ALIASES
+                ):
+                    names = {
+                        keyword.arg
+                        for keyword in node.keywords
+                        if keyword.arg in symbols
+                    }
+                    for keyword in node.keywords:
+                        if keyword.arg is not None:
+                            continue
+                        if isinstance(keyword.value, ast.Name):
+                            names.update(literal_dicts[keyword.value.id])
+                        elif isinstance(keyword.value, ast.Dict):
+                            names.update(
+                                key.value
+                                for key in keyword.value.keys
+                                if (
+                                    isinstance(key, ast.Constant)
+                                    and isinstance(key.value, str)
+                                    and key.value in symbols
+                                )
+                            )
+                    for name in names:
+                        consumers[name].add(relative)
+                if (
+                    isinstance(node.func, ast.Name)
+                    and node.func.id == "setattr"
+                    and len(node.args) >= 2
+                    and ast.unparse(node.args[0]) in ROOT_COMPAT_TEST_ALIASES
+                    and isinstance(node.args[1], ast.Constant)
+                    and node.args[1].value in symbols
+                ):
+                    consumers[node.args[1].value].add(relative)
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and ast.unparse(target.value) in ROOT_COMPAT_TEST_ALIASES
+                    and target.attr in symbols
+                ):
+                    consumers[target.attr].add(relative)
+    return {
+        symbol: sorted(paths)
+        for symbol, paths in sorted(consumers.items())
+        if paths
+    }
+
+
+def _runtime_binder_audit(
+    tree: ast.Module,
+    canonical_bindings: dict[str, str],
+    legacy_bindings: dict[str, str],
+    residuals: dict[str, list[str]],
+) -> dict[str, Any]:
+    binders = _runtime_binders(tree)
+    targets = _runtime_binder_targets(tree, canonical_bindings)
+    call_modes = _runtime_binder_call_modes(tree)
+    family_by_binder = {
+        binder: family
+        for family, family_binders in RUNTIME_BINDER_FAMILIES.items()
+        for binder in family_binders
+    }
+    if set(family_by_binder) != set(binders):
+        raise AssertionError("runtime binder family classification is incomplete")
+    if set(targets) != set(binders) or set(call_modes) != set(binders):
+        raise AssertionError("runtime binder target/call inventory is incomplete")
+
+    root_names = set(canonical_bindings) | set(legacy_bindings)
+    root_names.update(PREAMBLE_IMPLEMENTATION_BINDINGS)
+    for names in residuals.values():
+        root_names.update(names)
+    provider_names = set(COMFY_HOST_WRAPPERS)
+    valid_resolver_names = root_names | provider_names
+    all_root_replacements = _repository_root_replacements(root_names)
+    entries = []
+    all_resolver_names: set[str] = set()
+    all_root_names: set[str] = set()
+    all_provider_names: set[str] = set()
+    all_direct_root_dependencies: set[str] = set()
+    for binder in binders:
+        module = targets[binder]
+        direct_names = _direct_runtime_lookup_names(module)
+        unknown_direct_names = direct_names - valid_resolver_names
+        if unknown_direct_names:
+            raise AssertionError(
+                f"{binder} has unknown direct resolver names: "
+                + ", ".join(sorted(unknown_direct_names))
+            )
+        resolver_names = _resolver_names_from_module(module, valid_resolver_names)
+        classified_root = resolver_names.intersection(root_names)
+        classified_provider = resolver_names.intersection(provider_names)
+        all_resolver_names.update(resolver_names)
+        all_root_names.update(classified_root)
+        all_provider_names.update(classified_provider)
+        direct_root_dependencies = root_names.intersection(
+            call_modes[binder]["root_name_candidates"]
+        )
+        all_direct_root_dependencies.update(direct_root_dependencies)
+        entries.append(
+            {
+                "binder": binder,
+                "module": module,
+                "family": family_by_binder[binder],
+                "mode": call_modes[binder]["mode"],
+                "root_observation": (
+                    "call_time_callback"
+                    if call_modes[binder]["mode"] == "explicit_callbacks"
+                    else "call_time_resolver"
+                ),
+                "root_keywords": call_modes[binder]["root_keywords"],
+                "bound_globals": _binder_global_names(module, binder),
+                "direct_root_dependencies": sorted(direct_root_dependencies),
+                "resolver_names": sorted(resolver_names),
+                "root_resolver_names": sorted(classified_root),
+                "provider_resolver_names": sorted(classified_provider),
+            }
+        )
+
+    binder_root_names = all_root_names | all_direct_root_dependencies
+    root_replacements = {
+        symbol: paths
+        for symbol, paths in all_root_replacements.items()
+        if symbol in binder_root_names
+    }
+    for entry in entries:
+        entry["repository_replacement_names"] = sorted(
+            (
+                set(entry["root_resolver_names"])
+                | set(entry["direct_root_dependencies"])
+            ).intersection(root_replacements)
+        )
+
+    mode_counts = {
+        mode: sum(entry["mode"] == mode for entry in entries)
+        for mode in (
+            "comfy_provider_then_root",
+            "root_globals",
+            "explicit_callbacks",
+        )
+    }
+    return {
+        "summary": {
+            "binder_count": len(entries),
+            "family_count": len(RUNTIME_BINDER_FAMILIES),
+            "mode_counts": mode_counts,
+            "unique_resolver_names": len(all_resolver_names),
+            "unique_root_resolver_names": len(all_root_names),
+            "unique_provider_resolver_names": len(all_provider_names),
+            "unique_direct_root_dependencies": len(
+                all_direct_root_dependencies
+            ),
+            "direct_root_dependency_slots": sum(
+                len(entry["direct_root_dependencies"]) for entry in entries
+            ),
+            "provider_consumer_slots": sum(
+                len(entry["provider_resolver_names"]) for entry in entries
+            ),
+            "provider_consumer_modules": sum(
+                bool(entry["provider_resolver_names"]) for entry in entries
+            ),
+            "repository_replacement_names": len(root_replacements),
+            "repository_replacement_files": len(
+                {
+                    path
+                    for paths in root_replacements.values()
+                    for path in paths
+                }
+            ),
+        },
+        "families": {
+            family: list(family_binders)
+            for family, family_binders in RUNTIME_BINDER_FAMILIES.items()
+        },
+        "root_resolver_names": sorted(all_root_names),
+        "provider_resolver_names": sorted(all_provider_names),
+        "repository_root_replacements": root_replacements,
+        "entries": entries,
+    }
+
+
 def _direct_nodes_import_test_files() -> list[str]:
     consumers = []
     for path in sorted((ROOT / "tests").glob("test_*.py")):
@@ -1553,6 +1952,12 @@ def _build_document() -> dict[str, Any]:
         relative,
         available,
     )
+    runtime_binder_audit = _runtime_binder_audit(
+        nodes_tree,
+        relative,
+        relative_legacy,
+        residuals,
+    )
 
     missing_documented_aliases = set(DOCUMENTED_TRANSITIONAL_ALIASES) - available
     if missing_documented_aliases:
@@ -1698,6 +2103,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c29c",
                 "B-11c29d",
                 "B-11c29b3",
+                "B-11c30",
             ],
         },
         "enums": {
@@ -1725,6 +2131,7 @@ def _build_document() -> dict[str, Any]:
         "excluded_preamble_implementation_bindings": preamble_bindings,
         "runtime_binders": _runtime_binders(nodes_tree),
         "runtime_resolver_consumers": runtime_resolver_consumers,
+        "runtime_binder_audit": runtime_binder_audit,
         "documented_transitional_aliases": DOCUMENTED_TRANSITIONAL_ALIASES,
         "retired_private_bindings": RETIRED_PRIVATE_BINDINGS,
         "direct_nodes_import_test_files": _direct_nodes_import_test_files(),
@@ -1950,6 +2357,87 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         )
         self.assertEqual(len(set(self.document["runtime_binders"])), 30)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
+
+    def test_runtime_binder_audit_covers_provider_and_root_names(self):
+        audit = self.document["runtime_binder_audit"]
+        self.assertEqual(
+            audit["summary"],
+            {
+                "binder_count": 30,
+                "family_count": 5,
+                "mode_counts": {
+                    "comfy_provider_then_root": 15,
+                    "root_globals": 13,
+                    "explicit_callbacks": 2,
+                },
+                "unique_resolver_names": 295,
+                "unique_root_resolver_names": 288,
+                "unique_provider_resolver_names": 7,
+                "unique_direct_root_dependencies": 14,
+                "direct_root_dependency_slots": 32,
+                "provider_consumer_slots": 22,
+                "provider_consumer_modules": 15,
+                "repository_replacement_names": 165,
+                "repository_replacement_files": 20,
+            },
+        )
+        self.assertEqual(
+            audit["provider_resolver_names"],
+            sorted(COMFY_HOST_WRAPPERS),
+        )
+        self.assertEqual(
+            set(audit["root_resolver_names"])
+            - set(self.document["runtime_resolver_consumers"]),
+            {"ceil", "json", "random", "sqrt"},
+        )
+        self.assertTrue(
+            set(self.document["runtime_resolver_consumers"]).issubset(
+                audit["root_resolver_names"]
+            )
+        )
+        self.assertEqual(
+            {entry["binder"] for entry in audit["entries"]},
+            set(self.document["runtime_binders"]),
+        )
+        self.assertEqual(
+            audit["families"],
+            {
+                family: list(binders)
+                for family, binders in RUNTIME_BINDER_FAMILIES.items()
+            },
+        )
+        self.assertEqual(
+            set(audit["repository_root_replacements"]),
+            {
+                name
+                for entry in audit["entries"]
+                for name in entry["repository_replacement_names"]
+            },
+        )
+        for paths in audit["repository_root_replacements"].values():
+            self.assertTrue(paths)
+            self.assertTrue(all(path.startswith("tests/") for path in paths))
+        for entry in audit["entries"]:
+            self.assertTrue(entry["bound_globals"])
+            self.assertEqual(
+                set(entry["resolver_names"]),
+                set(entry["root_resolver_names"])
+                | set(entry["provider_resolver_names"]),
+            )
+            if entry["mode"] == "explicit_callbacks":
+                self.assertNotIn("resolve_helper", entry["root_keywords"])
+                self.assertEqual(entry["resolver_names"], [])
+                self.assertTrue(entry["direct_root_dependencies"])
+                self.assertEqual(
+                    entry["root_observation"],
+                    "call_time_callback",
+                )
+            else:
+                self.assertIn("resolve_helper", entry["root_keywords"])
+                self.assertEqual(
+                    entry["root_observation"],
+                    "call_time_resolver",
+                )
 
     def test_string_runtime_resolvers_keep_production_seams_transitional(self):
         representative = {


### PR DESCRIPTION
## 분류

- Task: B-11c30
- Owner: #184 / #188
- Type: Contract/gate
- Base: `dev@53d92aa944663a18ee593c027b90fa0b8e9444be`
- 검증 head: `de007388fb9a60065341f2fa7003a537d9105806`
- Production changes: 없음
- Move/Behavior: 포함하지 않음

## 작업 전 symbol/caller/alias/global-state inventory

- root `nodes.py`의 canonical `_bind_*_runtime` 호출: 30개
- owner family:
  - AiO 12
  - Image/SAM3/Impact 3
  - Prompt/Regional 10
  - Wildcard/NAIA 2
  - LoRA 3
- resolver mode:
  - provider-aware resolver → root fallback 15
  - root `globals()` resolver 13
  - explicit root callback 2
- 고유 lookup 이름: 295
  - current root 이름 288
  - E-07 provider virtual seam 7
- 288개 root 이름 구성:
  - compatibility/residual resolver 284
  - preamble dependency `ceil`, `json`, `random`, `sqrt`
- provider consumer: 22 slot / 15 canonical module
- binder direct root dependency: 14개 고유 / 32 slot
- repository root replacement: 165개 이름 / 20개 test file
  - 이는 test 이관 비용 증거이며 supported-public evidence가 아님
- string resolver는 call-time root lookup을 유지
- explicit callback binder는 root-calling closure를 받아 use-time target
  observation을 유지
- binder-owned module global state는 entry별 exact 목록으로 기록

## 변경

- 기존 compatibility fixture에 `runtime_binder_audit`를 추가했습니다.
- binder별 canonical module, family, mode, root keyword, bound global, direct
  dependency, root/provider resolver name, repository replacement file을
  machine-readable하게 기록합니다.
- unknown direct resolver, returned/new provider virtual seam, family 누락,
  count drift를 실패시키는 gate를 추가했습니다.
- B-11c29b3 완료 상태와 B-11c30 후속 family 순서를 로드맵에 반영했습니다.

## Allowed boundary

- `tests/test_python_compatibility_surface.py`
- `tests/fixtures/python_compatibility_surface.v1.json`
- `docs/architecture/*`

## 금지 경계 확인

- `nodes.py`, binder, runtime consumer, provider, wiring 변경 없음
- schema/workflow/seed/stage/cache/route/persistence/optional dependency 변경
  없음
- repository test replacement을 public compatibility로 승격하지 않음
- alias 삭제/test 이관/cleanup Move 포함하지 않음
- 여러 owner family를 한 cleanup PR로 합치지 않음

## 후속 Move 경계

1. B-11c30a Image/SAM3/Impact 3개 binder
2. B-11c30b LoRA 3개 binder
3. B-11c30c Prompt/Regional 10개 binder — service/adapter로 추가 분할
4. B-11c30d AiO 12개 binder — support/service/adapter로 추가 분할
5. B-11c30e Wildcard/NAIA explicit callbacks — D-12 Behavior와 분리

첫 후보는 provider-bearing family 중 가장 작은 Image/SAM3/Impact입니다.

## 검증

- focused compatibility surface: 20 tests passed
- `git diff --check`: passed
- official full:
  - `tools/check_custom_node.ps1 -Project <absolute PR worktree> -Profile full`
  - Python 964 tests passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline, G-03 import boundary 6 groups, diff check passed
  - Ruff 113 existing findings, report-only
- package/Registry pack: production/package surface 변경이 없어 생략
- live ComfyUI smoke: production 변경이 없어 생략

## 남은 위험

- repository replacement detector는 현재 root test alias와
  `patch`/`patch.object`/`patch.multiple`/`setattr`/direct assignment 형태를
  gate로 고정합니다. 새로운 patch 형태는 detector 확장 없이 자동
  분류되지 않습니다.
- 이 PR은 다음 Move를 승인하는 inventory이며 실제 binder retirement
  correctness를 대신하지 않습니다.

Closes no issue. Parent: #184. Quality owner: #188.
