### PR TITLE
B-11c30a: retire Image/SAM3/Impact runtime binders

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1009,7 +1009,7 @@ Forbidden:
 
 ### B-11c30 — Runtime binder/resolver migration audit
 
-- **State:** IN PROGRESS in PR #336
+- **State:** COMPLETE on `dev` in PR #336 / `02b8c4a`
 - **Owner:** #184/#188
 - **Type:** Contract/gate
 - **Production changes:** none
@@ -1090,6 +1090,72 @@ Planned cleanup sequence:
    slots in one PR.
 5. **B-11c30e Wildcard/NAIA:** two explicit-callback binders; keep separate from
    D-12 seed/Wildcard behavior and legacy engine consolidation.
+
+### B-11c30a — Image/SAM3/Impact binder retirement
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Type:** Move
+- **Base:** `dev@02b8c4a17b11011f1381c27cef6bd869b50f81bb`
+
+Pre-edit inventory:
+
+- root `nodes.py` imports three private binders in both package and flat-import
+  paths, then calls each binder once during module initialization:
+  `_bind_sam3_runtime`, `_bind_impact_detailer_node_runtime`, and
+  `_bind_sam3_node_runtime`;
+- those binders install eight canonical module globals: two SAM3 discovery
+  helpers, two Impact node input helpers, and four SAM3 node input/execution
+  helpers;
+- five slots are E-07 provider decisions:
+  `_find_comfy_node_class`, `_find_comfy_node_mapping_class`,
+  `_comfy_max_resolution` in two modules, and `_encode_with_comfy_clip`;
+- three slots are existing canonical root-name helpers:
+  `_impact_scheduler_names`, `_load_checkpoint_with_comfy`, and
+  `_preferred_checkpoint_default`;
+- all three root calls depend directly on `_resolve_comfy_host_helper`;
+- the consumers are SAM3 optional-node discovery, Impact Detailer input
+  construction, SAM3 context input/loading, and SAM3 prompt encoding;
+- repository tests replace two names that occur in this family,
+  `_impact_scheduler_names` and `_load_checkpoint_with_comfy`. This is test
+  migration evidence, not public root compatibility;
+- the binders mutate canonical module globals once at root import, while each
+  installed closure resolves its actual target at call time; and
+- the root aliases for the three non-provider helpers remain required by other
+  owner families and are not retirement targets in this lane.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/image/sam3.py
+easyuse_anima/nodes/impact_detailer_nodes.py
+easyuse_anima/nodes/sam3_nodes.py
+```
+
+Allowed supporting files are the focused SAM3/node-contract tests, the Python
+compatibility gate and fixture, and these architecture documents.
+
+Exit:
+
+- root no longer imports or calls the three family binders;
+- the canonical modules own their provider and direct-helper wiring without
+  importing root `nodes.py`;
+- E-07 provider decisions remain call-time and flat pre-bootstrap imports keep
+  the default-provider fallback;
+- the three non-provider targets keep their current canonical implementation,
+  return identity, exceptions, and call timing;
+- no bind-time mutable runtime installation remains in these three modules; and
+- node schema, workflow, SAM3/Impact behavior, optional dependency timing, and
+  public mappings remain unchanged.
+
+Forbidden:
+
+- changing provider protocol or lifecycle, detection/detailing behavior,
+  checkpoint semantics, input defaults, schemas, workflows, seed/stage/cache,
+  dependency discovery, or error text;
+- removing root aliases still consumed by AiO or another binder family; and
+- including LoRA, Prompt/Regional, AiO, or Wildcard/NAIA binder cleanup.
 
 ### B-11d — Final root shim
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1093,7 +1093,7 @@ Planned cleanup sequence:
 
 ### B-11c30a — Image/SAM3/Impact binder retirement
 
-- **State:** IN PROGRESS
+- **State:** IMPLEMENTED in PR #337
 - **Owner:** #184
 - **Type:** Move
 - **Base:** `dev@02b8c4a17b11011f1381c27cef6bd869b50f81bb`
@@ -1157,10 +1157,25 @@ Forbidden:
 - removing root aliases still consumed by AiO or another binder family; and
 - including LoRA, Prompt/Regional, AiO, or Wildcard/NAIA binder cleanup.
 
+Implementation result:
+
+- root imports/calls and the three canonical binder definitions are removed;
+- provider-backed helpers now resolve directly in their canonical modules at
+  call time, while the scheduler/checkpoint/default helpers are direct
+  canonical imports;
+- the Comfy host ledger still records 22 provider slots across 15 modules and
+  marks the five moved slots as direct call-time consumers instead of root
+  binder consumers;
+- the remaining root audit is 27 binders in four families: 12
+  provider-then-root, 13 root-only, and two explicit callbacks;
+- `nodes.py` is 1,820 lines, down 30 lines from the B-11c30 base; and
+- focused SAM3, Comfy adapter, compatibility, and backend analyzer validation
+  passes 61 tests.
+
 ### B-11d — Final root shim
 
-- **State:** BLOCKED by B-11c30 and the separate seed/Wildcard decision for the
-  final non-provider function
+- **State:** BLOCKED by the remaining B-11c30 family Moves and the separate
+  seed/Wildcard decision for the final non-provider function
 - **Owner:** #184
 - **Type:** Move
 
@@ -1195,7 +1210,8 @@ COMPLETE: B-11c29b2 loaded lookup retirement / PR #331
 COMPLETE: B-11c29c requirement helper retirement / PR #332
 COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
 COMPLETE: B-11c29b3 general node lookup retirement / PR #334
-IN PROGRESS: B-11c30 binder/resolver migration audit / PR #336
+COMPLETE: B-11c30 binder/resolver migration audit / PR #336
+IN PROGRESS: B-11c30a Image/SAM3/Impact binder Move / PR #337
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30 / PR #336; B-11c30a Image/SAM3/Impact binder Move in progress | Complete binder families, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c30 / PR #336; B-11c30a Image/SAM3/Impact binder Move implemented in PR #337 | Complete binder families, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -98,8 +98,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c29d retired the pure CLIP invocation root helper in PR #333. B-11c29b3
   retired the final general host lookup root wrapper in PR #334. B-11c30
   inventoried the remaining binder/resolver families without production
-  changes in PR #336 / `02b8c4a`. B-11c30a now retires only the three
-  Image/SAM3/Impact binders.
+  changes in PR #336 / `02b8c4a`. B-11c30a retires only the three
+  Image/SAM3/Impact binders in PR #337; the remaining audit contains 27 binders
+  across four families.
 
 ### Current quality baseline
 
@@ -341,7 +342,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30 audit PR #336; B-11c30a Image/SAM3/Impact binder Move active | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30 audit PR #336; B-11c30a Image/SAM3/Impact binder Move in PR #337 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c29b3 / PR #334; B-11c30 binder/resolver audit in PR #336 | Complete binder families, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c30 / PR #336; B-11c30a Image/SAM3/Impact binder Move in progress | Complete binder families, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -96,9 +96,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   B-11c29b2 retired only the unsupported loaded-node root lookup in PR #331.
   B-11c29c retired the two pure requirement root helpers together in PR #332.
   B-11c29d retired the pure CLIP invocation root helper in PR #333. B-11c29b3
-  retired the final general host lookup root wrapper in PR #334. B-11c30 now
-  inventories the remaining binder/resolver families without production
-  changes before any cleanup Move starts.
+  retired the final general host lookup root wrapper in PR #334. B-11c30
+  inventoried the remaining binder/resolver families without production
+  changes in PR #336 / `02b8c4a`. B-11c30a now retires only the three
+  Image/SAM3/Impact binders.
 
 ### Current quality baseline
 
@@ -340,7 +341,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c29b3 general lookup retirement PR #334; B-11c30 binder/resolver Contract audit in PR #336 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30 audit PR #336; B-11c30a Image/SAM3/Impact binder Move active | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,9 +8,9 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c29b3 are integrated. B-11c is split into
+- Current state: B-11a through B-11c30 are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c30 binder/resolver Contract audit is in PR #336.
+  root shim; B-11c30a retires only the Image/SAM3/Impact binder family.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -706,6 +706,21 @@ convenience-node compatibility; it remains unmapped and is not public support.
   Prompt/Regional and AiO require further sub-splitting, while Wildcard/NAIA
   remains separate from D-12 behavior.
 
+### B-11c30a Image/SAM3/Impact binder retirement
+
+- The three root binder imports/calls and the three canonical binder
+  definitions are removed.
+- Five E-07 provider slots remain call-time direct consumers in their canonical
+  modules. The Comfy host ledger keeps the same 22 slots and 15 modules.
+- `_impact_scheduler_names`, `_load_checkpoint_with_comfy`, and
+  `_preferred_checkpoint_default` use their existing canonical owners; their
+  other root consumers and aliases are unchanged.
+- The remaining binder audit contains 27 binders in four owner families. It no
+  longer treats the retired family or its bind-time module globals as active
+  compatibility state.
+- No node schema, workflow, optional-dependency timing, or SAM3/Impact behavior
+  changes in this Move.
+
 ### `nodes.py` public node-class surface
 
 The confirmed 0.5.2 mapped classes are:

--- a/easyuse_anima/image/sam3.py
+++ b/easyuse_anima/image/sam3.py
@@ -7,26 +7,27 @@ import re
 import sys
 from typing import Any
 
-
-def _unbound_runtime(*_args, **_kwargs) -> Any:
-    raise RuntimeError("SAM3 runtime dependencies are not bound.")
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 
 
-_find_comfy_node_class = _unbound_runtime
-_find_comfy_node_mapping_class = _unbound_runtime
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"SAM3 Comfy host helper is unavailable: {name}")
 
 
-def _bind_sam3_runtime(*, resolve_helper) -> None:
-    global _find_comfy_node_class, _find_comfy_node_mapping_class
+def _find_comfy_node_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_comfy_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
 
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
 
-        return call
-
-    _find_comfy_node_class = runtime_helper("_find_comfy_node_class")
-    _find_comfy_node_mapping_class = runtime_helper("_find_comfy_node_mapping_class")
+def _find_comfy_node_mapping_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_comfy_node_mapping_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
 
 
 def _find_impact_detailer_class():

--- a/easyuse_anima/nodes/impact_detailer_nodes.py
+++ b/easyuse_anima/nodes/impact_detailer_nodes.py
@@ -3,34 +3,30 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from ..common.values import _as_bool
 from ..image.detailer import _EasyUseAnimaAlignedDetailerHook
 from ..image.geometry import _alignment_value
 from ..image.sam3 import _call_impact_detailer, _find_impact_detailer_class
-from ..infrastructure.comfy.capabilities import _comfy_sampler_names
+from ..infrastructure.comfy.capabilities import (
+    _comfy_sampler_names,
+    _impact_scheduler_names,
+)
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
-def _unbound_runtime(*_args, **_kwargs) -> Any:
-    raise RuntimeError("Impact Detailer node runtime dependencies are not bound.")
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"Impact Detailer Comfy host helper is unavailable: {name}")
 
 
-_comfy_max_resolution = _unbound_runtime
-_impact_scheduler_names = _unbound_runtime
-
-
-def _bind_impact_detailer_node_runtime(*, resolve_helper) -> None:
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
-
-        return call
-
-    for name in ("_comfy_max_resolution", "_impact_scheduler_names"):
-        globals()[name] = runtime_helper(name)
+def _comfy_max_resolution() -> int:
+    helper = resolve_comfy_host_helper(
+        "_comfy_max_resolution",
+        _missing_host_helper,
+    )
+    return helper()
 
 
 class _EasyUseAnimaImpactDetailerDelegate:

--- a/easyuse_anima/nodes/sam3_nodes.py
+++ b/easyuse_anima/nodes/sam3_nodes.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
+from ..aio.resources import (
+    _load_checkpoint_with_comfy,
+    _preferred_checkpoint_default,
+)
 from ..common.values import _as_bool
 from ..image.sam3 import (
     _context_value,
@@ -18,35 +21,31 @@ from ..image.sam3 import (
 )
 from ..infrastructure.comfy.invocation import _node_output_tuple
 from ..infrastructure.comfy.resources import _comfy_checkpoint_names
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 from .impact_detailer_nodes import _EasyUseAnimaImpactDetailerDelegate
 
 logger = logging.getLogger("ComfyUI-EasyUseAnima")
 
 
-def _unbound_runtime(*_args, **_kwargs) -> Any:
-    raise RuntimeError("SAM3 node runtime dependencies are not bound.")
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"SAM3 node Comfy host helper is unavailable: {name}")
 
 
-_comfy_max_resolution = _unbound_runtime
-_encode_with_comfy_clip = _unbound_runtime
-_load_checkpoint_with_comfy = _unbound_runtime
-_preferred_checkpoint_default = _unbound_runtime
-
-
-def _bind_sam3_node_runtime(*, resolve_helper) -> None:
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
-
-        return call
-
-    for name in (
+def _comfy_max_resolution() -> int:
+    helper = resolve_comfy_host_helper(
         "_comfy_max_resolution",
+        _missing_host_helper,
+    )
+    return helper()
+
+
+def _encode_with_comfy_clip(clip, text: str):
+    helper = resolve_comfy_host_helper(
         "_encode_with_comfy_clip",
-        "_load_checkpoint_with_comfy",
-        "_preferred_checkpoint_default",
-    ):
-        globals()[name] = runtime_helper(name)
+        _missing_host_helper,
+    )
+    return helper(clip, text)
+
 
 
 class EasyUseAnimaSAM3Context:

--- a/nodes.py
+++ b/nodes.py
@@ -387,7 +387,6 @@ try:
     # Canonical image and Impact Detailer adapters import the owner directly.
     # The root module no longer re-exports this unsupported private helper.
     from .easyuse_anima.image.sam3 import (
-        _bind_sam3_runtime as _bind_sam3_runtime,
         # B-10b9 retires seven root SAM3 helper aliases.
         _context_value as _context_value,
         # Canonical SAM3 and Impact adapters import the owner directly.
@@ -433,14 +432,9 @@ try:
         EasyUseAnimaDetailerAlignHook as EasyUseAnimaDetailerAlignHook,
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
     )
-    from .easyuse_anima.nodes.impact_detailer_nodes import (
-        # B-10b3 deliberately omits the retired root Impact delegate alias.
-        _bind_impact_detailer_node_runtime as _bind_impact_detailer_node_runtime,
-    )
     from .easyuse_anima.nodes.sam3_nodes import (
         EasyUseAnimaSAM3Context as EasyUseAnimaSAM3Context,
         EasyUseAnimaSAM3Detailer as EasyUseAnimaSAM3Detailer,
-        _bind_sam3_node_runtime as _bind_sam3_node_runtime,
     )
     from .easyuse_anima.nodes.prompt_nodes import (
         EasyUseAnimaPromptBuilder as EasyUseAnimaPromptBuilder,
@@ -945,7 +939,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     # Canonical image and Impact Detailer adapters import the owner directly.
     # The root module no longer re-exports this unsupported private helper.
     from easyuse_anima.image.sam3 import (
-        _bind_sam3_runtime as _bind_sam3_runtime,
         # B-10b9 retires seven root SAM3 helper aliases.
         _context_value as _context_value,
         # Canonical SAM3 and Impact adapters import the owner directly.
@@ -991,14 +984,9 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaDetailerAlignHook as EasyUseAnimaDetailerAlignHook,
         EasyUseAnimaImageScaleByMultiple as EasyUseAnimaImageScaleByMultiple,
     )
-    from easyuse_anima.nodes.impact_detailer_nodes import (
-        # B-10b3 deliberately omits the retired root Impact delegate alias.
-        _bind_impact_detailer_node_runtime as _bind_impact_detailer_node_runtime,
-    )
     from easyuse_anima.nodes.sam3_nodes import (
         EasyUseAnimaSAM3Context as EasyUseAnimaSAM3Context,
         EasyUseAnimaSAM3Detailer as EasyUseAnimaSAM3Detailer,
-        _bind_sam3_node_runtime as _bind_sam3_node_runtime,
     )
     from easyuse_anima.nodes.prompt_nodes import (
         EasyUseAnimaPromptBuilder as EasyUseAnimaPromptBuilder,
@@ -1750,24 +1738,6 @@ _bind_aio_output_runtime(
     ),
 )
 _bind_aio_conditioning_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_sam3_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_impact_detailer_node_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_sam3_node_runtime(
     resolve_helper=lambda name: _resolve_comfy_host_helper(
         name,
         lambda fallback_name: globals()[fallback_name],

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -52,12 +52,12 @@
         },
         {
           "module": "easyuse_anima.nodes.impact_detailer_nodes",
-          "binder": "_bind_impact_detailer_node_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
           "module": "easyuse_anima.nodes.sam3_nodes",
-          "binder": "_bind_sam3_node_runtime",
+          "binder": null,
           "root_observation": "call_time"
         }
       ],
@@ -123,7 +123,7 @@
         },
         {
           "module": "easyuse_anima.nodes.sam3_nodes",
-          "binder": "_bind_sam3_node_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {
@@ -198,7 +198,7 @@
         },
         {
           "module": "easyuse_anima.image.sam3",
-          "binder": "_bind_sam3_runtime",
+          "binder": null,
           "root_observation": "call_time"
         }
       ],
@@ -242,7 +242,7 @@
       "production_consumers": [
         {
           "module": "easyuse_anima.image.sam3",
-          "binder": "_bind_sam3_runtime",
+          "binder": null,
           "root_observation": "call_time"
         }
       ],

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -7315,6 +7315,24 @@
       },
       {
         "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 10,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/image/sam3.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
         "bound_name": "DetailerForEach",
         "branch_context": [
           {
@@ -7322,7 +7340,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 44
+            "line": 45
           }
         ],
         "classification": "external",
@@ -7330,7 +7348,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 45,
+        "line": 46,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -7347,7 +7365,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 50
+            "line": 51
           }
         ],
         "classification": "external",
@@ -7355,7 +7373,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "name": "DetailerForEach",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -7372,7 +7390,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 70
+            "line": 71
           }
         ],
         "classification": "external",
@@ -7380,7 +7398,7 @@
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 71,
+        "line": 72,
         "name": "SAM3_Detect",
         "optional": true,
         "requested": "comfy_extras.nodes_sam3",
@@ -7397,7 +7415,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 94
+            "line": 95
           }
         ],
         "classification": "external",
@@ -7405,7 +7423,7 @@
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.segs_nodes",
@@ -7422,7 +7440,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 100
+            "line": 101
           }
         ],
         "classification": "external",
@@ -7430,7 +7448,7 @@
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 101,
+        "line": 102,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.segs_nodes",
@@ -7447,7 +7465,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 106
+            "line": 107
           }
         ],
         "classification": "external",
@@ -7455,7 +7473,7 @@
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "impact.impact_pack",
@@ -7472,7 +7490,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 112
+            "line": 113
           }
         ],
         "classification": "external",
@@ -7480,7 +7498,7 @@
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 113,
+        "line": 114,
         "name": "MaskToSEGS",
         "optional": true,
         "requested": "modules.impact.impact_pack",
@@ -7497,7 +7515,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 157
+            "line": 158
           }
         ],
         "classification": "external",
@@ -7505,7 +7523,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 158,
+        "line": 159,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -9133,23 +9151,6 @@
       },
       {
         "alias": null,
-        "bound_name": "Any",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 6,
-        "name": "Any",
-        "optional": false,
-        "requested": "typing",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py"
-      },
-      {
-        "alias": null,
         "bound_name": "_as_bool",
         "branch_context": [],
         "classification": "internal",
@@ -9157,7 +9158,7 @@
         "conditional": false,
         "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "_as_bool",
         "optional": false,
         "requested": "..common.values",
@@ -9175,7 +9176,7 @@
         "conditional": false,
         "imported": "..image.detailer:_EasyUseAnimaAlignedDetailerHook",
         "kind": "static_from",
-        "line": 9,
+        "line": 8,
         "name": "_EasyUseAnimaAlignedDetailerHook",
         "optional": false,
         "requested": "..image.detailer",
@@ -9193,7 +9194,7 @@
         "conditional": false,
         "imported": "..image.geometry:_alignment_value",
         "kind": "static_from",
-        "line": 10,
+        "line": 9,
         "name": "_alignment_value",
         "optional": false,
         "requested": "..image.geometry",
@@ -9211,7 +9212,7 @@
         "conditional": false,
         "imported": "..image.sam3:_call_impact_detailer",
         "kind": "static_from",
-        "line": 11,
+        "line": 10,
         "name": "_call_impact_detailer",
         "optional": false,
         "requested": "..image.sam3",
@@ -9229,7 +9230,7 @@
         "conditional": false,
         "imported": "..image.sam3:_find_impact_detailer_class",
         "kind": "static_from",
-        "line": 11,
+        "line": 10,
         "name": "_find_impact_detailer_class",
         "optional": false,
         "requested": "..image.sam3",
@@ -9247,7 +9248,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 12,
+        "line": 11,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "..infrastructure.comfy.capabilities",
@@ -9255,6 +9256,42 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
         "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_impact_scheduler_names",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.capabilities:_impact_scheduler_names",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_impact_scheduler_names",
+        "optional": false,
+        "requested": "..infrastructure.comfy.capabilities",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 15,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/impact_detailer_nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "alias": null,
@@ -11578,20 +11615,39 @@
       },
       {
         "alias": null,
-        "bound_name": "Any",
+        "bound_name": "_load_checkpoint_with_comfy",
         "branch_context": [],
-        "classification": "external",
+        "classification": "internal",
         "column": 0,
         "conditional": false,
-        "imported": "typing:Any",
+        "imported": "..aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 6,
-        "name": "Any",
+        "line": 7,
+        "name": "_load_checkpoint_with_comfy",
         "optional": false,
-        "requested": "typing",
+        "requested": "..aio.resources",
         "role": "ordinary",
         "scope": "<module>",
-        "source": "easyuse_anima/nodes/sam3_nodes.py"
+        "source": "easyuse_anima/nodes/sam3_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_preferred_checkpoint_default",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.resources:_preferred_checkpoint_default",
+        "kind": "static_from",
+        "line": 7,
+        "name": "_preferred_checkpoint_default",
+        "optional": false,
+        "requested": "..aio.resources",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/sam3_nodes.py",
+        "target": "easyuse_anima/aio/resources.py"
       },
       {
         "alias": null,
@@ -11602,7 +11658,7 @@
         "conditional": false,
         "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 8,
+        "line": 11,
         "name": "_as_bool",
         "optional": false,
         "requested": "..common.values",
@@ -11620,7 +11676,7 @@
         "conditional": false,
         "imported": "..image.sam3:_context_value",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_context_value",
         "optional": false,
         "requested": "..image.sam3",
@@ -11638,7 +11694,7 @@
         "conditional": false,
         "imported": "..image.sam3:_empty_mask_for_image",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_empty_mask_for_image",
         "optional": false,
         "requested": "..image.sam3",
@@ -11656,7 +11712,7 @@
         "conditional": false,
         "imported": "..image.sam3:_empty_segs_for_image",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_empty_segs_for_image",
         "optional": false,
         "requested": "..image.sam3",
@@ -11674,7 +11730,7 @@
         "conditional": false,
         "imported": "..image.sam3:_find_impact_mask_to_segs_class",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_find_impact_mask_to_segs_class",
         "optional": false,
         "requested": "..image.sam3",
@@ -11692,7 +11748,7 @@
         "conditional": false,
         "imported": "..image.sam3:_find_sam3_detect_class",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_find_sam3_detect_class",
         "optional": false,
         "requested": "..image.sam3",
@@ -11710,7 +11766,7 @@
         "conditional": false,
         "imported": "..image.sam3:_format_sam3_detection_prompt",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_format_sam3_detection_prompt",
         "optional": false,
         "requested": "..image.sam3",
@@ -11728,7 +11784,7 @@
         "conditional": false,
         "imported": "..image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_sam3_context",
         "optional": false,
         "requested": "..image.sam3",
@@ -11746,7 +11802,7 @@
         "conditional": false,
         "imported": "..image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 9,
+        "line": 12,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "..image.sam3",
@@ -11764,7 +11820,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 19,
+        "line": 22,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "..infrastructure.comfy.invocation",
@@ -11782,7 +11838,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.resources:_comfy_checkpoint_names",
         "kind": "static_from",
-        "line": 20,
+        "line": 23,
         "name": "_comfy_checkpoint_names",
         "optional": false,
         "requested": "..infrastructure.comfy.resources",
@@ -11793,6 +11849,24 @@
       },
       {
         "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 24,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/sam3_nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_EasyUseAnimaImpactDetailerDelegate",
         "branch_context": [],
         "classification": "internal",
@@ -11800,7 +11874,7 @@
         "conditional": false,
         "imported": ".impact_detailer_nodes:_EasyUseAnimaImpactDetailerDelegate",
         "kind": "static_from",
-        "line": 21,
+        "line": 25,
         "name": "_EasyUseAnimaImpactDetailerDelegate",
         "optional": false,
         "requested": ".impact_detailer_nodes",
@@ -21761,37 +21835,6 @@
         "target": "easyuse_anima/image/geometry.py"
       },
       {
-        "alias": "_bind_sam3_runtime",
-        "bound_name": "_bind_sam3_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_sam3_runtime",
-          "target": "easyuse_anima/image/sam3.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.image.sam3:_bind_sam3_runtime",
-        "kind": "static_from",
-        "line": 389,
-        "name": "_bind_sam3_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.image.sam3",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
         "alias": "_context_value",
         "bound_name": "_context_value",
         "branch_context": [
@@ -21906,7 +21949,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 402,
+        "line": 401,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21937,7 +21980,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 402,
+        "line": 401,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -21968,7 +22011,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 410,
+        "line": 409,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -21999,7 +22042,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 410,
+        "line": 409,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22030,7 +22073,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 410,
+        "line": 409,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22061,7 +22104,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 416,
+        "line": 415,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22092,7 +22135,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 416,
+        "line": 415,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22123,7 +22166,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 416,
+        "line": 415,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22154,7 +22197,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 421,
+        "line": 420,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22185,7 +22228,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 424,
+        "line": 423,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22216,7 +22259,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 423,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22247,7 +22290,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 423,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22278,7 +22321,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 423,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22309,7 +22352,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 424,
+        "line": 423,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22340,7 +22383,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 432,
+        "line": 431,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22371,7 +22414,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 432,
+        "line": 431,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22379,37 +22422,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
-      },
-      {
-        "alias": "_bind_impact_detailer_node_runtime",
-        "bound_name": "_bind_impact_detailer_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_impact_detailer_node_runtime",
-          "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
-        "kind": "static_from",
-        "line": 436,
-        "name": "_bind_impact_detailer_node_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.impact_detailer_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/impact_detailer_nodes.py"
       },
       {
         "alias": "EasyUseAnimaSAM3Context",
@@ -22433,7 +22445,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 440,
+        "line": 435,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22464,39 +22476,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 440,
+        "line": 435,
         "name": "EasyUseAnimaSAM3Detailer",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.sam3_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/sam3_nodes.py"
-      },
-      {
-        "alias": "_bind_sam3_node_runtime",
-        "bound_name": "_bind_sam3_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_sam3_node_runtime",
-          "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
-        "kind": "static_from",
-        "line": 440,
-        "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
         "role": "compatibility_primary",
@@ -22526,7 +22507,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 445,
+        "line": 439,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22557,7 +22538,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 445,
+        "line": 439,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22588,7 +22569,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 445,
+        "line": 439,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22619,7 +22600,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 445,
+        "line": 439,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22650,7 +22631,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 445,
+        "line": 439,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22681,7 +22662,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 452,
+        "line": 446,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22712,7 +22693,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 452,
+        "line": 446,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22743,7 +22724,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 452,
+        "line": 446,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22774,7 +22755,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 457,
+        "line": 451,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22805,7 +22786,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 457,
+        "line": 451,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22836,7 +22817,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 457,
+        "line": 451,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22867,7 +22848,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 475,
+        "line": 469,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22898,7 +22879,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 475,
+        "line": 469,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22929,7 +22910,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 475,
+        "line": 469,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22960,7 +22941,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 475,
+        "line": 469,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22991,7 +22972,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 475,
+        "line": 469,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23022,7 +23003,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 498,
+        "line": 492,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23053,7 +23034,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 498,
+        "line": 492,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23084,7 +23065,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 502,
+        "line": 496,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23115,7 +23096,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 502,
+        "line": 496,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23146,7 +23127,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23177,7 +23158,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23208,7 +23189,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23239,7 +23220,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23270,7 +23251,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23301,7 +23282,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23332,7 +23313,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23363,7 +23344,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23394,7 +23375,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23425,7 +23406,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23456,7 +23437,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23487,7 +23468,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23518,7 +23499,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23549,7 +23530,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23580,7 +23561,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 507,
+        "line": 501,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23611,7 +23592,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23642,7 +23623,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23673,7 +23654,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23704,7 +23685,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23735,7 +23716,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23766,7 +23747,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23797,7 +23778,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23828,7 +23809,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 524,
+        "line": 518,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23859,7 +23840,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 534,
+        "line": 528,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23890,7 +23871,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 534,
+        "line": 528,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23921,7 +23902,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 538,
+        "line": 532,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23952,7 +23933,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 538,
+        "line": 532,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23983,7 +23964,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 539,
+        "line": 533,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24014,7 +23995,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 540,
+        "line": 534,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24045,7 +24026,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 534,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24076,7 +24057,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 540,
+        "line": 534,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24107,7 +24088,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 545,
+        "line": 539,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24138,7 +24119,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 545,
+        "line": 539,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24169,7 +24150,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24200,7 +24181,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24231,7 +24212,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24262,7 +24243,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24293,7 +24274,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24324,7 +24305,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24355,7 +24336,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24386,7 +24367,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24417,7 +24398,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24448,7 +24429,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24479,7 +24460,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24510,7 +24491,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24541,7 +24522,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24572,7 +24553,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24603,7 +24584,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24634,7 +24615,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24665,7 +24646,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24696,7 +24677,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24727,7 +24708,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 546,
+        "line": 540,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24746,7 +24727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24761,7 +24742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24780,7 +24761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24795,7 +24776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24814,7 +24795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24829,7 +24810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24848,7 +24829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24863,7 +24844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24882,7 +24863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24897,7 +24878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24916,7 +24897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24931,7 +24912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24950,7 +24931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24965,7 +24946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24984,7 +24965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -24999,7 +24980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25018,7 +24999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25033,7 +25014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25052,7 +25033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25067,7 +25048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25086,7 +25067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25101,7 +25082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25120,7 +25101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25135,7 +25116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25154,7 +25135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25169,7 +25150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25188,7 +25169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25203,7 +25184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25222,7 +25203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25237,7 +25218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25256,7 +25237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25271,7 +25252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25290,7 +25271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25305,7 +25286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25324,7 +25305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25339,7 +25320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25358,7 +25339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25373,7 +25354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25392,7 +25373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25407,7 +25388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25426,7 +25407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25441,7 +25422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25460,7 +25441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25475,7 +25456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25494,7 +25475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25509,7 +25490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25528,7 +25509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25543,7 +25524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25562,7 +25543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25577,7 +25558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25596,7 +25577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25611,7 +25592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25630,7 +25611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25645,7 +25626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25664,7 +25645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25679,7 +25660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25698,7 +25679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25713,7 +25694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25732,7 +25713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25747,7 +25728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25766,7 +25747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25781,7 +25762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25800,7 +25781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25815,7 +25796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25834,7 +25815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25849,7 +25830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 607,
+        "line": 601,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25868,7 +25849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25883,7 +25864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 610,
+        "line": 604,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25902,7 +25883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25917,7 +25898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 610,
+        "line": 604,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25936,7 +25917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25951,7 +25932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 604,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25970,7 +25951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -25985,7 +25966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26004,7 +25985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26019,7 +26000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26038,7 +26019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26053,7 +26034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26072,7 +26053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26087,7 +26068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26106,7 +26087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26121,7 +26102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26140,7 +26121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26155,7 +26136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26174,7 +26155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26189,7 +26170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26208,7 +26189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26223,7 +26204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26242,7 +26223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26257,7 +26238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26276,7 +26257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26291,7 +26272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26310,7 +26291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26325,7 +26306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26344,7 +26325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26359,7 +26340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26378,7 +26359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26393,7 +26374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26412,7 +26393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26427,7 +26408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26446,7 +26427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26461,7 +26442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26480,7 +26461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26495,7 +26476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26514,7 +26495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26529,7 +26510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26548,7 +26529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26563,7 +26544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26582,7 +26563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26597,7 +26578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26616,7 +26597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26631,7 +26612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26650,7 +26631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26665,7 +26646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26684,7 +26665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26699,7 +26680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26718,7 +26699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26733,7 +26714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26752,7 +26733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26767,7 +26748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26786,7 +26767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26801,7 +26782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26820,7 +26801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26835,7 +26816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26854,7 +26835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26869,7 +26850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26888,7 +26869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26903,7 +26884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26922,7 +26903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26937,7 +26918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26956,7 +26937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -26971,7 +26952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26990,7 +26971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27005,7 +26986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27024,7 +27005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27039,7 +27020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27058,7 +27039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27073,7 +27054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27092,7 +27073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27107,7 +27088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27126,7 +27107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27141,7 +27122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27160,7 +27141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27175,7 +27156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27194,7 +27175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27209,7 +27190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27228,7 +27209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27243,7 +27224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27262,7 +27243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27277,7 +27258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27296,7 +27277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27311,7 +27292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27330,7 +27311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27345,7 +27326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27364,7 +27345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27379,7 +27360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27398,7 +27379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27413,7 +27394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27432,7 +27413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27447,7 +27428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27466,7 +27447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27481,7 +27462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27500,7 +27481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27515,7 +27496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27534,7 +27515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27549,7 +27530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27568,7 +27549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27583,7 +27564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27602,7 +27583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27617,7 +27598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27636,7 +27617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27651,7 +27632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27670,7 +27651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27685,7 +27666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27704,7 +27685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27719,7 +27700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27738,7 +27719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27753,7 +27734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27772,7 +27753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27787,7 +27768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27806,7 +27787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27821,7 +27802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27840,7 +27821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27855,7 +27836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27874,7 +27855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27889,7 +27870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27908,7 +27889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27923,7 +27904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27942,7 +27923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27957,7 +27938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27976,7 +27957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -27991,7 +27972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28010,7 +27991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28025,7 +28006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28044,7 +28025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28059,7 +28040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28078,7 +28059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28093,7 +28074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28112,7 +28093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28127,7 +28108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28146,7 +28127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28161,7 +28142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28180,7 +28161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28195,7 +28176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28214,7 +28195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28229,7 +28210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28248,7 +28229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28263,7 +28244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28282,7 +28263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28297,7 +28278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28316,7 +28297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28331,7 +28312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28350,7 +28331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28365,7 +28346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 699,
+        "line": 693,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28384,7 +28365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28399,7 +28380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 699,
+        "line": 693,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28418,7 +28399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28433,7 +28414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 699,
+        "line": 693,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28452,7 +28433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28467,7 +28448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28486,7 +28467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28501,7 +28482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28520,7 +28501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28535,7 +28516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28554,7 +28535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28569,7 +28550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28588,7 +28569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28603,7 +28584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28622,7 +28603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28637,7 +28618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 711,
+        "line": 705,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28656,7 +28637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28671,7 +28652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28690,7 +28671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28705,7 +28686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28724,7 +28705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28739,7 +28720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28758,7 +28739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28773,7 +28754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28792,7 +28773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28807,7 +28788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28826,7 +28807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28841,7 +28822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28860,7 +28841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28875,7 +28856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28894,7 +28875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28909,7 +28890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28928,7 +28909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28943,7 +28924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28962,7 +28943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -28977,7 +28958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28996,7 +28977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29011,7 +28992,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29030,7 +29011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29045,7 +29026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29064,7 +29045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29079,7 +29060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29098,7 +29079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29113,7 +29094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29132,7 +29113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29147,7 +29128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29166,7 +29147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29181,7 +29162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29200,7 +29181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29215,7 +29196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29234,7 +29215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29249,7 +29230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29268,7 +29249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29283,7 +29264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29302,7 +29283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29317,7 +29298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29336,7 +29317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29351,7 +29332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29370,7 +29351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29385,7 +29366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29404,7 +29385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29419,7 +29400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29438,7 +29419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29453,7 +29434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29472,7 +29453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29487,7 +29468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29506,7 +29487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29521,7 +29502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29540,7 +29521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29555,7 +29536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29574,7 +29555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29589,7 +29570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29608,7 +29589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29623,7 +29604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29642,7 +29623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29657,7 +29638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29676,7 +29657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29691,7 +29672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29710,7 +29691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29725,7 +29706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29744,7 +29725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29759,7 +29740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29778,7 +29759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29793,7 +29774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29812,7 +29793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29827,7 +29808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29846,7 +29827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29861,7 +29842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29880,7 +29861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29895,7 +29876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29914,7 +29895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29929,7 +29910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29948,7 +29929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29963,7 +29944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29982,7 +29963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -29997,7 +29978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30016,7 +29997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30031,7 +30012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30050,7 +30031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30065,7 +30046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30084,7 +30065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30099,7 +30080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30118,7 +30099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30133,7 +30114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30152,7 +30133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30167,7 +30148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30186,7 +30167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30201,7 +30182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30220,7 +30201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30235,7 +30216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30254,7 +30235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30269,7 +30250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30288,7 +30269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30303,7 +30284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30322,7 +30303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30337,7 +30318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30356,7 +30337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30371,7 +30352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30390,7 +30371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30405,7 +30386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30424,7 +30405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30439,7 +30420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30458,7 +30439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30473,7 +30454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30492,7 +30473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30507,7 +30488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30526,7 +30507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30541,7 +30522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30560,7 +30541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30575,7 +30556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30594,7 +30575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30609,7 +30590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30628,7 +30609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30643,7 +30624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30662,7 +30643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30677,7 +30658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30696,7 +30677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30711,7 +30692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30730,7 +30711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30745,7 +30726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30764,7 +30745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30779,7 +30760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30798,7 +30779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30813,7 +30794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30832,7 +30813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30847,7 +30828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30866,7 +30847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30881,7 +30862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30900,7 +30881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30915,7 +30896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30934,7 +30915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30949,7 +30930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30968,7 +30949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -30983,7 +30964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31002,7 +30983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31017,7 +30998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31036,7 +31017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31051,7 +31032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31070,7 +31051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31085,7 +31066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31104,7 +31085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31119,7 +31100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31138,7 +31119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31153,7 +31134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31172,7 +31153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31187,7 +31168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31206,7 +31187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31221,7 +31202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31240,7 +31221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31255,7 +31236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31274,7 +31255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31289,7 +31270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31308,7 +31289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31323,7 +31304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31342,7 +31323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31357,7 +31338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31376,7 +31357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31391,7 +31372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31410,7 +31391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31425,7 +31406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31444,7 +31425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31459,7 +31440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31478,7 +31459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31493,7 +31474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31512,7 +31493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31527,7 +31508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31546,7 +31527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31561,7 +31542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31580,7 +31561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31595,7 +31576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31614,7 +31595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31629,7 +31610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31648,7 +31629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31663,7 +31644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31682,7 +31663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31697,7 +31678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31716,7 +31697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31731,7 +31712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31750,7 +31731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31765,7 +31746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31784,7 +31765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31799,7 +31780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31818,7 +31799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31833,7 +31814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31852,7 +31833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31867,7 +31848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31886,7 +31867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31901,7 +31882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 916,
+        "line": 910,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31920,7 +31901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31935,7 +31916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 916,
+        "line": 910,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31954,7 +31935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -31969,7 +31950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 916,
+        "line": 910,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31988,7 +31969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32003,7 +31984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 921,
+        "line": 915,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32022,7 +32003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32037,7 +32018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 921,
+        "line": 915,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32056,7 +32037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32071,7 +32052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 915,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32090,7 +32071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32105,7 +32086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32124,7 +32105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32139,7 +32120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32158,7 +32139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32173,7 +32154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32192,7 +32173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32207,7 +32188,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32226,7 +32207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32241,7 +32222,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32260,7 +32241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32275,7 +32256,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32294,7 +32275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32309,7 +32290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32328,7 +32309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32343,7 +32324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 936,
+        "line": 930,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32362,7 +32343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32377,7 +32358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 936,
+        "line": 930,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32396,7 +32377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32411,7 +32392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 936,
+        "line": 930,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32419,40 +32400,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/image/geometry.py"
-      },
-      {
-        "alias": "_bind_sam3_runtime",
-        "bound_name": "_bind_sam3_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 567,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_sam3_runtime",
-          "target": "easyuse_anima/image/sam3.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
-        "kind": "static_from",
-        "line": 947,
-        "name": "_bind_sam3_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.image.sam3",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
       },
       {
         "alias": "_context_value",
@@ -32464,7 +32411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32479,7 +32426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 947,
+        "line": 941,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32498,7 +32445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32513,7 +32460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 947,
+        "line": 941,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32532,7 +32479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32547,7 +32494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 947,
+        "line": 941,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32566,7 +32513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32581,7 +32528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 960,
+        "line": 953,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32600,7 +32547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32615,7 +32562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 960,
+        "line": 953,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32634,7 +32581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32649,7 +32596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 961,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32668,7 +32615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32683,7 +32630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 961,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32702,7 +32649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32717,7 +32664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 961,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32736,7 +32683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32751,7 +32698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 974,
+        "line": 967,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32770,7 +32717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32785,7 +32732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 974,
+        "line": 967,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32804,7 +32751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32819,7 +32766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 974,
+        "line": 967,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32838,7 +32785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32853,7 +32800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 979,
+        "line": 972,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -32872,7 +32819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32887,7 +32834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32906,7 +32853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32921,7 +32868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32940,7 +32887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32955,7 +32902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32974,7 +32921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -32989,7 +32936,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33008,7 +32955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33023,7 +32970,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33042,7 +32989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33057,7 +33004,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 990,
+        "line": 983,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33076,7 +33023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33091,7 +33038,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 990,
+        "line": 983,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33099,40 +33046,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/nodes/image_nodes.py"
-      },
-      {
-        "alias": "_bind_impact_detailer_node_runtime",
-        "bound_name": "_bind_impact_detailer_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 567,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_impact_detailer_node_runtime",
-          "target": "easyuse_anima/nodes/impact_detailer_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
-        "kind": "static_from",
-        "line": 994,
-        "name": "_bind_impact_detailer_node_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.impact_detailer_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/impact_detailer_nodes.py"
       },
       {
         "alias": "EasyUseAnimaSAM3Context",
@@ -33144,7 +33057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33159,7 +33072,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 998,
+        "line": 987,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33178,7 +33091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33193,42 +33106,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 998,
+        "line": 987,
         "name": "EasyUseAnimaSAM3Detailer",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.sam3_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/sam3_nodes.py"
-      },
-      {
-        "alias": "_bind_sam3_node_runtime",
-        "bound_name": "_bind_sam3_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 567,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_sam3_node_runtime",
-          "target": "easyuse_anima/nodes/sam3_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
-        "kind": "static_from",
-        "line": 998,
-        "name": "_bind_sam3_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
         "role": "compatibility_fallback",
@@ -33246,7 +33125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33261,7 +33140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33280,7 +33159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33295,7 +33174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33314,7 +33193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33329,7 +33208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33348,7 +33227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33363,7 +33242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33382,7 +33261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33397,7 +33276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33416,7 +33295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33431,7 +33310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1010,
+        "line": 998,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33450,7 +33329,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33465,7 +33344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1010,
+        "line": 998,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33484,7 +33363,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33499,7 +33378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 998,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33518,7 +33397,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33533,7 +33412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1003,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33552,7 +33431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33567,7 +33446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1003,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33586,7 +33465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33601,7 +33480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1003,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33620,7 +33499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33635,7 +33514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33654,7 +33533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33669,7 +33548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33688,7 +33567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33703,7 +33582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33722,7 +33601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33737,7 +33616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33756,7 +33635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33771,7 +33650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33790,7 +33669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33805,7 +33684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1044,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33824,7 +33703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33839,7 +33718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1044,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33858,7 +33737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33873,7 +33752,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1048,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33892,7 +33771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33907,7 +33786,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1048,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33926,7 +33805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33941,7 +33820,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33960,7 +33839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -33975,7 +33854,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33994,7 +33873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34009,7 +33888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34028,7 +33907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34043,7 +33922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34062,7 +33941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34077,7 +33956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34096,7 +33975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34111,7 +33990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34130,7 +34009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34145,7 +34024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34164,7 +34043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34179,7 +34058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34198,7 +34077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34213,7 +34092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34232,7 +34111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34247,7 +34126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34266,7 +34145,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34281,7 +34160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34300,7 +34179,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34315,7 +34194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34334,7 +34213,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34349,7 +34228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34368,7 +34247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34383,7 +34262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34402,7 +34281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34417,7 +34296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34436,7 +34315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34451,7 +34330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_bind_lora_preset_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34470,7 +34349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34485,7 +34364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34504,7 +34383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34519,7 +34398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34538,7 +34417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34553,7 +34432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34572,7 +34451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34587,7 +34466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34606,7 +34485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34621,7 +34500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34640,7 +34519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34655,7 +34534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34674,7 +34553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34689,7 +34568,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34708,7 +34587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34723,7 +34602,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1080,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34742,7 +34621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34757,7 +34636,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1080,
         "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34776,7 +34655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34791,7 +34670,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1084,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34810,7 +34689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34825,7 +34704,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1084,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34844,7 +34723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34859,7 +34738,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1085,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34878,7 +34757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34893,7 +34772,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1086,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34912,7 +34791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34927,7 +34806,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1086,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34946,7 +34825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34961,7 +34840,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1086,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34980,7 +34859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -34995,7 +34874,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1091,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35014,7 +34893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35029,7 +34908,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1091,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35048,7 +34927,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35063,7 +34942,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35082,7 +34961,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35097,7 +34976,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35116,7 +34995,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35131,7 +35010,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35150,7 +35029,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35165,7 +35044,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35184,7 +35063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35199,7 +35078,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35218,7 +35097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35233,7 +35112,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35252,7 +35131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35267,7 +35146,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35286,7 +35165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35301,7 +35180,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35320,7 +35199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35335,7 +35214,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35354,7 +35233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35369,7 +35248,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35388,7 +35267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35403,7 +35282,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35422,7 +35301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35437,7 +35316,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35456,7 +35335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35471,7 +35350,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35490,7 +35369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35505,7 +35384,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35524,7 +35403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35539,7 +35418,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35558,7 +35437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35573,7 +35452,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35592,7 +35471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35607,7 +35486,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35626,7 +35505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35641,7 +35520,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35660,7 +35539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -35675,7 +35554,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37358,6 +37237,10 @@
         "to": "easyuse_anima/common/values.py"
       },
       {
+        "from": "easyuse_anima/image/sam3.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
         "from": "easyuse_anima/image/scaling.py",
         "to": "easyuse_anima/common/values.py"
       },
@@ -37428,6 +37311,10 @@
       {
         "from": "easyuse_anima/nodes/impact_detailer_nodes.py",
         "to": "easyuse_anima/infrastructure/comfy/capabilities.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/impact_detailer_nodes.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "easyuse_anima/nodes/lora_nodes.py",
@@ -37539,6 +37426,10 @@
       },
       {
         "from": "easyuse_anima/nodes/sam3_nodes.py",
+        "to": "easyuse_anima/aio/resources.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/sam3_nodes.py",
         "to": "easyuse_anima/common/values.py"
       },
       {
@@ -37552,6 +37443,10 @@
       {
         "from": "easyuse_anima/nodes/sam3_nodes.py",
         "to": "easyuse_anima/infrastructure/comfy/resources.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/sam3_nodes.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "easyuse_anima/nodes/sam3_nodes.py",
@@ -37784,10 +37679,6 @@
       {
         "from": "nodes.py",
         "to": "easyuse_anima/nodes/image_nodes.py"
-      },
-      {
-        "from": "nodes.py",
-        "to": "easyuse_anima/nodes/impact_detailer_nodes.py"
       },
       {
         "from": "nodes.py",
@@ -38894,14 +38785,14 @@
       },
       {
         "is_package": false,
-        "loc": 191,
+        "loc": 192,
         "module": "easyuse_anima.image.sam3",
-        "normalized_git_blob_sha1": "655947f76249b9ec1abb5ab8921f86f615e474ad",
+        "normalized_git_blob_sha1": "bac169cbcdb61f3b6a30c5dc62515425dce3a3de",
         "path": "easyuse_anima/image/sam3.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 12,
-          "global_count": 3
+          "function_count": 13,
+          "global_count": 1
         }
       },
       {
@@ -39110,14 +39001,14 @@
       },
       {
         "is_package": false,
-        "loc": 270,
+        "loc": 266,
         "module": "easyuse_anima.nodes.impact_detailer_nodes",
-        "normalized_git_blob_sha1": "10e0dd033160ebabb34480dd6f7c6fd2fa50d8c7",
+        "normalized_git_blob_sha1": "ce6551a48a8fcb596d046724ca0644ca27d88622",
         "path": "easyuse_anima/nodes/impact_detailer_nodes.py",
         "top_level": {
           "class_count": 1,
           "function_count": 2,
-          "global_count": 4
+          "global_count": 2
         }
       },
       {
@@ -39206,14 +39097,14 @@
       },
       {
         "is_package": false,
-        "loc": 327,
+        "loc": 326,
         "module": "easyuse_anima.nodes.sam3_nodes",
-        "normalized_git_blob_sha1": "95cabbf5b14504e5d9eddb324371dbfcc144c0aa",
+        "normalized_git_blob_sha1": "2aede23aed23964b3a8beb13143c206b76c8221a",
         "path": "easyuse_anima/nodes/sam3_nodes.py",
         "top_level": {
           "class_count": 2,
-          "function_count": 2,
-          "global_count": 6
+          "function_count": 3,
+          "global_count": 2
         }
       },
       {
@@ -39398,9 +39289,9 @@
       },
       {
         "is_package": false,
-        "loc": 1850,
+        "loc": 1820,
         "module": "nodes",
-        "normalized_git_blob_sha1": "7ed2145d779e4069da1f8a6629e172dda9778262",
+        "normalized_git_blob_sha1": "c08a5d730f6078a8a2211bcc73ea3ca22a9452fa",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -40764,7 +40655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40773,7 +40664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40787,7 +40678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40796,7 +40687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40810,7 +40701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40819,7 +40710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40833,7 +40724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40842,7 +40733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40856,7 +40747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40865,7 +40756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40879,7 +40770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40888,7 +40779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40902,7 +40793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40911,7 +40802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40925,7 +40816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40934,7 +40825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 568,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40948,7 +40839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40957,7 +40848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40971,7 +40862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -40980,7 +40871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40994,7 +40885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41003,7 +40894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41017,7 +40908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41026,7 +40917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41040,7 +40931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41049,7 +40940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41063,7 +40954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41072,7 +40963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41086,7 +40977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41095,7 +40986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41109,7 +41000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41118,7 +41009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 579,
+        "line": 573,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41132,7 +41023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41141,7 +41032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41155,7 +41046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41164,7 +41055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41178,7 +41069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41187,7 +41078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41201,7 +41092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41210,7 +41101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41224,7 +41115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41233,7 +41124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41247,7 +41138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41256,7 +41147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41270,7 +41161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41279,7 +41170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41293,7 +41184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41302,7 +41193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41316,7 +41207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41325,7 +41216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41339,7 +41230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41348,7 +41239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41362,7 +41253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41371,7 +41262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41385,7 +41276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41394,7 +41285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41408,7 +41299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41417,7 +41308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41431,7 +41322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41440,7 +41331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41454,7 +41345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41463,7 +41354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41477,7 +41368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41486,7 +41377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 589,
+        "line": 583,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41500,7 +41391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41509,7 +41400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 607,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41523,7 +41414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41532,7 +41423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 610,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41546,7 +41437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41555,7 +41446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 610,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41569,7 +41460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41578,7 +41469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 610,
+        "line": 604,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41592,7 +41483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41601,7 +41492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41615,7 +41506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41624,7 +41515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41638,7 +41529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41647,7 +41538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41661,7 +41552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41670,7 +41561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41684,7 +41575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41693,7 +41584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 615,
+        "line": 609,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41707,7 +41598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41716,7 +41607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41730,7 +41621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41739,7 +41630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41753,7 +41644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41762,7 +41653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41776,7 +41667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41785,7 +41676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 616,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41799,7 +41690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41808,7 +41699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41822,7 +41713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41831,7 +41722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41845,7 +41736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41854,7 +41745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41868,7 +41759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41877,7 +41768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41891,7 +41782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41900,7 +41791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41914,7 +41805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41923,7 +41814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41937,7 +41828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41946,7 +41837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41960,7 +41851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41969,7 +41860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41983,7 +41874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -41992,7 +41883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42006,7 +41897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42015,7 +41906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42029,7 +41920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42038,7 +41929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42052,7 +41943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42061,7 +41952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42075,7 +41966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42084,7 +41975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 628,
+        "line": 622,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42098,7 +41989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42107,7 +41998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42121,7 +42012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42130,7 +42021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42144,7 +42035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42153,7 +42044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42167,7 +42058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42176,7 +42067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42190,7 +42081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42199,7 +42090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42213,7 +42104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42222,7 +42113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42236,7 +42127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42245,7 +42136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42259,7 +42150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42268,7 +42159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42282,7 +42173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42291,7 +42182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42305,7 +42196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42314,7 +42205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42328,7 +42219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42337,7 +42228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42351,7 +42242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42360,7 +42251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 643,
+        "line": 637,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42374,7 +42265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42383,7 +42274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42397,7 +42288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42406,7 +42297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42420,7 +42311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42429,7 +42320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42443,7 +42334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42452,7 +42343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42466,7 +42357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42475,7 +42366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42489,7 +42380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42498,7 +42389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42512,7 +42403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42521,7 +42412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42535,7 +42426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42544,7 +42435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42558,7 +42449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42567,7 +42458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42581,7 +42472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42590,7 +42481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 657,
+        "line": 651,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42604,7 +42495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42613,7 +42504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42627,7 +42518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42636,7 +42527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42650,7 +42541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42659,7 +42550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42673,7 +42564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42682,7 +42573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42696,7 +42587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42705,7 +42596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42719,7 +42610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42728,7 +42619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42742,7 +42633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42751,7 +42642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42765,7 +42656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42774,7 +42665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42788,7 +42679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42797,7 +42688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42811,7 +42702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42820,7 +42711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 669,
+        "line": 663,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42834,7 +42725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42843,7 +42734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42857,7 +42748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42866,7 +42757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42880,7 +42771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42889,7 +42780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42903,7 +42794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42912,7 +42803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42926,7 +42817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42935,7 +42826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42949,7 +42840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42958,7 +42849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42972,7 +42863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -42981,7 +42872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42995,7 +42886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43004,7 +42895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43018,7 +42909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43027,7 +42918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43041,7 +42932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43050,7 +42941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43064,7 +42955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43073,7 +42964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43087,7 +42978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43096,7 +42987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43110,7 +43001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43119,7 +43010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43133,7 +43024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43142,7 +43033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43156,7 +43047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43165,7 +43056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43179,7 +43070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43188,7 +43079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 681,
+        "line": 675,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43202,7 +43093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43211,7 +43102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 699,
+        "line": 693,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43225,7 +43116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43234,7 +43125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 699,
+        "line": 693,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43248,7 +43139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43257,7 +43148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 699,
+        "line": 693,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43271,7 +43162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43280,7 +43171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43294,7 +43185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43303,7 +43194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43317,7 +43208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43326,7 +43217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43340,7 +43231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43349,7 +43240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43363,7 +43254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43372,7 +43263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 704,
+        "line": 698,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43386,7 +43277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43395,7 +43286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 711,
+        "line": 705,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43409,7 +43300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43418,7 +43309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43432,7 +43323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43441,7 +43332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43455,7 +43346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43464,7 +43355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43478,7 +43369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43487,7 +43378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 712,
+        "line": 706,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43501,7 +43392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43510,7 +43401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43524,7 +43415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43533,7 +43424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43547,7 +43438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43556,7 +43447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43570,7 +43461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43579,7 +43470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43593,7 +43484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43602,7 +43493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43616,7 +43507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43625,7 +43516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43639,7 +43530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43648,7 +43539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43662,7 +43553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43671,7 +43562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43685,7 +43576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43694,7 +43585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43708,7 +43599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43717,7 +43608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 718,
+        "line": 712,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43731,7 +43622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43740,7 +43631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43754,7 +43645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43763,7 +43654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43777,7 +43668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43786,7 +43677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43800,7 +43691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43809,7 +43700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43823,7 +43714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43832,7 +43723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43846,7 +43737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43855,7 +43746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43869,7 +43760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43878,7 +43769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 732,
+        "line": 726,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43892,7 +43783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43901,7 +43792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43915,7 +43806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43924,7 +43815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43938,7 +43829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43947,7 +43838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43961,7 +43852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43970,7 +43861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43984,7 +43875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -43993,7 +43884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44007,7 +43898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44016,7 +43907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44030,7 +43921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44039,7 +43930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44053,7 +43944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44062,7 +43953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44076,7 +43967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44085,7 +43976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44099,7 +43990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44108,7 +43999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44122,7 +44013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44131,7 +44022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44145,7 +44036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44154,7 +44045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44168,7 +44059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44177,7 +44068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44191,7 +44082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44200,7 +44091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44214,7 +44105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44223,7 +44114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44237,7 +44128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44246,7 +44137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44260,7 +44151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44269,7 +44160,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44283,7 +44174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44292,7 +44183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44306,7 +44197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44315,7 +44206,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44329,7 +44220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44338,7 +44229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44352,7 +44243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44361,7 +44252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44375,7 +44266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44384,7 +44275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 750,
+        "line": 744,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44398,7 +44289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44407,7 +44298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44421,7 +44312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44430,7 +44321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44444,7 +44335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44453,7 +44344,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44467,7 +44358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44476,7 +44367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44490,7 +44381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44499,7 +44390,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44513,7 +44404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44522,7 +44413,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44536,7 +44427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44545,7 +44436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44559,7 +44450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44568,7 +44459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44582,7 +44473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44591,7 +44482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44605,7 +44496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44614,7 +44505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44628,7 +44519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44637,7 +44528,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44651,7 +44542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44660,7 +44551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44674,7 +44565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44683,7 +44574,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44697,7 +44588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44706,7 +44597,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 786,
+        "line": 780,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44720,7 +44611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44729,7 +44620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44743,7 +44634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44752,7 +44643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44766,7 +44657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44775,7 +44666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44789,7 +44680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44798,7 +44689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44812,7 +44703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44821,7 +44712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44835,7 +44726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44844,7 +44735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44858,7 +44749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44867,7 +44758,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44881,7 +44772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44890,7 +44781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44904,7 +44795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44913,7 +44804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 814,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44927,7 +44818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44936,7 +44827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44950,7 +44841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44959,7 +44850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44973,7 +44864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -44982,7 +44873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44996,7 +44887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45005,7 +44896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45019,7 +44910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45028,7 +44919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45042,7 +44933,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45051,7 +44942,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45065,7 +44956,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45074,7 +44965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45088,7 +44979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45097,7 +44988,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45111,7 +45002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45120,7 +45011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45134,7 +45025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45143,7 +45034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45157,7 +45048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45166,7 +45057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45180,7 +45071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45189,7 +45080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45203,7 +45094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45212,7 +45103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45226,7 +45117,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45235,7 +45126,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45249,7 +45140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45258,7 +45149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45272,7 +45163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45281,7 +45172,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45295,7 +45186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45304,7 +45195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45318,7 +45209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45327,7 +45218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45341,7 +45232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45350,7 +45241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45364,7 +45255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45373,7 +45264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45387,7 +45278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45396,7 +45287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45410,7 +45301,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45419,7 +45310,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45433,7 +45324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45442,7 +45333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45456,7 +45347,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45465,7 +45356,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45479,7 +45370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45488,7 +45379,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 830,
+        "line": 824,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45502,7 +45393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45511,7 +45402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45525,7 +45416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45534,7 +45425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45548,7 +45439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45557,7 +45448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45571,7 +45462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45580,7 +45471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 910,
+        "line": 904,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45594,7 +45485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45603,7 +45494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 916,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45617,7 +45508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45626,7 +45517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 916,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45640,7 +45531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45649,7 +45540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 916,
+        "line": 910,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45663,7 +45554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45672,7 +45563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 921,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45686,7 +45577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45695,7 +45586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 921,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45709,7 +45600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45718,7 +45609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45732,7 +45623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45741,7 +45632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45755,7 +45646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45764,7 +45655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45778,7 +45669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45787,7 +45678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45801,7 +45692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45810,7 +45701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45824,7 +45715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45833,7 +45724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45847,7 +45738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45856,7 +45747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45870,7 +45761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45879,7 +45770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 927,
+        "line": 921,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45893,7 +45784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45902,7 +45793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 936,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45916,7 +45807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45925,7 +45816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 936,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45939,7 +45830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45948,7 +45839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 936,
+        "line": 930,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45962,30 +45853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.image.sam3:_bind_sam3_runtime",
-        "kind": "static_from",
-        "line": 947,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/image/sam3.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -45994,7 +45862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 947,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46008,7 +45876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46017,7 +45885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 947,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46031,7 +45899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46040,7 +45908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 947,
+        "line": 941,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46054,7 +45922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46063,7 +45931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 960,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46077,7 +45945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46086,7 +45954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 960,
+        "line": 953,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46100,7 +45968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46109,7 +45977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46123,7 +45991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46132,7 +46000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46146,7 +46014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46155,7 +46023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 968,
+        "line": 961,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46169,7 +46037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46178,7 +46046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 974,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46192,7 +46060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46201,7 +46069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 974,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46215,7 +46083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46224,7 +46092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 974,
+        "line": 967,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46238,7 +46106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46247,7 +46115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 979,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46261,7 +46129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46270,7 +46138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46284,7 +46152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46293,7 +46161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46307,7 +46175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46316,7 +46184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46330,7 +46198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46339,7 +46207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46353,7 +46221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46362,7 +46230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 982,
+        "line": 975,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46376,7 +46244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46385,7 +46253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 990,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46399,7 +46267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46408,7 +46276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 990,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46422,30 +46290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.impact_detailer_nodes:_bind_impact_detailer_node_runtime",
-        "kind": "static_from",
-        "line": 994,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/impact_detailer_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46454,7 +46299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 998,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46468,7 +46313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46477,7 +46322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 998,
+        "line": 987,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46491,30 +46336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.sam3_nodes:_bind_sam3_node_runtime",
-        "kind": "static_from",
-        "line": 998,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/sam3_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46523,7 +46345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46537,7 +46359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46546,7 +46368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46560,7 +46382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46569,7 +46391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46583,7 +46405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46592,7 +46414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46606,7 +46428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46615,7 +46437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 1003,
+        "line": 991,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46629,7 +46451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46638,7 +46460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 1010,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46652,7 +46474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46661,7 +46483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 1010,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46675,7 +46497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46684,7 +46506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 1010,
+        "line": 998,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46698,7 +46520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46707,7 +46529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46721,7 +46543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46730,7 +46552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46744,7 +46566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46753,7 +46575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1015,
+        "line": 1003,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46767,7 +46589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46776,7 +46598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46790,7 +46612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46799,7 +46621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46813,7 +46635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46822,7 +46644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46836,7 +46658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46845,7 +46667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46859,7 +46681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46868,7 +46690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1021,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46882,7 +46704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46891,7 +46713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1044,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46905,7 +46727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46914,7 +46736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1056,
+        "line": 1044,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46928,7 +46750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46937,7 +46759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46951,7 +46773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46960,7 +46782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1060,
+        "line": 1048,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46974,7 +46796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -46983,7 +46805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46997,7 +46819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47006,7 +46828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47020,7 +46842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47029,7 +46851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47043,7 +46865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47052,7 +46874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47066,7 +46888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47075,7 +46897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47089,7 +46911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47098,7 +46920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47112,7 +46934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47121,7 +46943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47135,7 +46957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47144,7 +46966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47158,7 +46980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47167,7 +46989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47181,7 +47003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47190,7 +47012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47204,7 +47026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47213,7 +47035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47227,7 +47049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47236,7 +47058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47250,7 +47072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47259,7 +47081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47273,7 +47095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47282,7 +47104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47296,7 +47118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47305,7 +47127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1065,
+        "line": 1053,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47319,7 +47141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47328,7 +47150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47342,7 +47164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47351,7 +47173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47365,7 +47187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47374,7 +47196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47388,7 +47210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47397,7 +47219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47411,7 +47233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47420,7 +47242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47434,7 +47256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47443,7 +47265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47457,7 +47279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47466,7 +47288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47480,7 +47302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47489,7 +47311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1082,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47503,7 +47325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47512,7 +47334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1080,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47526,7 +47348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47535,7 +47357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1080,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47549,7 +47371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47558,7 +47380,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47572,7 +47394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47581,7 +47403,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1096,
+        "line": 1084,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47595,7 +47417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47604,7 +47426,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1097,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47618,7 +47440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47627,7 +47449,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47641,7 +47463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47650,7 +47472,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47664,7 +47486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47673,7 +47495,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1098,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47687,7 +47509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47696,7 +47518,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47710,7 +47532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47719,7 +47541,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1103,
+        "line": 1091,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47733,7 +47555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47742,7 +47564,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47756,7 +47578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47765,7 +47587,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47779,7 +47601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47788,7 +47610,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47802,7 +47624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47811,7 +47633,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47825,7 +47647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47834,7 +47656,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47848,7 +47670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47857,7 +47679,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47871,7 +47693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47880,7 +47702,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47894,7 +47716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47903,7 +47725,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47917,7 +47739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47926,7 +47748,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47940,7 +47762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47949,7 +47771,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47963,7 +47785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47972,7 +47794,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47986,7 +47808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -47995,7 +47817,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48009,7 +47831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -48018,7 +47840,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48032,7 +47854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -48041,7 +47863,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48055,7 +47877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -48064,7 +47886,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48078,7 +47900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -48087,7 +47909,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48101,7 +47923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -48110,7 +47932,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48124,7 +47946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -48133,7 +47955,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48147,7 +47969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 567,
+            "handler_line": 561,
             "kind": "try",
             "line": 9
           }
@@ -48156,7 +47978,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1104,
+        "line": 1092,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50310,14 +50132,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 44
+            "line": 45
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 45,
+        "line": 46,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -50329,14 +50151,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 50
+            "line": 51
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -50348,14 +50170,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 70
+            "line": 71
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 71,
+        "line": 72,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -50367,14 +50189,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 94
+            "line": 95
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -50386,14 +50208,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 100
+            "line": 101
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 101,
+        "line": 102,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -50405,14 +50227,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 106
+            "line": 107
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -50424,14 +50246,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 112
+            "line": 113
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 113,
+        "line": 114,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -50443,14 +50265,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 157
+            "line": 158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 158,
+        "line": 159,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -51261,17 +51083,6 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 6,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/nodes/impact_detailer_nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
         "line": 3,
@@ -51451,17 +51262,6 @@
         "imported": "logging",
         "kind": "static_import",
         "line": 5,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/nodes/sam3_nodes.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
-        "imported": "typing:Any",
-        "kind": "static_from",
-        "line": 6,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/nodes/sam3_nodes.py"
@@ -52913,14 +52713,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 44
+            "line": 45
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 45,
+        "line": 46,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -52932,14 +52732,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 50
+            "line": 51
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:DetailerForEach",
         "kind": "static_from",
-        "line": 51,
+        "line": 52,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -52951,14 +52751,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 70
+            "line": 71
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "comfy_extras.nodes_sam3:SAM3_Detect",
         "kind": "static_from",
-        "line": 71,
+        "line": 72,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -52970,14 +52770,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 94
+            "line": 95
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 95,
+        "line": 96,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -52989,14 +52789,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 100
+            "line": 101
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.segs_nodes:MaskToSEGS",
         "kind": "static_from",
-        "line": 101,
+        "line": 102,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -53008,14 +52808,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 106
+            "line": 107
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 107,
+        "line": 108,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -53027,14 +52827,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 112
+            "line": 113
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "modules.impact.impact_pack:MaskToSEGS",
         "kind": "static_from",
-        "line": 113,
+        "line": 114,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -53046,14 +52846,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 157
+            "line": 158
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 158,
+        "line": 159,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/image/sam3.py"
@@ -54596,7 +54396,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 14,
+        "line": 17,
         "module": "easyuse_anima/nodes/impact_detailer_nodes.py",
         "scope": "<module>"
       },
@@ -54623,7 +54423,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 23,
+        "line": 27,
         "module": "easyuse_anima/nodes/sam3_nodes.py",
         "scope": "<module>"
       },
@@ -54947,7 +54747,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1126,
+        "line": 1114,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54956,7 +54756,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1701,
+        "line": 1689,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54965,7 +54765,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1704,
+        "line": 1692,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54974,7 +54774,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1710,
+        "line": 1698,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54983,7 +54783,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1716,
+        "line": 1704,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54992,7 +54792,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1719,
+        "line": 1707,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55001,7 +54801,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1722,
+        "line": 1710,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55010,7 +54810,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1728,
+        "line": 1716,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55019,7 +54819,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1734,
+        "line": 1722,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55028,7 +54828,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1740,
+        "line": 1728,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55037,7 +54837,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1746,
+        "line": 1734,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55046,34 +54846,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1752,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_sam3_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1758,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_impact_detailer_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1764,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_sam3_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1770,
+        "line": 1740,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55082,7 +54855,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1776,
+        "line": 1746,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55091,7 +54864,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1779,
+        "line": 1749,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55100,7 +54873,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1786,
+        "line": 1756,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55109,7 +54882,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1789,
+        "line": 1759,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55118,7 +54891,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1793,
+        "line": 1763,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55127,7 +54900,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1796,
+        "line": 1766,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55136,7 +54909,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1803,
+        "line": 1773,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55145,7 +54918,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1809,
+        "line": 1779,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55154,7 +54927,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1815,
+        "line": 1785,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55163,7 +54936,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1818,
+        "line": 1788,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55172,7 +54945,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1821,
+        "line": 1791,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55181,7 +54954,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1824,
+        "line": 1794,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55190,7 +54963,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1831,
+        "line": 1801,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55199,7 +54972,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1837,
+        "line": 1807,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55208,7 +54981,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1842,
+        "line": 1812,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55217,7 +54990,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1846,
+        "line": 1816,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55731,13 +55504,13 @@
       },
       {
         "kind": "dict",
-        "line": 1188,
+        "line": 1176,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1177,
+        "line": 1165,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -65,7 +65,8 @@
       "B-11c29c",
       "B-11c29d",
       "B-11c29b3",
-      "B-11c30"
+      "B-11c30",
+      "B-11c30a"
     ]
   },
   "enums": {
@@ -100,14 +101,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 295,
+    "nodes_canonical_bindings": 292,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 1,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
-    "runtime_binders": 30,
+    "runtime_binders": 27,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -153,9 +154,6 @@
     "_bind_aio_preview_runtime",
     "_bind_aio_output_runtime",
     "_bind_aio_conditioning_runtime",
-    "_bind_sam3_runtime",
-    "_bind_impact_detailer_node_runtime",
-    "_bind_sam3_node_runtime",
     "_bind_regional_runtime",
     "_bind_regional_node_runtime",
     "_bind_advanced_runtime",
@@ -761,8 +759,7 @@
       "easyuse_anima.aio.usdu"
     ],
     "_impact_scheduler_names": [
-      "easyuse_anima.aio.generation_normalization",
-      "easyuse_anima.nodes.impact_detailer_nodes"
+      "easyuse_anima.aio.generation_normalization"
     ],
     "_is_aio_detailer_target_name": [
       "easyuse_anima.aio.generation_normalization"
@@ -793,8 +790,7 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_load_checkpoint_with_comfy": [
-      "easyuse_anima.aio.resources",
-      "easyuse_anima.nodes.sam3_nodes"
+      "easyuse_anima.aio.resources"
     ],
     "_load_clip_with_comfy": [
       "easyuse_anima.aio.resources"
@@ -935,9 +931,6 @@
     ],
     "_post_random": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "_preferred_checkpoint_default": [
-      "easyuse_anima.nodes.sam3_nodes"
     ],
     "_preferred_clip_type_default": [
       "easyuse_anima.nodes.aio_nodes"
@@ -1181,22 +1174,22 @@
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 30,
-      "family_count": 5,
+      "binder_count": 27,
+      "family_count": 4,
       "mode_counts": {
-        "comfy_provider_then_root": 15,
+        "comfy_provider_then_root": 12,
         "root_globals": 13,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 295,
-      "unique_root_resolver_names": 288,
-      "unique_provider_resolver_names": 7,
+      "unique_resolver_names": 293,
+      "unique_root_resolver_names": 287,
+      "unique_provider_resolver_names": 6,
       "unique_direct_root_dependencies": 14,
-      "direct_root_dependency_slots": 32,
-      "provider_consumer_slots": 22,
-      "provider_consumer_modules": 15,
+      "direct_root_dependency_slots": 29,
+      "provider_consumer_slots": 17,
+      "provider_consumer_modules": 12,
       "repository_replacement_names": 165,
-      "repository_replacement_files": 20
+      "repository_replacement_files": 19
     },
     "families": {
       "aio": [
@@ -1212,11 +1205,6 @@
         "_bind_aio_output_runtime",
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime"
-      ],
-      "image_sam3_impact": [
-        "_bind_sam3_runtime",
-        "_bind_impact_detailer_node_runtime",
-        "_bind_sam3_node_runtime"
       ],
       "prompt_regional": [
         "_bind_regional_runtime",
@@ -1459,7 +1447,6 @@
       "_parse_random_response",
       "_patch_model_sampling_aura_flow",
       "_post_random",
-      "_preferred_checkpoint_default",
       "_preferred_clip_type_default",
       "_preferred_name_default",
       "_profile_key",
@@ -1534,7 +1521,6 @@
       "_comfy_max_resolution",
       "_encode_with_comfy_clip",
       "_find_comfy_node_class",
-      "_find_comfy_node_mapping_class",
       "_find_loaded_node_class",
       "_require_any_custom_node_class",
       "_require_custom_node_class"
@@ -1890,8 +1876,7 @@
         "tests/test_aio_nodes.py"
       ],
       "_load_checkpoint_with_comfy": [
-        "tests/test_aio_resources.py",
-        "tests/test_sam3_nodes.py"
+        "tests/test_aio_resources.py"
       ],
       "_load_clip_with_comfy": [
         "tests/test_aio_resources.py"
@@ -3026,99 +3011,6 @@
           "_aio_usdu_prompt_without_general",
           "_as_bool",
           "_normalize_prompt_data"
-        ]
-      },
-      {
-        "binder": "_bind_sam3_runtime",
-        "module": "easyuse_anima.image.sam3",
-        "family": "image_sam3_impact",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_find_comfy_node_class",
-          "_find_comfy_node_mapping_class"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "_find_comfy_node_class",
-          "_find_comfy_node_mapping_class"
-        ],
-        "root_resolver_names": [],
-        "provider_resolver_names": [
-          "_find_comfy_node_class",
-          "_find_comfy_node_mapping_class"
-        ],
-        "repository_replacement_names": []
-      },
-      {
-        "binder": "_bind_impact_detailer_node_runtime",
-        "module": "easyuse_anima.nodes.impact_detailer_nodes",
-        "family": "image_sam3_impact",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_comfy_max_resolution",
-          "_impact_scheduler_names"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "_comfy_max_resolution",
-          "_impact_scheduler_names"
-        ],
-        "root_resolver_names": [
-          "_impact_scheduler_names"
-        ],
-        "provider_resolver_names": [
-          "_comfy_max_resolution"
-        ],
-        "repository_replacement_names": [
-          "_impact_scheduler_names"
-        ]
-      },
-      {
-        "binder": "_bind_sam3_node_runtime",
-        "module": "easyuse_anima.nodes.sam3_nodes",
-        "family": "image_sam3_impact",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_comfy_max_resolution",
-          "_encode_with_comfy_clip",
-          "_load_checkpoint_with_comfy",
-          "_preferred_checkpoint_default"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "_comfy_max_resolution",
-          "_encode_with_comfy_clip",
-          "_load_checkpoint_with_comfy",
-          "_preferred_checkpoint_default"
-        ],
-        "root_resolver_names": [
-          "_load_checkpoint_with_comfy",
-          "_preferred_checkpoint_default"
-        ],
-        "provider_resolver_names": [
-          "_comfy_max_resolution",
-          "_encode_with_comfy_clip"
-        ],
-        "repository_replacement_names": [
-          "_load_checkpoint_with_comfy"
         ]
       },
       {
@@ -5326,7 +5218,6 @@
         "_load_upscale_model_with_comfy": "_load_upscale_model_with_comfy",
         "_load_vae_with_comfy": "_load_vae_with_comfy",
         "_normalize_aio_input_settings": "_normalize_aio_input_settings",
-        "_preferred_checkpoint_default": "_preferred_checkpoint_default",
         "_preferred_clip_type_default": "_preferred_clip_type_default",
         "_preferred_name_default": "_preferred_name_default"
       },
@@ -5343,15 +5234,13 @@
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.resources",
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.sam3_nodes"
+        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup",
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.sam3_nodes string runtime lookup"
+        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5359,6 +5248,35 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.aio.resources:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_preferred_checkpoint_default": "_preferred_checkpoint_default"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.aio.resources",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.aio.resources",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.aio.sampling:transitional_private_seam",
@@ -5597,7 +5515,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.image.sam3:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_bind_sam3_runtime": "_bind_sam3_runtime",
         "_context_value": "_context_value",
         "_sam3_context": "_sam3_context",
         "_segs_has_items": "_segs_has_items"
@@ -5612,12 +5529,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.resources"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.resources string runtime lookup"
       ],
@@ -5675,12 +5590,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
-        "canonical runtime resolver: easyuse_anima.nodes.impact_detailer_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.generation_normalization"
       ],
       "evidence": [
-        "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
-        "AST:easyuse_anima.nodes.impact_detailer_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.generation_normalization string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6045,34 +5958,6 @@
         "mapping, workflow, and direct identity parity"
       ],
       "lifecycle_state": "supported"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.impact_detailer_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_impact_detailer_node_runtime": "_bind_impact_detailer_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.impact_detailer_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.impact_detailer_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.input_types:transitional_private_seam",
@@ -6492,8 +6377,7 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "EasyUseAnimaSAM3Context": "EasyUseAnimaSAM3Context",
-        "EasyUseAnimaSAM3Detailer": "EasyUseAnimaSAM3Detailer",
-        "_bind_sam3_node_runtime": "_bind_sam3_node_runtime"
+        "EasyUseAnimaSAM3Detailer": "EasyUseAnimaSAM3Detailer"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -6505,12 +6389,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "historical SAM3 convenience-node compatibility"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "docs/version-plans/0.1.6-Detailer.md"
       ],

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,13 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "7ed2145d779e4069da1f8a6629e172dda9778262")
-        # B-11c29b3 retires only the provider-owned general node lookup root
-        # helper and its two adapter imports without changing the public class
-        # surface.
+        self.assertEqual(report["git_blob_sha1"], "c08a5d730f6078a8a2211bcc73ea3ca22a9452fa")
+        # B-11c30a retires only the three Image/SAM3/Impact runtime binder
+        # imports and calls without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 1)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_850)
+        self.assertEqual(report["line_count"], 1_820)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -70,6 +70,7 @@ DOCUMENTED_TRANSITIONAL_ALIASES = {
 RUNTIME_LOOKUP_CALLS = {
     "_runtime_helper",
     "_runtime_object",
+    "resolve_comfy_host_helper",
     "runtime_helper",
     "runtime_object",
     "_runtime_proxy",
@@ -96,11 +97,6 @@ RUNTIME_BINDER_FAMILIES = {
         "_bind_aio_output_runtime",
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime",
-    ),
-    "image_sam3_impact": (
-        "_bind_sam3_runtime",
-        "_bind_impact_detailer_node_runtime",
-        "_bind_sam3_node_runtime",
     ),
     "prompt_regional": (
         "_bind_regional_runtime",
@@ -1013,13 +1009,37 @@ def _runtime_resolver_consumers(
     available: set[str],
 ) -> dict[str, list[str]]:
     consumers: dict[str, set[str]] = defaultdict(set)
-    for module in sorted(set(_runtime_binder_targets(tree, canonical_bindings).values())):
+    modules = set(_runtime_binder_targets(tree, canonical_bindings).values())
+    modules.update(_direct_runtime_resolver_modules())
+    for module in sorted(modules):
         for name in _resolver_names_from_module(module, available):
             consumers[name].add(module)
     return {
         name: sorted(modules)
         for name, modules in sorted(consumers.items())
     }
+
+
+def _direct_runtime_resolver_modules() -> set[str]:
+    modules = set()
+    for path in sorted((ROOT / "easyuse_anima").rglob("*.py")):
+        tree = _read_tree(path)
+        imports_resolver = any(
+            isinstance(node, ast.ImportFrom)
+            and node.module is not None
+            and node.module.endswith("infrastructure.comfy.wiring")
+            and any(
+                alias.name == "resolve_comfy_host_helper"
+                for alias in node.names
+            )
+            for node in tree.body
+        )
+        if not imports_resolver:
+            continue
+        modules.add(
+            ".".join(path.relative_to(ROOT).with_suffix("").parts)
+        )
+    return modules
 
 
 def _direct_runtime_lookup_names(module: str) -> set[str]:
@@ -1240,17 +1260,22 @@ def _comfy_host_runtime_consumers(
         set(COMFY_HOST_WRAPPERS),
     )
     result = {}
+    direct_modules = _direct_runtime_resolver_modules()
     for symbol in COMFY_HOST_WRAPPERS:
         consumers = []
         for module in resolver_consumers.get(symbol, []):
             binder = target_binders.get(module)
-            if binder is None:
+            if binder is None and module not in direct_modules:
                 raise AssertionError(f"{symbol} consumer has no root binder: {module}")
             consumers.append(
                 {
                     "module": module,
                     "binder": binder,
-                    "root_observation": _binder_observation_mode(module, binder),
+                    "root_observation": (
+                        "call_time"
+                        if binder is None
+                        else _binder_observation_mode(module, binder)
+                    ),
                 }
             )
         result[symbol] = consumers
@@ -2104,6 +2129,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c29d",
                 "B-11c29b3",
                 "B-11c30",
+                "B-11c30a",
             ],
         },
         "enums": {
@@ -2116,14 +2142,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 295,
+            "nodes_canonical_bindings": 292,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 1,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
-            "runtime_binders": 30,
+            "runtime_binders": 27,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2355,7 +2381,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 30)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 27)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2363,27 +2389,30 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 30,
-                "family_count": 5,
+                "binder_count": 27,
+                "family_count": 4,
                 "mode_counts": {
-                    "comfy_provider_then_root": 15,
+                    "comfy_provider_then_root": 12,
                     "root_globals": 13,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 295,
-                "unique_root_resolver_names": 288,
-                "unique_provider_resolver_names": 7,
+                "unique_resolver_names": 293,
+                "unique_root_resolver_names": 287,
+                "unique_provider_resolver_names": 6,
                 "unique_direct_root_dependencies": 14,
-                "direct_root_dependency_slots": 32,
-                "provider_consumer_slots": 22,
-                "provider_consumer_modules": 15,
+                "direct_root_dependency_slots": 29,
+                "provider_consumer_slots": 17,
+                "provider_consumer_modules": 12,
                 "repository_replacement_names": 165,
-                "repository_replacement_files": 20,
+                "repository_replacement_files": 19,
             },
         )
         self.assertEqual(
             audit["provider_resolver_names"],
-            sorted(COMFY_HOST_WRAPPERS),
+            sorted(
+                set(COMFY_HOST_WRAPPERS)
+                - {"_find_comfy_node_mapping_class"}
+            ),
         )
         self.assertEqual(
             set(audit["root_resolver_names"])

--- a/tests/test_sam3_nodes.py
+++ b/tests/test_sam3_nodes.py
@@ -5,7 +5,9 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import nodes
+from easyuse_anima.aio import resources as aio_resources
 from easyuse_anima.image import sam3 as sam3_service
+from easyuse_anima.infrastructure.comfy import capabilities
 from easyuse_anima.nodes import impact_detailer_nodes
 from easyuse_anima.nodes import sam3_nodes
 from tests.comfy_host_fakes import patch_comfy_helper
@@ -84,6 +86,25 @@ class SAM3MoveTests(unittest.TestCase):
             sam3_nodes._EasyUseAnimaImpactDetailerDelegate,
             impact_detailer_nodes._EasyUseAnimaImpactDetailerDelegate,
         )
+        self.assertIs(
+            impact_detailer_nodes._impact_scheduler_names,
+            capabilities._impact_scheduler_names,
+        )
+        self.assertIs(
+            sam3_nodes._load_checkpoint_with_comfy,
+            aio_resources._load_checkpoint_with_comfy,
+        )
+        self.assertIs(
+            sam3_nodes._preferred_checkpoint_default,
+            aio_resources._preferred_checkpoint_default,
+        )
+        for module, binder_name in (
+            (sam3_service, "_bind_sam3_runtime"),
+            (impact_detailer_nodes, "_bind_impact_detailer_node_runtime"),
+            (sam3_nodes, "_bind_sam3_node_runtime"),
+        ):
+            with self.subTest(module=module.__name__, binder=binder_name):
+                self.assertFalse(hasattr(module, binder_name))
         with (
             patch.object(
                 impact_detailer_nodes,
@@ -134,7 +155,7 @@ class SAM3MoveTests(unittest.TestCase):
 
     def test_context_node_keeps_call_time_checkpoint_loader(self):
         with patch.object(
-            nodes,
+            sam3_nodes,
             "_load_checkpoint_with_comfy",
             return_value=("model", "clip", "vae"),
         ) as load:


### PR DESCRIPTION
## 분류

- Task: B-11c30a
- Owner: #184
- Type: Move
- Base: `dev@02b8c4a17b11011f1381c27cef6bd869b50f81bb`
- 검증 head: `eb5c295bc75ab741b310b3153e666aaffbae2783`
- Production changes: 완료
- Contract/Behavior: 포함하지 않음

## 작업 전 symbol/caller/alias/global-state inventory

- root `nodes.py`가 package/flat import 경로에서 가져오고 초기화 시 각 1회 호출하는 binder:
  - `_bind_sam3_runtime`
  - `_bind_impact_detailer_node_runtime`
  - `_bind_sam3_node_runtime`
- binder가 설치하는 canonical module global: 8 slot
  - SAM3 discovery: `_find_comfy_node_class`, `_find_comfy_node_mapping_class`
  - Impact input: `_comfy_max_resolution`, `_impact_scheduler_names`
  - SAM3 node: `_comfy_max_resolution`, `_encode_with_comfy_clip`, `_load_checkpoint_with_comfy`, `_preferred_checkpoint_default`
- E-07 provider decision: 5 slot
- existing root-name helper: 3 slot
- root direct dependency: 세 호출 모두 `_resolve_comfy_host_helper`
- callers:
  - SAM3 optional-node discovery
  - Impact Detailer `INPUT_TYPES`
  - SAM3 context `INPUT_TYPES` / checkpoint load
  - SAM3 Detailer prompt encode
- repository replacement names: `_impact_scheduler_names`, `_load_checkpoint_with_comfy`
  - test 이관 비용 증거이며 public root compatibility 근거가 아님
- alias boundary:
  - provider helper는 이미 root symbol이 아닌 E-07 virtual seam
  - 세 non-provider root alias는 다른 AiO/owner consumer 때문에 이 lane에서 제거하지 않음
- global state:
  - 현재 binder가 canonical module global을 root import 때 1회 변경
  - 설치된 closure는 실제 target을 call time에 다시 resolve

## Allowed boundary

Production:

- `nodes.py`
- `easyuse_anima/image/sam3.py`
- `easyuse_anima/nodes/impact_detailer_nodes.py`
- `easyuse_anima/nodes/sam3_nodes.py`

Supporting:

- focused SAM3/node-contract tests
- Python compatibility gate/fixture
- `docs/architecture/*`

## Exit

- root가 세 binder를 import/call하지 않음
- canonical module이 root import 없이 provider/direct-helper wiring을 소유
- provider decision은 call-time이며 flat pre-bootstrap default-provider fallback 유지
- non-provider target의 구현·반환 identity·예외·호출 timing 유지
- 세 canonical module에서 bind-time mutable runtime 설치 제거
- schema/workflow/SAM3·Impact behavior/optional dependency timing/public mapping 불변

## 금지 경계

- provider protocol/lifecycle 변경
- detection/detailing/checkpoint behavior 또는 error text 변경
- input/schema/workflow/seed/stage/cache/dependency discovery 변경
- 다른 owner family binder cleanup
- 다른 consumer가 쓰는 root alias 제거

## 검증 상태

- focused:
  - `python -m unittest tests.test_sam3_nodes tests.test_python_compatibility_surface tests.test_node_contracts.ComfyAdapterMoveContractTests tests.test_comfy_adapters tests.test_python_backend_analyzer`
  - 61 tests passed
  - nodes module analyzer 4 tests passed after the reviewed B-11c30a shape baseline update
- official full:
  - `tools/check_custom_node.ps1 -Project <absolute PR worktree> -Profile full`
  - Python 964 tests passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline and G-03 six-group import boundary passed
  - `git diff --check` passed
  - Ruff 113 findings remain the existing G-01 report-only baseline
- 첫 full은 변경된 `nodes.py`의 별도 shape baseline이 B-11c29b3 blob을 가리켜 1건 실패했습니다. 새 1,820-line shape와 blob을 검토해 gate를 갱신한 뒤 최종 head에서 full 전체가 통과했습니다.
- package/Registry surface 변경 없음
- live ComfyUI smoke는 node schema/workflow/behavior 변경이 없는 Move라 실행하지 않음

## 구현 결과

- root binder import/call 3개와 canonical binder 정의 3개 제거
- bind-time canonical module global 설치 8 slot 제거
- provider 5 slot은 direct call-time consumer로 유지
- Comfy host ledger 전체는 22 slot / 15 module 유지
- non-provider 3 slot은 기존 canonical owner 직접 참조
- remaining audit: 27 binders / 4 families
- root `nodes.py`: 1,850 → 1,820 lines

Parent: #184. Closes no issue.
