### PR TITLE
B-11c30b: retire LoRA runtime binders

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1093,7 +1093,7 @@ Planned cleanup sequence:
 
 ### B-11c30a — Image/SAM3/Impact binder retirement
 
-- **State:** IMPLEMENTED in PR #337
+- **State:** COMPLETE on `dev` in PR #337 / `3647d3a`
 - **Owner:** #184
 - **Type:** Move
 - **Base:** `dev@02b8c4a17b11011f1381c27cef6bd869b50f81bb`
@@ -1172,6 +1172,75 @@ Implementation result:
 - focused SAM3, Comfy adapter, compatibility, and backend analyzer validation
   passes 61 tests.
 
+### B-11c30b — LoRA binder retirement
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Type:** Move
+- **Base:** `dev@3647d3ad35dffb77b35ca423e1b89c6a4d7c3116`
+
+Pre-edit inventory:
+
+- root `nodes.py` imports three private binders in both package and flat-import
+  paths, then calls `_bind_lora_metadata_runtime`,
+  `_bind_lora_preset_runtime`, and `_bind_lora_node_runtime` once each;
+- the metadata binder installs `_prompt_tokens`, `_resolve_helper`, and a
+  `_RuntimeLoggerProxy` in three module globals. Its resolver observes eight
+  metadata-owned names through root at call time;
+- the preset binder installs the prompt-correction callback and resolver in two
+  module globals. Its resolver observes five preset/value names through root at
+  call time;
+- the node binder replaces twelve already-imported canonical helpers with
+  call-time root closures, then installs the two shared input-type objects by
+  identity, for 14 bound globals total;
+- combined scope is 25 root-name slots, five direct dependency slots, and 19
+  bind-time global installations;
+- repository tests replace 14 names found in this family. The LoRA-specific
+  migrations are in `tests/test_lora_preset.py` and the LoRA contract section
+  of `tests/test_node_contracts.py`; replacements for other owner families do
+  not move in this lane;
+- root direct aliases for the metadata/preset helpers and shared input types
+  remain consumed by other tests or owner families and are not retirement
+  targets here; and
+- metadata/preset internal recursion, logger access, prompt-token/prompt-
+  correction callbacks, and node adapter helper calls all observe their
+  current target at use time after the one-time root binder installation.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/lora/metadata.py
+easyuse_anima/lora/preset.py
+easyuse_anima/nodes/lora_nodes.py
+```
+
+Allowed supporting files are focused LoRA/node-contract tests, the Python
+compatibility gate and fixtures, the nodes/backend analyzer baselines, and
+these architecture documents.
+
+Exit:
+
+- root no longer imports or calls the three LoRA binders;
+- canonical LoRA modules own their internal calls and canonical cross-module
+  dependencies without importing root `nodes.py`;
+- logger access and prompt-token/prompt-correction callbacks remain use-time;
+- `_FlexibleOptionalInputType` and `_ANY_TYPE` retain exact canonical object
+  identity;
+- LoRA helper/class root aliases, node schema, workflow payloads, stack order,
+  trigger order, error text, and optional dependency timing remain unchanged;
+  and
+- tests that previously replaced root only to drive LoRA canonical consumers
+  replace the owning canonical module instead.
+
+Forbidden:
+
+- changing LoRA profile/metadata/model-discovery behavior, prompt correction,
+  missing-model policy, schema/workflow serialization, logger message text, or
+  optional imports;
+- retiring root aliases used by another owner family; and
+- including Prompt/Regional, AiO, or Wildcard/NAIA binder cleanup.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining B-11c30 family Moves and the separate
@@ -1211,7 +1280,8 @@ COMPLETE: B-11c29c requirement helper retirement / PR #332
 COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
 COMPLETE: B-11c29b3 general node lookup retirement / PR #334
 COMPLETE: B-11c30 binder/resolver migration audit / PR #336
-IN PROGRESS: B-11c30a Image/SAM3/Impact binder Move / PR #337
+COMPLETE: B-11c30a Image/SAM3/Impact binder Move / PR #337
+IN PROGRESS: B-11c30b LoRA binder Move
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1174,7 +1174,7 @@ Implementation result:
 
 ### B-11c30b — LoRA binder retirement
 
-- **State:** IN PROGRESS
+- **State:** IMPLEMENTED in PR #338
 - **Owner:** #184
 - **Type:** Move
 - **Base:** `dev@3647d3ad35dffb77b35ca423e1b89c6a4d7c3116`
@@ -1241,6 +1241,25 @@ Forbidden:
 - retiring root aliases used by another owner family; and
 - including Prompt/Regional, AiO, or Wildcard/NAIA binder cleanup.
 
+Implementation result:
+
+- root imports/calls and the three canonical LoRA binder definitions are
+  removed;
+- metadata and preset internal helper calls resolve their canonical module
+  globals at use time, while prompt tokenization and prompt correction remain
+  lazy use-time callbacks to `prompt.fields`;
+- `_RuntimeLoggerProxy` remains installed at module import and resolves the
+  canonical logger at attribute access time;
+- the LoRA node adapter keeps direct canonical helper imports and exact
+  `_FlexibleOptionalInputType` / `_ANY_TYPE` identity;
+- LoRA-specific root-patch tests now replace the canonical owner, while root
+  aliases and replacements belonging to other families remain unchanged;
+- the remaining root audit is 24 binders in three families: 12
+  provider-then-root, ten root-only, and two explicit callbacks;
+- `nodes.py` is 1,800 lines, down 20 lines from the B-11c30a base; and
+- focused LoRA, contract, compatibility, and analyzer validation passes 61
+  tests.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining B-11c30 family Moves and the separate
@@ -1281,7 +1300,7 @@ COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
 COMPLETE: B-11c29b3 general node lookup retirement / PR #334
 COMPLETE: B-11c30 binder/resolver migration audit / PR #336
 COMPLETE: B-11c30a Image/SAM3/Impact binder Move / PR #337
-IN PROGRESS: B-11c30b LoRA binder Move
+IN PROGRESS: B-11c30b LoRA binder Move / PR #338
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30a / PR #337; B-11c30b LoRA binder Move in progress | Complete binder families, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c30a / PR #337; B-11c30b LoRA binder Move implemented in PR #338 | Complete binder families, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -100,8 +100,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   inventoried the remaining binder/resolver families without production
   changes in PR #336 / `02b8c4a`. B-11c30a retires only the three
   Image/SAM3/Impact binders in PR #337 / `3647d3a`; the remaining audit
-  contains 27 binders across four families. B-11c30b now retires only the three
-  LoRA binders.
+  contains 27 binders across four families. B-11c30b retires only the three
+  LoRA binders in PR #338; 24 binders across three families remain.
 
 ### Current quality baseline
 
@@ -343,7 +343,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30a PR #337; B-11c30b LoRA binder Move active | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30a PR #337; B-11c30b LoRA binder Move in PR #338 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30 / PR #336; B-11c30a Image/SAM3/Impact binder Move implemented in PR #337 | Complete binder families, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c30a / PR #337; B-11c30b LoRA binder Move in progress | Complete binder families, then the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -99,8 +99,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   retired the final general host lookup root wrapper in PR #334. B-11c30
   inventoried the remaining binder/resolver families without production
   changes in PR #336 / `02b8c4a`. B-11c30a retires only the three
-  Image/SAM3/Impact binders in PR #337; the remaining audit contains 27 binders
-  across four families.
+  Image/SAM3/Impact binders in PR #337 / `3647d3a`; the remaining audit
+  contains 27 binders across four families. B-11c30b now retires only the three
+  LoRA binders.
 
 ### Current quality baseline
 
@@ -342,7 +343,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30 audit PR #336; B-11c30a Image/SAM3/Impact binder Move in PR #337 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30a PR #337; B-11c30b LoRA binder Move active | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -721,6 +721,22 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - No node schema, workflow, optional-dependency timing, or SAM3/Impact behavior
   changes in this Move.
 
+### B-11c30b LoRA binder retirement
+
+- The three root LoRA binder imports/calls and canonical binder definitions are
+  removed.
+- Metadata and preset keep use-time canonical-module helper lookup. Prompt
+  tokenization and prompt correction remain lazy callbacks, and the logger
+  remains a use-time proxy.
+- The LoRA node adapter keeps direct canonical helper imports and exact shared
+  input-type identity.
+- Root helper/class aliases remain direct canonical aliases. Only tests that
+  used root replacement to drive LoRA canonical consumers move to the owning
+  module.
+- The remaining binder audit contains 24 binders in three owner families. No
+  LoRA schema, workflow, stack/trigger order, missing-model policy, or optional
+  dependency behavior changes in this Move.
+
 ### `nodes.py` public node-class surface
 
 The confirmed 0.5.2 mapped classes are:

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,9 +8,9 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30 are integrated. B-11c is split into
+- Current state: B-11a through B-11c30a are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c30a retires only the Image/SAM3/Impact binder family.
+  root shim; B-11c30b retires only the LoRA binder family.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root

--- a/easyuse_anima/lora/metadata.py
+++ b/easyuse_anima/lora/metadata.py
@@ -6,16 +6,7 @@ import json
 import logging
 import os
 
-
-logger = logging.getLogger("ComfyUI-EasyUseAnima")
 _TRIGGER_WORD_KEYS = ("trainedWords", "trained_words", "trigger_words", "activation_text")
-
-
-def _unbound_prompt_tokens(*_args, **_kwargs):
-    raise RuntimeError("LoRA metadata prompt-token dependency is not bound.")
-
-
-_prompt_tokens = _unbound_prompt_tokens
 
 
 class _RuntimeLoggerProxy:
@@ -26,22 +17,17 @@ class _RuntimeLoggerProxy:
         return getattr(self._resolve_logger(), name)
 
 
-def _default_resolve_helper(name):
-    return globals()[name]
+def _resolve_logger():
+    return logging.getLogger("ComfyUI-EasyUseAnima")
 
 
-_resolve_helper = _default_resolve_helper
+logger = _RuntimeLoggerProxy(lambda: _resolve_logger())
 
 
-def _runtime_helper(name):
-    return _resolve_helper(name)
+def _prompt_tokens(*args, **kwargs):
+    from ..prompt.fields import _prompt_tokens as prompt_tokens
 
-
-def _bind_lora_metadata_runtime(*, prompt_tokens, resolve_helper, resolve_logger) -> None:
-    global _prompt_tokens, _resolve_helper, logger
-    _prompt_tokens = prompt_tokens
-    _resolve_helper = resolve_helper
-    logger = _RuntimeLoggerProxy(resolve_logger)
+    return prompt_tokens(*args, **kwargs)
 
 
 def _apply_lora_syntax_format(name: str) -> str:
@@ -118,17 +104,17 @@ def _dedupe_text_values(values) -> list[str]:
 
 def _trigger_words_from_value(value) -> list[str]:
     if isinstance(value, str):
-        return _runtime_helper("_dedupe_text_values")(_prompt_tokens(value))
+        return _dedupe_text_values(_prompt_tokens(value))
     if isinstance(value, dict):
         for key in ("word", "name", "tag", "text"):
             if key in value:
-                return _runtime_helper("_trigger_words_from_value")(value.get(key))
+                return _trigger_words_from_value(value.get(key))
         return []
     if isinstance(value, (list, tuple, set)):
         words: list[str] = []
         for item in value:
-            words.extend(_runtime_helper("_trigger_words_from_value")(item))
-        return _runtime_helper("_dedupe_text_values")(words)
+            words.extend(_trigger_words_from_value(item))
+        return _dedupe_text_values(words)
     return []
 
 
@@ -138,11 +124,11 @@ def _metadata_json_paths_for_lora(lora_path: str) -> list[str]:
         return []
     base, _ext = os.path.splitext(path)
     candidates = [f"{base}.metadata.json", f"{path}.metadata.json"]
-    return _runtime_helper("_dedupe_text_values")(candidates)
+    return _dedupe_text_values(candidates)
 
 
 def _load_lora_manager_metadata(lora_path: str) -> dict:
-    for metadata_path in _runtime_helper("_metadata_json_paths_for_lora")(lora_path):
+    for metadata_path in _metadata_json_paths_for_lora(lora_path):
         if not os.path.isfile(metadata_path):
             continue
         try:
@@ -161,25 +147,25 @@ def _lora_manager_trigger_words_from_metadata(metadata: dict) -> list[str]:
         return []
 
     words: list[str] = []
-    for key in _runtime_helper("_TRIGGER_WORD_KEYS"):
-        words.extend(_runtime_helper("_trigger_words_from_value")(metadata.get(key)))
+    for key in _TRIGGER_WORD_KEYS:
+        words.extend(_trigger_words_from_value(metadata.get(key)))
 
     civitai = metadata.get("civitai")
     if isinstance(civitai, dict):
-        for key in _runtime_helper("_TRIGGER_WORD_KEYS"):
-            words.extend(_runtime_helper("_trigger_words_from_value")(civitai.get(key)))
+        for key in _TRIGGER_WORD_KEYS:
+            words.extend(_trigger_words_from_value(civitai.get(key)))
 
-    return _runtime_helper("_dedupe_text_values")(words)
+    return _dedupe_text_values(words)
 
 
 def _get_lora_manager_trigger_words(lora_path: str) -> list[str]:
-    metadata = _runtime_helper("_load_lora_manager_metadata")(lora_path)
-    return _runtime_helper("_lora_manager_trigger_words_from_metadata")(metadata)
+    metadata = _load_lora_manager_metadata(lora_path)
+    return _lora_manager_trigger_words_from_metadata(metadata)
 
 
 def _get_lora_info(lora_name: str) -> tuple[str, list[str]]:
-    fallback_path = _runtime_helper("_fallback_lora_path")(lora_name)
-    trigger_words = _runtime_helper("_get_lora_manager_trigger_words")(fallback_path)
+    fallback_path = _fallback_lora_path(lora_name)
+    trigger_words = _get_lora_manager_trigger_words(fallback_path)
     if trigger_words:
         return fallback_path, trigger_words
 
@@ -189,10 +175,10 @@ def _get_lora_info(lora_name: str) -> tuple[str, list[str]]:
         path, trigger_words = get_lora_info(lora_name)
         if not isinstance(trigger_words, list):
             trigger_words = []
-        trigger_words = _runtime_helper("_dedupe_text_values")(trigger_words)
+        trigger_words = _dedupe_text_values(trigger_words)
         if trigger_words:
             return str(path), trigger_words
-        json_trigger_words = _runtime_helper("_get_lora_manager_trigger_words")(str(path))
+        json_trigger_words = _get_lora_manager_trigger_words(str(path))
         return str(path), json_trigger_words
     except Exception:
         return fallback_path, []
@@ -229,7 +215,7 @@ def _lora_model_exists(lora_name: str) -> bool | None:
     except Exception:
         return None
 
-    candidates = _runtime_helper("_dedupe_text_values")((
+    candidates = _dedupe_text_values((
         name,
         name.replace("\\", "/"),
         name.replace("/", os.sep),

--- a/easyuse_anima/lora/preset.py
+++ b/easyuse_anima/lora/preset.py
@@ -7,37 +7,20 @@ from typing import Any
 
 from ..common.values import _as_int
 
-def _unbound_correct_builder_prompt(*_args, **_kwargs):
-    raise RuntimeError("LoRA preset prompt-correction dependency is not bound.")
 
+def _correct_builder_prompt(*args, **kwargs):
+    from ..prompt.fields import _correct_builder_prompt as correct_builder_prompt
 
-_correct_builder_prompt = _unbound_correct_builder_prompt
-
-
-def _default_resolve_helper(name):
-    return globals()[name]
-
-
-_resolve_helper = _default_resolve_helper
-
-
-def _runtime_helper(name):
-    return _resolve_helper(name)
-
-
-def _bind_lora_preset_runtime(*, correct_builder_prompt, resolve_helper) -> None:
-    global _correct_builder_prompt, _resolve_helper
-    _correct_builder_prompt = correct_builder_prompt
-    _resolve_helper = resolve_helper
+    return correct_builder_prompt(*args, **kwargs)
 
 
 def _profile_key(profile_index: int) -> str:
-    return str(max(1, _runtime_helper("_as_int")(profile_index, 1)))
+    return str(max(1, _as_int(profile_index, 1)))
 
 
 def _wrap_profile_index(profile_index: int, profile_count: int) -> int:
-    count = max(1, min(16, _runtime_helper("_as_int")(profile_count, 1)))
-    index = max(1, _runtime_helper("_as_int")(profile_index, 1))
+    count = max(1, min(16, _as_int(profile_count, 1)))
+    index = max(1, _as_int(profile_index, 1))
     return ((index - 1) % count) + 1
 
 
@@ -88,9 +71,9 @@ def _select_profile_values(
     style_prompt: str,
     kwargs: dict,
 ) -> tuple[str, list[dict], int]:
-    selected_index = _runtime_helper("_wrap_profile_index")(profile_index, profile_count)
-    profile = _runtime_helper("_load_profile_data")(profile_data).get(
-        _runtime_helper("_profile_key")(selected_index),
+    selected_index = _wrap_profile_index(profile_index, profile_count)
+    profile = _load_profile_data(profile_data).get(
+        _profile_key(selected_index),
         {},
     )
     selected_style = str(profile.get("style_prompt", style_prompt or ""))
@@ -98,7 +81,7 @@ def _select_profile_values(
     if isinstance(profile_loras, list):
         loras = [item for item in profile_loras if isinstance(item, dict)]
     else:
-        loras = _runtime_helper("_get_loras_list")(kwargs)
+        loras = _get_loras_list(kwargs)
     return selected_style, loras, selected_index
 
 

--- a/easyuse_anima/nodes/lora_nodes.py
+++ b/easyuse_anima/nodes/lora_nodes.py
@@ -19,35 +19,6 @@ from ..lora.preset import _correct_style_prompt, _format_strength, _select_profi
 from .input_types import _ANY_TYPE, _FlexibleOptionalInputType
 
 
-def _bind_lora_node_runtime(*, resolve_helper, flexible_optional_input_type, any_type) -> None:
-    global _as_bool, _stable_change_key
-    global _apply_lora_syntax_format, _get_lora_info, _lora_combo_values
-    global _lora_model_exists, _lora_stack_name, _missing_lora_display_name
-    global _raise_missing_loras, _correct_style_prompt, _format_strength
-    global _select_profile_values, _FlexibleOptionalInputType, _ANY_TYPE
-
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
-
-        return call
-
-    _as_bool = runtime_helper("_as_bool")
-    _stable_change_key = runtime_helper("_stable_change_key")
-    _apply_lora_syntax_format = runtime_helper("_apply_lora_syntax_format")
-    _get_lora_info = runtime_helper("_get_lora_info")
-    _lora_combo_values = runtime_helper("_lora_combo_values")
-    _lora_model_exists = runtime_helper("_lora_model_exists")
-    _lora_stack_name = runtime_helper("_lora_stack_name")
-    _missing_lora_display_name = runtime_helper("_missing_lora_display_name")
-    _raise_missing_loras = runtime_helper("_raise_missing_loras")
-    _correct_style_prompt = runtime_helper("_correct_style_prompt")
-    _format_strength = runtime_helper("_format_strength")
-    _select_profile_values = runtime_helper("_select_profile_values")
-    _FlexibleOptionalInputType = flexible_optional_input_type
-    _ANY_TYPE = any_type
-
-
 class EasyUseAnimaLoraPreset:
     """Multi-profile LoRA stack preset node for ANIMA style prompts."""
 

--- a/nodes.py
+++ b/nodes.py
@@ -500,7 +500,6 @@ try:
     )
     from .easyuse_anima.lora.metadata import (
         _apply_lora_syntax_format as _apply_lora_syntax_format,
-        _bind_lora_metadata_runtime as _bind_lora_metadata_runtime,
         _dedupe_text_values as _dedupe_text_values,
         _fallback_lora_path as _fallback_lora_path,
         _get_lora_info as _get_lora_info,
@@ -516,7 +515,6 @@ try:
         _trigger_words_from_value as _trigger_words_from_value,
     )
     from .easyuse_anima.lora.preset import (
-        _bind_lora_preset_runtime as _bind_lora_preset_runtime,
         _correct_style_prompt as _correct_style_prompt,
         _format_strength as _format_strength,
         _get_loras_list as _get_loras_list,
@@ -527,7 +525,6 @@ try:
     )
     from .easyuse_anima.nodes.lora_nodes import (
         EasyUseAnimaLoraPreset as EasyUseAnimaLoraPreset,
-        _bind_lora_node_runtime as _bind_lora_node_runtime,
     )
     from .anima_prompt import correct_prompt, load_knowledge_base
     from .anima_prompt.parser import parse_prompt
@@ -1052,7 +1049,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.lora.metadata import (
         _apply_lora_syntax_format as _apply_lora_syntax_format,
-        _bind_lora_metadata_runtime as _bind_lora_metadata_runtime,
         _dedupe_text_values as _dedupe_text_values,
         _fallback_lora_path as _fallback_lora_path,
         _get_lora_info as _get_lora_info,
@@ -1068,7 +1064,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _trigger_words_from_value as _trigger_words_from_value,
     )
     from easyuse_anima.lora.preset import (
-        _bind_lora_preset_runtime as _bind_lora_preset_runtime,
         _correct_style_prompt as _correct_style_prompt,
         _format_strength as _format_strength,
         _get_loras_list as _get_loras_list,
@@ -1079,7 +1074,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.nodes.lora_nodes import (
         EasyUseAnimaLoraPreset as EasyUseAnimaLoraPreset,
-        _bind_lora_node_runtime as _bind_lora_node_runtime,
     )
     from anima_prompt import correct_prompt, load_knowledge_base
     from anima_prompt.parser import parse_prompt
@@ -1803,18 +1797,4 @@ _bind_naia_node_runtime(
     get_workflow_node=lambda *args, **kwargs: _get_workflow_node(*args, **kwargs),
     post_random=lambda *args, **kwargs: _post_random(*args, **kwargs),
     parse_random_response=lambda *args, **kwargs: _parse_random_response(*args, **kwargs),
-)
-_bind_lora_metadata_runtime(
-    prompt_tokens=lambda *args, **kwargs: _prompt_tokens(*args, **kwargs),
-    resolve_helper=lambda name: globals()[name],
-    resolve_logger=lambda: logger,
-)
-_bind_lora_preset_runtime(
-    correct_builder_prompt=lambda *args, **kwargs: _correct_builder_prompt(*args, **kwargs),
-    resolve_helper=lambda name: globals()[name],
-)
-_bind_lora_node_runtime(
-    resolve_helper=lambda name: globals()[name],
-    flexible_optional_input_type=_FlexibleOptionalInputType,
-    any_type=_ANY_TYPE,
 )

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -8488,6 +8488,24 @@
         "source": "easyuse_anima/lora/metadata.py"
       },
       {
+        "alias": "prompt_tokens",
+        "bound_name": "prompt_tokens",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": "..prompt.fields:_prompt_tokens",
+        "kind": "static_from",
+        "line": 28,
+        "name": "_prompt_tokens",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "_prompt_tokens",
+        "source": "easyuse_anima/lora/metadata.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
         "alias": null,
         "bound_name": "apply_lora_syntax_format",
         "branch_context": [
@@ -8496,7 +8514,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 48
+            "line": 34
           }
         ],
         "classification": "external",
@@ -8504,7 +8522,7 @@
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 49,
+        "line": 35,
         "name": "apply_lora_syntax_format",
         "optional": true,
         "requested": "py.nodes.utils",
@@ -8521,7 +8539,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 58
+            "line": 44
           }
         ],
         "classification": "external",
@@ -8529,7 +8547,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 59,
+        "line": 45,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -8546,7 +8564,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 80
+            "line": 66
           }
         ],
         "classification": "external",
@@ -8554,7 +8572,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 81,
+        "line": 67,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -8571,7 +8589,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 186
+            "line": 172
           }
         ],
         "classification": "external",
@@ -8579,7 +8597,7 @@
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 187,
+        "line": 173,
         "name": "get_lora_info",
         "optional": true,
         "requested": "py.utils.utils",
@@ -8596,7 +8614,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 202
+            "line": 188
           }
         ],
         "classification": "external",
@@ -8604,7 +8622,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 203,
+        "line": 189,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -8621,7 +8639,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 227
+            "line": 213
           }
         ],
         "classification": "external",
@@ -8629,7 +8647,7 @@
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 228,
+        "line": 214,
         "name": null,
         "optional": true,
         "requested": "folder_paths",
@@ -8705,6 +8723,24 @@
         "scope": "<module>",
         "source": "easyuse_anima/lora/preset.py",
         "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": "correct_builder_prompt",
+        "bound_name": "correct_builder_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": "..prompt.fields:_correct_builder_prompt",
+        "kind": "static_from",
+        "line": 12,
+        "name": "_correct_builder_prompt",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "_correct_builder_prompt",
+        "source": "easyuse_anima/lora/preset.py",
+        "target": "easyuse_anima/prompt/fields.py"
       },
       {
         "alias": null,
@@ -23137,37 +23173,6 @@
         "target": "easyuse_anima/lora/metadata.py"
       },
       {
-        "alias": "_bind_lora_metadata_runtime",
-        "bound_name": "_bind_lora_metadata_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_lora_metadata_runtime",
-          "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
-        "kind": "static_from",
-        "line": 501,
-        "name": "_bind_lora_metadata_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.lora.metadata",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/lora/metadata.py"
-      },
-      {
         "alias": "_dedupe_text_values",
         "bound_name": "_dedupe_text_values",
         "branch_context": [
@@ -23571,37 +23576,6 @@
         "target": "easyuse_anima/lora/metadata.py"
       },
       {
-        "alias": "_bind_lora_preset_runtime",
-        "bound_name": "_bind_lora_preset_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_lora_preset_runtime",
-          "target": "easyuse_anima/lora/preset.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.lora.preset:_bind_lora_preset_runtime",
-        "kind": "static_from",
-        "line": 518,
-        "name": "_bind_lora_preset_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.lora.preset",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/lora/preset.py"
-      },
-      {
         "alias": "_correct_style_prompt",
         "bound_name": "_correct_style_prompt",
         "branch_context": [
@@ -23623,7 +23597,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 518,
+        "line": 517,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23654,7 +23628,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 518,
+        "line": 517,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23685,7 +23659,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 518,
+        "line": 517,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23716,7 +23690,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 518,
+        "line": 517,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23747,7 +23721,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 518,
+        "line": 517,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23778,7 +23752,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 518,
+        "line": 517,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23809,7 +23783,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 518,
+        "line": 517,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23840,39 +23814,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 528,
+        "line": 526,
         "name": "EasyUseAnimaLoraPreset",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.lora_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/lora_nodes.py"
-      },
-      {
-        "alias": "_bind_lora_node_runtime",
-        "bound_name": "_bind_lora_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_lora_node_runtime",
-          "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
-        "kind": "static_from",
-        "line": 528,
-        "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
         "role": "compatibility_primary",
@@ -23902,7 +23845,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 532,
+        "line": 529,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23933,7 +23876,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 532,
+        "line": 529,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23964,7 +23907,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 533,
+        "line": 530,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23995,7 +23938,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 534,
+        "line": 531,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24026,7 +23969,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 534,
+        "line": 531,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24057,7 +24000,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 534,
+        "line": 531,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24088,7 +24031,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 539,
+        "line": 536,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24119,7 +24062,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 539,
+        "line": 536,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24150,7 +24093,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24181,7 +24124,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24212,7 +24155,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24243,7 +24186,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24274,7 +24217,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24305,7 +24248,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24336,7 +24279,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24367,7 +24310,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24398,7 +24341,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24429,7 +24372,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24460,7 +24403,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24491,7 +24434,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24522,7 +24465,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24553,7 +24496,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24584,7 +24527,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24615,7 +24558,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24646,7 +24589,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24677,7 +24620,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24708,7 +24651,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 540,
+        "line": 537,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24727,7 +24670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24742,7 +24685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24761,7 +24704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24776,7 +24719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24795,7 +24738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24810,7 +24753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24829,7 +24772,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24844,7 +24787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24863,7 +24806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24878,7 +24821,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24897,7 +24840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24912,7 +24855,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24931,7 +24874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24946,7 +24889,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24965,7 +24908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -24980,7 +24923,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24999,7 +24942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25014,7 +24957,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25033,7 +24976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25048,7 +24991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25067,7 +25010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25082,7 +25025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25101,7 +25044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25116,7 +25059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25135,7 +25078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25150,7 +25093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25169,7 +25112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25184,7 +25127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25203,7 +25146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25218,7 +25161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25237,7 +25180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25252,7 +25195,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25271,7 +25214,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25286,7 +25229,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25305,7 +25248,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25320,7 +25263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25339,7 +25282,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25354,7 +25297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25373,7 +25316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25388,7 +25331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25407,7 +25350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25422,7 +25365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25441,7 +25384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25456,7 +25399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25475,7 +25418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25490,7 +25433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25509,7 +25452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25524,7 +25467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25543,7 +25486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25558,7 +25501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25577,7 +25520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25592,7 +25535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25611,7 +25554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25626,7 +25569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25645,7 +25588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25660,7 +25603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25679,7 +25622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25694,7 +25637,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25713,7 +25656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25728,7 +25671,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25747,7 +25690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25762,7 +25705,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25781,7 +25724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25796,7 +25739,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25815,7 +25758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25830,7 +25773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 601,
+        "line": 598,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25849,7 +25792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25864,7 +25807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 604,
+        "line": 601,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25883,7 +25826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25898,7 +25841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 604,
+        "line": 601,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25917,7 +25860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25932,7 +25875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 601,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25951,7 +25894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -25966,7 +25909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25985,7 +25928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26000,7 +25943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26019,7 +25962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26034,7 +25977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26053,7 +25996,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26068,7 +26011,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26087,7 +26030,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26102,7 +26045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26121,7 +26064,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26136,7 +26079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26155,7 +26098,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26170,7 +26113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26189,7 +26132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26204,7 +26147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26223,7 +26166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26238,7 +26181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26257,7 +26200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26272,7 +26215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26291,7 +26234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26306,7 +26249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26325,7 +26268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26340,7 +26283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26359,7 +26302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26374,7 +26317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26393,7 +26336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26408,7 +26351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26427,7 +26370,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26442,7 +26385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26461,7 +26404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26476,7 +26419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26495,7 +26438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26510,7 +26453,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26529,7 +26472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26544,7 +26487,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26563,7 +26506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26578,7 +26521,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26597,7 +26540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26612,7 +26555,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26631,7 +26574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26646,7 +26589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26665,7 +26608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26680,7 +26623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26699,7 +26642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26714,7 +26657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26733,7 +26676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26748,7 +26691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26767,7 +26710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26782,7 +26725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26801,7 +26744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26816,7 +26759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26835,7 +26778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26850,7 +26793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26869,7 +26812,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26884,7 +26827,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26903,7 +26846,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26918,7 +26861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26937,7 +26880,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26952,7 +26895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26971,7 +26914,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -26986,7 +26929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27005,7 +26948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27020,7 +26963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27039,7 +26982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27054,7 +26997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27073,7 +27016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27088,7 +27031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27107,7 +27050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27122,7 +27065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27141,7 +27084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27156,7 +27099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27175,7 +27118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27190,7 +27133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27209,7 +27152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27224,7 +27167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27243,7 +27186,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27258,7 +27201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27277,7 +27220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27292,7 +27235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27311,7 +27254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27326,7 +27269,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27345,7 +27288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27360,7 +27303,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27379,7 +27322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27394,7 +27337,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27413,7 +27356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27428,7 +27371,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27447,7 +27390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27462,7 +27405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27481,7 +27424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27496,7 +27439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27515,7 +27458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27530,7 +27473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27549,7 +27492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27564,7 +27507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27583,7 +27526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27598,7 +27541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27617,7 +27560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27632,7 +27575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27651,7 +27594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27666,7 +27609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27685,7 +27628,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27700,7 +27643,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27719,7 +27662,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27734,7 +27677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27753,7 +27696,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27768,7 +27711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27787,7 +27730,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27802,7 +27745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27821,7 +27764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27836,7 +27779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27855,7 +27798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27870,7 +27813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27889,7 +27832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27904,7 +27847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27923,7 +27866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27938,7 +27881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27957,7 +27900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -27972,7 +27915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27991,7 +27934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28006,7 +27949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28025,7 +27968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28040,7 +27983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28059,7 +28002,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28074,7 +28017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28093,7 +28036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28108,7 +28051,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28127,7 +28070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28142,7 +28085,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28161,7 +28104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28176,7 +28119,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28195,7 +28138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28210,7 +28153,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28229,7 +28172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28244,7 +28187,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28263,7 +28206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28278,7 +28221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28297,7 +28240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28312,7 +28255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28331,7 +28274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28346,7 +28289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 693,
+        "line": 690,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28365,7 +28308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28380,7 +28323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 693,
+        "line": 690,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28399,7 +28342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28414,7 +28357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 693,
+        "line": 690,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28433,7 +28376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28448,7 +28391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28467,7 +28410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28482,7 +28425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28501,7 +28444,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28516,7 +28459,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28535,7 +28478,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28550,7 +28493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28569,7 +28512,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28584,7 +28527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28603,7 +28546,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28618,7 +28561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 705,
+        "line": 702,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28637,7 +28580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28652,7 +28595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "name": "_bind_prompt_correction_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28671,7 +28614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28686,7 +28629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28705,7 +28648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28720,7 +28663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28739,7 +28682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28754,7 +28697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28773,7 +28716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28788,7 +28731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28807,7 +28750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28822,7 +28765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28841,7 +28784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28856,7 +28799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28875,7 +28818,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28890,7 +28833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28909,7 +28852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28924,7 +28867,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28943,7 +28886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28958,7 +28901,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28977,7 +28920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -28992,7 +28935,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29011,7 +28954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29026,7 +28969,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29045,7 +28988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29060,7 +29003,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29079,7 +29022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29094,7 +29037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29113,7 +29056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29128,7 +29071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29147,7 +29090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29162,7 +29105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29181,7 +29124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29196,7 +29139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29215,7 +29158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29230,7 +29173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29249,7 +29192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29264,7 +29207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29283,7 +29226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29298,7 +29241,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29317,7 +29260,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29332,7 +29275,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29351,7 +29294,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29366,7 +29309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29385,7 +29328,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29400,7 +29343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29419,7 +29362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29434,7 +29377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29453,7 +29396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29468,7 +29411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29487,7 +29430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29502,7 +29445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29521,7 +29464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29536,7 +29479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29555,7 +29498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29570,7 +29513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29589,7 +29532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29604,7 +29547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29623,7 +29566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29638,7 +29581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29657,7 +29600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29672,7 +29615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29691,7 +29634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29706,7 +29649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29725,7 +29668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29740,7 +29683,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29759,7 +29702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29774,7 +29717,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29793,7 +29736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29808,7 +29751,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29827,7 +29770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29842,7 +29785,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29861,7 +29804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29876,7 +29819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29895,7 +29838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29910,7 +29853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29929,7 +29872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29944,7 +29887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29963,7 +29906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -29978,7 +29921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29997,7 +29940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30012,7 +29955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30031,7 +29974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30046,7 +29989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30065,7 +30008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30080,7 +30023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30099,7 +30042,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30114,7 +30057,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30133,7 +30076,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30148,7 +30091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30167,7 +30110,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30182,7 +30125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30201,7 +30144,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30216,7 +30159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30235,7 +30178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30250,7 +30193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30269,7 +30212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30284,7 +30227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30303,7 +30246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30318,7 +30261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30337,7 +30280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30352,7 +30295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30371,7 +30314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30386,7 +30329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30405,7 +30348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30420,7 +30363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30439,7 +30382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30454,7 +30397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30473,7 +30416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30488,7 +30431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30507,7 +30450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30522,7 +30465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30541,7 +30484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30556,7 +30499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30575,7 +30518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30590,7 +30533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30609,7 +30552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30624,7 +30567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30643,7 +30586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30658,7 +30601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30677,7 +30620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30692,7 +30635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30711,7 +30654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30726,7 +30669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30745,7 +30688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30760,7 +30703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30779,7 +30722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30794,7 +30737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30813,7 +30756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30828,7 +30771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30847,7 +30790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30862,7 +30805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30881,7 +30824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30896,7 +30839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30915,7 +30858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30930,7 +30873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30949,7 +30892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30964,7 +30907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30983,7 +30926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -30998,7 +30941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31017,7 +30960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31032,7 +30975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31051,7 +30994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31066,7 +31009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31085,7 +31028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31100,7 +31043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31119,7 +31062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31134,7 +31077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31153,7 +31096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31168,7 +31111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31187,7 +31130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31202,7 +31145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31221,7 +31164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31236,7 +31179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31255,7 +31198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31270,7 +31213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31289,7 +31232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31304,7 +31247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31323,7 +31266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31338,7 +31281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31357,7 +31300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31372,7 +31315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31391,7 +31334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31406,7 +31349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31425,7 +31368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31440,7 +31383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31459,7 +31402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31474,7 +31417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31493,7 +31436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31508,7 +31451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31527,7 +31470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31542,7 +31485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31561,7 +31504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31576,7 +31519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31595,7 +31538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31610,7 +31553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31629,7 +31572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31644,7 +31587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31663,7 +31606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31678,7 +31621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31697,7 +31640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31712,7 +31655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31731,7 +31674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31746,7 +31689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31765,7 +31708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31780,7 +31723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31799,7 +31742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31814,7 +31757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31833,7 +31776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31848,7 +31791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31867,7 +31810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31882,7 +31825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 910,
+        "line": 907,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31901,7 +31844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31916,7 +31859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 910,
+        "line": 907,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31935,7 +31878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31950,7 +31893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 910,
+        "line": 907,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31969,7 +31912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -31984,7 +31927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32003,7 +31946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32018,7 +31961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32037,7 +31980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32052,7 +31995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32071,7 +32014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32086,7 +32029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32105,7 +32048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32120,7 +32063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32139,7 +32082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32154,7 +32097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32173,7 +32116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32188,7 +32131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32207,7 +32150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32222,7 +32165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32241,7 +32184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32256,7 +32199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32275,7 +32218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32290,7 +32233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32309,7 +32252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32324,7 +32267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 930,
+        "line": 927,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32343,7 +32286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32358,7 +32301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 930,
+        "line": 927,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32377,7 +32320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32392,7 +32335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 930,
+        "line": 927,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32411,7 +32354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32426,7 +32369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 941,
+        "line": 938,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32445,7 +32388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32460,7 +32403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 941,
+        "line": 938,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32479,7 +32422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32494,7 +32437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 941,
+        "line": 938,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32513,7 +32456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32528,7 +32471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32547,7 +32490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32562,7 +32505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32581,7 +32524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32596,7 +32539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 961,
+        "line": 958,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32615,7 +32558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32630,7 +32573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 961,
+        "line": 958,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32649,7 +32592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32664,7 +32607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 961,
+        "line": 958,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32683,7 +32626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32698,7 +32641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32717,7 +32660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32732,7 +32675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32751,7 +32694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32766,7 +32709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32785,7 +32728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32800,7 +32743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 972,
+        "line": 969,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -32819,7 +32762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32834,7 +32777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32853,7 +32796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32868,7 +32811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32887,7 +32830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32902,7 +32845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32921,7 +32864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32936,7 +32879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32955,7 +32898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -32970,7 +32913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32989,7 +32932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33004,7 +32947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33023,7 +32966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33038,7 +32981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33057,7 +33000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33072,7 +33015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 987,
+        "line": 984,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33091,7 +33034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33106,7 +33049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 987,
+        "line": 984,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33125,7 +33068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33140,7 +33083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33159,7 +33102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33174,7 +33117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33193,7 +33136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33208,7 +33151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33227,7 +33170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33242,7 +33185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33261,7 +33204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33276,7 +33219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33295,7 +33238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33310,7 +33253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 998,
+        "line": 995,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33329,7 +33272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33344,7 +33287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 998,
+        "line": 995,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33363,7 +33306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33378,7 +33321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 995,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33397,7 +33340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33412,7 +33355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1000,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33431,7 +33374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33446,7 +33389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1000,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33465,7 +33408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33480,7 +33423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1000,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33499,7 +33442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33514,7 +33457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33533,7 +33476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33548,7 +33491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33567,7 +33510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33582,7 +33525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33601,7 +33544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33616,7 +33559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33635,7 +33578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33650,7 +33593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33669,7 +33612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33684,7 +33627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1041,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33703,7 +33646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33718,7 +33661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1041,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33737,7 +33680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33752,7 +33695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1045,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33771,7 +33714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33786,7 +33729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1045,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33805,7 +33748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33820,42 +33763,8 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_apply_lora_syntax_format",
-        "optional": false,
-        "requested": "easyuse_anima.lora.metadata",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/lora/metadata.py"
-      },
-      {
-        "alias": "_bind_lora_metadata_runtime",
-        "bound_name": "_bind_lora_metadata_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 561,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_lora_metadata_runtime",
-          "target": "easyuse_anima/lora/metadata.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
-        "kind": "static_from",
-        "line": 1053,
-        "name": "_bind_lora_metadata_runtime",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
         "role": "compatibility_fallback",
@@ -33873,7 +33782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33888,7 +33797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33907,7 +33816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33922,7 +33831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33941,7 +33850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33956,7 +33865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33975,7 +33884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -33990,7 +33899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34009,7 +33918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34024,7 +33933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34043,7 +33952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34058,7 +33967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34077,7 +33986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34092,7 +34001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34111,7 +34020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34126,7 +34035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34145,7 +34054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34160,7 +34069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34179,7 +34088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34194,7 +34103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34213,7 +34122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34228,7 +34137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34247,7 +34156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34262,7 +34171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34281,7 +34190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34296,7 +34205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34304,40 +34213,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/lora/metadata.py"
-      },
-      {
-        "alias": "_bind_lora_preset_runtime",
-        "bound_name": "_bind_lora_preset_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 561,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_lora_preset_runtime",
-          "target": "easyuse_anima/lora/preset.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
-        "kind": "static_from",
-        "line": 1070,
-        "name": "_bind_lora_preset_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.lora.preset",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/lora/preset.py"
       },
       {
         "alias": "_correct_style_prompt",
@@ -34349,7 +34224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34364,7 +34239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34383,7 +34258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34398,7 +34273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34417,7 +34292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34432,7 +34307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34451,7 +34326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34466,7 +34341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34485,7 +34360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34500,7 +34375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34519,7 +34394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34534,7 +34409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34553,7 +34428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34568,7 +34443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34587,7 +34462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34602,42 +34477,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1075,
         "name": "EasyUseAnimaLoraPreset",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.lora_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/lora_nodes.py"
-      },
-      {
-        "alias": "_bind_lora_node_runtime",
-        "bound_name": "_bind_lora_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 561,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_lora_node_runtime",
-          "target": "easyuse_anima/nodes/lora_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
-        "kind": "static_from",
-        "line": 1080,
-        "name": "_bind_lora_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
         "role": "compatibility_fallback",
@@ -34655,7 +34496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34670,7 +34511,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1078,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34689,7 +34530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34704,7 +34545,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1078,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34723,7 +34564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34738,7 +34579,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1079,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34757,7 +34598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34772,7 +34613,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1080,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34791,7 +34632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34806,7 +34647,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1080,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34825,7 +34666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34840,7 +34681,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1080,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34859,7 +34700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34874,7 +34715,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1085,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34893,7 +34734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34908,7 +34749,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1085,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34927,7 +34768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34942,7 +34783,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34961,7 +34802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -34976,7 +34817,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34995,7 +34836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35010,7 +34851,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35029,7 +34870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35044,7 +34885,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35063,7 +34904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35078,7 +34919,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35097,7 +34938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35112,7 +34953,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35131,7 +34972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35146,7 +34987,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35165,7 +35006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35180,7 +35021,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35199,7 +35040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35214,7 +35055,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35233,7 +35074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35248,7 +35089,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35267,7 +35108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35282,7 +35123,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35301,7 +35142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35316,7 +35157,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35335,7 +35176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35350,7 +35191,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35369,7 +35210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35384,7 +35225,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35403,7 +35244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35418,7 +35259,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35437,7 +35278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35452,7 +35293,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35471,7 +35312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35486,7 +35327,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35505,7 +35346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35520,7 +35361,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35539,7 +35380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -35554,7 +35395,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37269,8 +37110,16 @@
         "to": "easyuse_anima/runtime.py"
       },
       {
+        "from": "easyuse_anima/lora/metadata.py",
+        "to": "easyuse_anima/prompt/fields.py"
+      },
+      {
         "from": "easyuse_anima/lora/preset.py",
         "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/lora/preset.py",
+        "to": "easyuse_anima/prompt/fields.py"
       },
       {
         "from": "easyuse_anima/naia/resolution.py",
@@ -38905,26 +38754,26 @@
       },
       {
         "is_package": false,
-        "loc": 269,
+        "loc": 255,
         "module": "easyuse_anima.lora.metadata",
-        "normalized_git_blob_sha1": "d4bbee0807d4fd42fbb12628cb1a24385c6ed480",
+        "normalized_git_blob_sha1": "1ec058c4a5b87cc88628b60a279058b6b9473728",
         "path": "easyuse_anima/lora/metadata.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 18,
-          "global_count": 5
+          "function_count": 16,
+          "global_count": 3
         }
       },
       {
         "is_package": false,
-        "loc": 105,
+        "loc": 88,
         "module": "easyuse_anima.lora.preset",
-        "normalized_git_blob_sha1": "c1381ae8c3ff9414734c9febfa4f9ddbf1de31fd",
+        "normalized_git_blob_sha1": "ee0d8e8c049a1913ccd7a21f463bd50f43dd0627",
         "path": "easyuse_anima/lora/preset.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 11,
-          "global_count": 3
+          "function_count": 8,
+          "global_count": 1
         }
       },
       {
@@ -39025,13 +38874,13 @@
       },
       {
         "is_package": false,
-        "loc": 214,
+        "loc": 185,
         "module": "easyuse_anima.nodes.lora_nodes",
-        "normalized_git_blob_sha1": "1c870ccf56ea9a6338c1acdd256ab981b697db95",
+        "normalized_git_blob_sha1": "66ff2418a84f1c3dcb9697aa9743567c05a332a3",
         "path": "easyuse_anima/nodes/lora_nodes.py",
         "top_level": {
           "class_count": 1,
-          "function_count": 1,
+          "function_count": 0,
           "global_count": 1
         }
       },
@@ -39289,9 +39138,9 @@
       },
       {
         "is_package": false,
-        "loc": 1820,
+        "loc": 1800,
         "module": "nodes",
-        "normalized_git_blob_sha1": "c08a5d730f6078a8a2211bcc73ea3ca22a9452fa",
+        "normalized_git_blob_sha1": "256f87b4e83842437b5993661f42a9259a463e17",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -40655,7 +40504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40664,7 +40513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40678,7 +40527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40687,7 +40536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40701,7 +40550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40710,7 +40559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40724,7 +40573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40733,7 +40582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40747,7 +40596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40756,7 +40605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40770,7 +40619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40779,7 +40628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40793,7 +40642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40802,7 +40651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40816,7 +40665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40825,7 +40674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 562,
+        "line": 559,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40839,7 +40688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40848,7 +40697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40862,7 +40711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40871,7 +40720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40885,7 +40734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40894,7 +40743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40908,7 +40757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40917,7 +40766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40931,7 +40780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40940,7 +40789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40954,7 +40803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40963,7 +40812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40977,7 +40826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -40986,7 +40835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41000,7 +40849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41009,7 +40858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 573,
+        "line": 570,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41023,7 +40872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41032,7 +40881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41046,7 +40895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41055,7 +40904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41069,7 +40918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41078,7 +40927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41092,7 +40941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41101,7 +40950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41115,7 +40964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41124,7 +40973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41138,7 +40987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41147,7 +40996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41161,7 +41010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41170,7 +41019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41184,7 +41033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41193,7 +41042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41207,7 +41056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41216,7 +41065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41230,7 +41079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41239,7 +41088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41253,7 +41102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41262,7 +41111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41276,7 +41125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41285,7 +41134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41299,7 +41148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41308,7 +41157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41322,7 +41171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41331,7 +41180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41345,7 +41194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41354,7 +41203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41368,7 +41217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41377,7 +41226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 583,
+        "line": 580,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41391,7 +41240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41400,7 +41249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 601,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41414,7 +41263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41423,7 +41272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 604,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41437,7 +41286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41446,7 +41295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 604,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41460,7 +41309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41469,7 +41318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 604,
+        "line": 601,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41483,7 +41332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41492,7 +41341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41506,7 +41355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41515,7 +41364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41529,7 +41378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41538,7 +41387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41552,7 +41401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41561,7 +41410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41575,7 +41424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41584,7 +41433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 609,
+        "line": 606,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41598,7 +41447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41607,7 +41456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41621,7 +41470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41630,7 +41479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41644,7 +41493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41653,7 +41502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41667,7 +41516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41676,7 +41525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 616,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41690,7 +41539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41699,7 +41548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41713,7 +41562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41722,7 +41571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41736,7 +41585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41745,7 +41594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41759,7 +41608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41768,7 +41617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41782,7 +41631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41791,7 +41640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41805,7 +41654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41814,7 +41663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41828,7 +41677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41837,7 +41686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41851,7 +41700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41860,7 +41709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41874,7 +41723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41883,7 +41732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41897,7 +41746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41906,7 +41755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41920,7 +41769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41929,7 +41778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41943,7 +41792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41952,7 +41801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41966,7 +41815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41975,7 +41824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 622,
+        "line": 619,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41989,7 +41838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -41998,7 +41847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42012,7 +41861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42021,7 +41870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42035,7 +41884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42044,7 +41893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42058,7 +41907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42067,7 +41916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42081,7 +41930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42090,7 +41939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42104,7 +41953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42113,7 +41962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42127,7 +41976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42136,7 +41985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42150,7 +41999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42159,7 +42008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42173,7 +42022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42182,7 +42031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42196,7 +42045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42205,7 +42054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42219,7 +42068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42228,7 +42077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42242,7 +42091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42251,7 +42100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 637,
+        "line": 634,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42265,7 +42114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42274,7 +42123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42288,7 +42137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42297,7 +42146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42311,7 +42160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42320,7 +42169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42334,7 +42183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42343,7 +42192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42357,7 +42206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42366,7 +42215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42380,7 +42229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42389,7 +42238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42403,7 +42252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42412,7 +42261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42426,7 +42275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42435,7 +42284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42449,7 +42298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42458,7 +42307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42472,7 +42321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42481,7 +42330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 651,
+        "line": 648,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42495,7 +42344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42504,7 +42353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42518,7 +42367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42527,7 +42376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42541,7 +42390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42550,7 +42399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42564,7 +42413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42573,7 +42422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42587,7 +42436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42596,7 +42445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42610,7 +42459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42619,7 +42468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42633,7 +42482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42642,7 +42491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42656,7 +42505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42665,7 +42514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42679,7 +42528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42688,7 +42537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42702,7 +42551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42711,7 +42560,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 663,
+        "line": 660,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42725,7 +42574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42734,7 +42583,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42748,7 +42597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42757,7 +42606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42771,7 +42620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42780,7 +42629,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42794,7 +42643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42803,7 +42652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42817,7 +42666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42826,7 +42675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42840,7 +42689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42849,7 +42698,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42863,7 +42712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42872,7 +42721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42886,7 +42735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42895,7 +42744,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42909,7 +42758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42918,7 +42767,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42932,7 +42781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42941,7 +42790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42955,7 +42804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42964,7 +42813,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42978,7 +42827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -42987,7 +42836,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43001,7 +42850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43010,7 +42859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43024,7 +42873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43033,7 +42882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43047,7 +42896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43056,7 +42905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43070,7 +42919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43079,7 +42928,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 675,
+        "line": 672,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43093,7 +42942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43102,7 +42951,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 693,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43116,7 +42965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43125,7 +42974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 693,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43139,7 +42988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43148,7 +42997,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 693,
+        "line": 690,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43162,7 +43011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43171,7 +43020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43185,7 +43034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43194,7 +43043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43208,7 +43057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43217,7 +43066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43231,7 +43080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43240,7 +43089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43254,7 +43103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43263,7 +43112,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 698,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43277,7 +43126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43286,7 +43135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 705,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43300,7 +43149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43309,7 +43158,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43323,7 +43172,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43332,7 +43181,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43346,7 +43195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43355,7 +43204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43369,7 +43218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43378,7 +43227,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 706,
+        "line": 703,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43392,7 +43241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43401,7 +43250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43415,7 +43264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43424,7 +43273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43438,7 +43287,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43447,7 +43296,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43461,7 +43310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43470,7 +43319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43484,7 +43333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43493,7 +43342,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43507,7 +43356,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43516,7 +43365,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43530,7 +43379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43539,7 +43388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43553,7 +43402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43562,7 +43411,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43576,7 +43425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43585,7 +43434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43599,7 +43448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43608,7 +43457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 712,
+        "line": 709,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43622,7 +43471,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43631,7 +43480,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43645,7 +43494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43654,7 +43503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43668,7 +43517,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43677,7 +43526,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43691,7 +43540,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43700,7 +43549,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43714,7 +43563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43723,7 +43572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43737,7 +43586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43746,7 +43595,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43760,7 +43609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43769,7 +43618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 726,
+        "line": 723,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43783,7 +43632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43792,7 +43641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43806,7 +43655,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43815,7 +43664,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43829,7 +43678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43838,7 +43687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43852,7 +43701,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43861,7 +43710,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43875,7 +43724,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43884,7 +43733,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43898,7 +43747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43907,7 +43756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43921,7 +43770,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43930,7 +43779,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43944,7 +43793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43953,7 +43802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43967,7 +43816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43976,7 +43825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43990,7 +43839,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -43999,7 +43848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44013,7 +43862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44022,7 +43871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44036,7 +43885,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44045,7 +43894,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44059,7 +43908,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44068,7 +43917,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44082,7 +43931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44091,7 +43940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44105,7 +43954,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44114,7 +43963,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44128,7 +43977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44137,7 +43986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44151,7 +44000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44160,7 +44009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44174,7 +44023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44183,7 +44032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44197,7 +44046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44206,7 +44055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44220,7 +44069,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44229,7 +44078,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44243,7 +44092,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44252,7 +44101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44266,7 +44115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44275,7 +44124,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 744,
+        "line": 741,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44289,7 +44138,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44298,7 +44147,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44312,7 +44161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44321,7 +44170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44335,7 +44184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44344,7 +44193,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44358,7 +44207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44367,7 +44216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44381,7 +44230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44390,7 +44239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44404,7 +44253,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44413,7 +44262,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44427,7 +44276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44436,7 +44285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44450,7 +44299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44459,7 +44308,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44473,7 +44322,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44482,7 +44331,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44496,7 +44345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44505,7 +44354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44519,7 +44368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44528,7 +44377,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44542,7 +44391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44551,7 +44400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44565,7 +44414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44574,7 +44423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44588,7 +44437,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44597,7 +44446,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 780,
+        "line": 777,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44611,7 +44460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44620,7 +44469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44634,7 +44483,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44643,7 +44492,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44657,7 +44506,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44666,7 +44515,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44680,7 +44529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44689,7 +44538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44703,7 +44552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44712,7 +44561,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44726,7 +44575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44735,7 +44584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44749,7 +44598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44758,7 +44607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44772,7 +44621,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44781,7 +44630,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44795,7 +44644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44804,7 +44653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 808,
+        "line": 805,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44818,7 +44667,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44827,7 +44676,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44841,7 +44690,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44850,7 +44699,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44864,7 +44713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44873,7 +44722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44887,7 +44736,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44896,7 +44745,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44910,7 +44759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44919,7 +44768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44933,7 +44782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44942,7 +44791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44956,7 +44805,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44965,7 +44814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44979,7 +44828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -44988,7 +44837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45002,7 +44851,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45011,7 +44860,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45025,7 +44874,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45034,7 +44883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45048,7 +44897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45057,7 +44906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45071,7 +44920,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45080,7 +44929,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45094,7 +44943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45103,7 +44952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45117,7 +44966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45126,7 +44975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45140,7 +44989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45149,7 +44998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45163,7 +45012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45172,7 +45021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45186,7 +45035,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45195,7 +45044,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45209,7 +45058,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45218,7 +45067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45232,7 +45081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45241,7 +45090,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45255,7 +45104,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45264,7 +45113,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45278,7 +45127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45287,7 +45136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45301,7 +45150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45310,7 +45159,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45324,7 +45173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45333,7 +45182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45347,7 +45196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45356,7 +45205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45370,7 +45219,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45379,7 +45228,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 824,
+        "line": 821,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45393,7 +45242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45402,7 +45251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45416,7 +45265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45425,7 +45274,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45439,7 +45288,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45448,7 +45297,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45462,7 +45311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45471,7 +45320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 904,
+        "line": 901,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45485,7 +45334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45494,7 +45343,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 910,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45508,7 +45357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45517,7 +45366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 910,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45531,7 +45380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45540,7 +45389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 910,
+        "line": 907,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45554,7 +45403,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45563,7 +45412,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45577,7 +45426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45586,7 +45435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45600,7 +45449,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45609,7 +45458,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45623,7 +45472,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45632,7 +45481,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45646,7 +45495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45655,7 +45504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45669,7 +45518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45678,7 +45527,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45692,7 +45541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45701,7 +45550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45715,7 +45564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45724,7 +45573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45738,7 +45587,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45747,7 +45596,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45761,7 +45610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45770,7 +45619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 921,
+        "line": 918,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45784,7 +45633,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45793,7 +45642,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 930,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45807,7 +45656,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45816,7 +45665,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 930,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45830,7 +45679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45839,7 +45688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 930,
+        "line": 927,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45853,7 +45702,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45862,7 +45711,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 941,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45876,7 +45725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45885,7 +45734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 941,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45899,7 +45748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45908,7 +45757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 941,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45922,7 +45771,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45931,7 +45780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45945,7 +45794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45954,7 +45803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 953,
+        "line": 950,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45968,7 +45817,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -45977,7 +45826,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 961,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45991,7 +45840,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46000,7 +45849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 961,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46014,7 +45863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46023,7 +45872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 961,
+        "line": 958,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46037,7 +45886,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46046,7 +45895,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46060,7 +45909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46069,7 +45918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46083,7 +45932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46092,7 +45941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 967,
+        "line": 964,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46106,7 +45955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46115,7 +45964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 972,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46129,7 +45978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46138,7 +45987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46152,7 +46001,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46161,7 +46010,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46175,7 +46024,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46184,7 +46033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46198,7 +46047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46207,7 +46056,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46221,7 +46070,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46230,7 +46079,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 975,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46244,7 +46093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46253,7 +46102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46267,7 +46116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46276,7 +46125,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 983,
+        "line": 980,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46290,7 +46139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46299,7 +46148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 987,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46313,7 +46162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46322,7 +46171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 987,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46336,7 +46185,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46345,7 +46194,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46359,7 +46208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46368,7 +46217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46382,7 +46231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46391,7 +46240,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46405,7 +46254,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46414,7 +46263,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46428,7 +46277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46437,7 +46286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 991,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46451,7 +46300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46460,7 +46309,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 998,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46474,7 +46323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46483,7 +46332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 998,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46497,7 +46346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46506,7 +46355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 998,
+        "line": 995,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46520,7 +46369,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46529,7 +46378,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46543,7 +46392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46552,7 +46401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46566,7 +46415,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46575,7 +46424,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1003,
+        "line": 1000,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46589,7 +46438,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46598,7 +46447,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46612,7 +46461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46621,7 +46470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46635,7 +46484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46644,7 +46493,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46658,7 +46507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46667,7 +46516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46681,7 +46530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46690,7 +46539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1021,
+        "line": 1018,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46704,7 +46553,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46713,7 +46562,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46727,7 +46576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46736,7 +46585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1044,
+        "line": 1041,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46750,7 +46599,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46759,7 +46608,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46773,7 +46622,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46782,7 +46631,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1048,
+        "line": 1045,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46796,7 +46645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46805,7 +46654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46819,30 +46668,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.lora.metadata:_bind_lora_metadata_runtime",
-        "kind": "static_from",
-        "line": 1053,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/lora/metadata.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46851,7 +46677,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46865,7 +46691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46874,7 +46700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46888,7 +46714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46897,7 +46723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46911,7 +46737,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46920,7 +46746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46934,7 +46760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46943,7 +46769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46957,7 +46783,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46966,7 +46792,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46980,7 +46806,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -46989,7 +46815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47003,7 +46829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47012,7 +46838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47026,7 +46852,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47035,7 +46861,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47049,7 +46875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47058,7 +46884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47072,7 +46898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47081,7 +46907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47095,7 +46921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47104,7 +46930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47118,7 +46944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47127,7 +46953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1053,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47141,30 +46967,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.lora.preset:_bind_lora_preset_runtime",
-        "kind": "static_from",
-        "line": 1070,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/lora/preset.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47173,7 +46976,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47187,7 +46990,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47196,7 +46999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47210,7 +47013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47219,7 +47022,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47233,7 +47036,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47242,7 +47045,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47256,7 +47059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47265,7 +47068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47279,7 +47082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47288,7 +47091,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47302,7 +47105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47311,7 +47114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1070,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47325,7 +47128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47334,7 +47137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1075,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47348,30 +47151,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.lora_nodes:_bind_lora_node_runtime",
-        "kind": "static_from",
-        "line": 1080,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/lora_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47380,7 +47160,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47394,7 +47174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47403,7 +47183,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1084,
+        "line": 1078,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47417,7 +47197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47426,7 +47206,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1079,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47440,7 +47220,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47449,7 +47229,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1080,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47463,7 +47243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47472,7 +47252,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1080,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47486,7 +47266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47495,7 +47275,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1080,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47509,7 +47289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47518,7 +47298,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47532,7 +47312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47541,7 +47321,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1091,
+        "line": 1085,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47555,7 +47335,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47564,7 +47344,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47578,7 +47358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47587,7 +47367,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47601,7 +47381,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47610,7 +47390,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47624,7 +47404,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47633,7 +47413,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47647,7 +47427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47656,7 +47436,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47670,7 +47450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47679,7 +47459,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47693,7 +47473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47702,7 +47482,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47716,7 +47496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47725,7 +47505,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47739,7 +47519,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47748,7 +47528,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47762,7 +47542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47771,7 +47551,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47785,7 +47565,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47794,7 +47574,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47808,7 +47588,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47817,7 +47597,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47831,7 +47611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47840,7 +47620,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47854,7 +47634,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47863,7 +47643,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47877,7 +47657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47886,7 +47666,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47900,7 +47680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47909,7 +47689,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47923,7 +47703,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47932,7 +47712,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47946,7 +47726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47955,7 +47735,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47969,7 +47749,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 561,
+            "handler_line": 558,
             "kind": "try",
             "line": 9
           }
@@ -47978,7 +47758,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1092,
+        "line": 1086,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -50766,14 +50546,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 48
+            "line": 34
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 49,
+        "line": 35,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -50785,14 +50565,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 58
+            "line": 44
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 59,
+        "line": 45,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -50804,14 +50584,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 80
+            "line": 66
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 81,
+        "line": 67,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -50823,14 +50603,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 186
+            "line": 172
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 187,
+        "line": 173,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -50842,14 +50622,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 202
+            "line": 188
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 203,
+        "line": 189,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -50861,14 +50641,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 227
+            "line": 213
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 228,
+        "line": 214,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -53017,14 +52797,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 48
+            "line": 34
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.nodes.utils:apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 49,
+        "line": 35,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -53036,14 +52816,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 58
+            "line": 44
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 59,
+        "line": 45,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -53055,14 +52835,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 80
+            "line": 66
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 81,
+        "line": 67,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -53074,14 +52854,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 186
+            "line": 172
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "py.utils.utils:get_lora_info",
         "kind": "static_from",
-        "line": 187,
+        "line": 173,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -53093,14 +52873,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 202
+            "line": 188
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 203,
+        "line": 189,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -53112,14 +52892,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 227
+            "line": 213
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "folder_paths",
         "kind": "static_import",
-        "line": 228,
+        "line": 214,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/lora/metadata.py"
@@ -54356,11 +54136,11 @@
         "scope": "<module>"
       },
       {
-        "callee": "logging.getLogger",
+        "callee": "_RuntimeLoggerProxy",
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 10,
+        "line": 24,
         "module": "easyuse_anima/lora/metadata.py",
         "scope": "<module>"
       },
@@ -54747,7 +54527,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1114,
+        "line": 1108,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54756,7 +54536,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1689,
+        "line": 1683,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54765,7 +54545,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1692,
+        "line": 1686,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54774,7 +54554,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1698,
+        "line": 1692,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54783,7 +54563,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1704,
+        "line": 1698,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54792,7 +54572,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1707,
+        "line": 1701,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54801,7 +54581,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1710,
+        "line": 1704,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54810,7 +54590,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1716,
+        "line": 1710,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54819,7 +54599,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1722,
+        "line": 1716,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54828,7 +54608,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1728,
+        "line": 1722,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54837,7 +54617,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1734,
+        "line": 1728,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54846,7 +54626,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1740,
+        "line": 1734,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54855,7 +54635,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1746,
+        "line": 1740,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54864,7 +54644,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1749,
+        "line": 1743,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54873,7 +54653,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1756,
+        "line": 1750,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54882,7 +54662,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1759,
+        "line": 1753,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54891,7 +54671,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1763,
+        "line": 1757,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54900,7 +54680,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1766,
+        "line": 1760,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54909,7 +54689,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1773,
+        "line": 1767,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54918,7 +54698,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1779,
+        "line": 1773,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54927,7 +54707,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1785,
+        "line": 1779,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54936,7 +54716,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1788,
+        "line": 1782,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54945,7 +54725,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1791,
+        "line": 1785,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54954,7 +54734,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1794,
+        "line": 1788,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54963,34 +54743,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1801,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_lora_metadata_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1807,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_lora_preset_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1812,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_lora_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1816,
+        "line": 1795,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55504,13 +55257,13 @@
       },
       {
         "kind": "dict",
-        "line": 1176,
+        "line": 1170,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1165,
+        "line": 1159,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -66,7 +66,8 @@
       "B-11c29d",
       "B-11c29b3",
       "B-11c30",
-      "B-11c30a"
+      "B-11c30a",
+      "B-11c30b"
     ]
   },
   "enums": {
@@ -101,14 +102,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 292,
+    "nodes_canonical_bindings": 289,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 1,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
-    "runtime_binders": 27,
+    "runtime_binders": 24,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -166,10 +167,7 @@
     "_bind_prompt_correction_runtime",
     "_bind_prompt_node_runtime",
     "_bind_wildcard_node_runtime",
-    "_bind_naia_node_runtime",
-    "_bind_lora_metadata_runtime",
-    "_bind_lora_preset_runtime",
-    "_bind_lora_node_runtime"
+    "_bind_naia_node_runtime"
   ],
   "runtime_resolver_consumers": {
     "AIO_FINAL_FIT_MODES": [
@@ -364,9 +362,6 @@
     "_INLINE_SPACE_RE": [
       "easyuse_anima.prompt.fields"
     ],
-    "_TRIGGER_WORD_KEYS": [
-      "easyuse_anima.lora.metadata"
-    ],
     "_WEIGHTED_TOKEN_RE": [
       "easyuse_anima.prompt.fields"
     ],
@@ -527,9 +522,6 @@
     "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_apply_lora_syntax_format": [
-      "easyuse_anima.nodes.lora_nodes"
-    ],
     "_apply_prompt_data_overrides": [
       "easyuse_anima.nodes.prompt_data_nodes"
     ],
@@ -566,7 +558,6 @@
       "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.aio.usdu",
-      "easyuse_anima.nodes.lora_nodes",
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.prompt_data_nodes",
       "easyuse_anima.nodes.prompt_nodes",
@@ -593,7 +584,6 @@
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.aio.usdu",
-      "easyuse_anima.lora.preset",
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.prompt.advanced",
       "easyuse_anima.prompt.regional"
@@ -685,14 +675,8 @@
       "easyuse_anima.prompt.advanced",
       "easyuse_anima.prompt.artist_mix"
     ],
-    "_correct_style_prompt": [
-      "easyuse_anima.nodes.lora_nodes"
-    ],
     "_decode_latent_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_dedupe_text_values": [
-      "easyuse_anima.lora.metadata"
     ],
     "_easy_use_anima_input_signature": [
       "easyuse_anima.nodes.aio_nodes"
@@ -714,9 +698,6 @@
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.regional_nodes"
     ],
-    "_fallback_lora_path": [
-      "easyuse_anima.lora.metadata"
-    ],
     "_filter_metadata_prompt": [
       "easyuse_anima.nodes.prompt_nodes",
       "easyuse_anima.prompt.advanced",
@@ -729,8 +710,7 @@
       "easyuse_anima.aio.resources"
     ],
     "_format_strength": [
-      "easyuse_anima.aio.output",
-      "easyuse_anima.nodes.lora_nodes"
+      "easyuse_anima.aio.output"
     ],
     "_generate_empty_latent_with_comfy": [
       "easyuse_anima.aio.legacy_generation",
@@ -738,15 +718,6 @@
     ],
     "_get_aio_first_pass_cache": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_get_lora_info": [
-      "easyuse_anima.nodes.lora_nodes"
-    ],
-    "_get_lora_manager_trigger_words": [
-      "easyuse_anima.lora.metadata"
-    ],
-    "_get_loras_list": [
-      "easyuse_anima.lora.preset"
     ],
     "_get_workflow_node": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -798,30 +769,14 @@
     "_load_diffusion_model_with_comfy": [
       "easyuse_anima.aio.resources"
     ],
-    "_load_lora_manager_metadata": [
-      "easyuse_anima.lora.metadata"
-    ],
-    "_load_profile_data": [
-      "easyuse_anima.lora.preset"
-    ],
     "_load_upscale_model_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_load_vae_with_comfy": [
       "easyuse_anima.aio.resources"
     ],
-    "_lora_combo_values": [
-      "easyuse_anima.nodes.lora_nodes"
-    ],
-    "_lora_manager_trigger_words_from_metadata": [
-      "easyuse_anima.lora.metadata"
-    ],
-    "_lora_model_exists": [
-      "easyuse_anima.nodes.lora_nodes"
-    ],
     "_lora_stack_name": [
-      "easyuse_anima.aio.model_preparation",
-      "easyuse_anima.nodes.lora_nodes"
+      "easyuse_anima.aio.model_preparation"
     ],
     "_merge_versioned_settings": [
       "easyuse_anima.aio.resources"
@@ -831,12 +786,6 @@
     ],
     "_metadata_filter_keys": [
       "easyuse_anima.prompt.fields"
-    ],
-    "_metadata_json_paths_for_lora": [
-      "easyuse_anima.lora.metadata"
-    ],
-    "_missing_lora_display_name": [
-      "easyuse_anima.nodes.lora_nodes"
     ],
     "_new_aio_random_seed": [
       "easyuse_anima.aio.sampling"
@@ -938,9 +887,6 @@
     "_preferred_name_default": [
       "easyuse_anima.nodes.aio_nodes"
     ],
-    "_profile_key": [
-      "easyuse_anima.lora.preset"
-    ],
     "_prompt_data_json_safe": [
       "easyuse_anima.aio.first_pass_cache",
       "easyuse_anima.aio.generation_normalization",
@@ -961,9 +907,6 @@
     ],
     "_put_aio_first_pass_cache": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_raise_missing_loras": [
-      "easyuse_anima.nodes.lora_nodes"
     ],
     "_ratio_label": [
       "easyuse_anima.prompt.regional"
@@ -1060,9 +1003,6 @@
     "_segs_has_items": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_select_profile_values": [
-      "easyuse_anima.nodes.lora_nodes"
-    ],
     "_send_aio_preview_event": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -1084,7 +1024,6 @@
     "_stable_change_key": [
       "easyuse_anima.aio.first_pass_cache",
       "easyuse_anima.nodes.aio_nodes",
-      "easyuse_anima.nodes.lora_nodes",
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.prompt_data_nodes",
       "easyuse_anima.nodes.prompt_nodes",
@@ -1102,12 +1041,6 @@
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.prompt_nodes",
       "easyuse_anima.prompt.advanced"
-    ],
-    "_trigger_words_from_value": [
-      "easyuse_anima.lora.metadata"
-    ],
-    "_wrap_profile_index": [
-      "easyuse_anima.lora.preset"
     ],
     "correct_prompt": [
       "easyuse_anima.nodes.prompt_nodes",
@@ -1174,22 +1107,22 @@
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 27,
-      "family_count": 4,
+      "binder_count": 24,
+      "family_count": 3,
       "mode_counts": {
         "comfy_provider_then_root": 12,
-        "root_globals": 13,
+        "root_globals": 10,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 293,
-      "unique_root_resolver_names": 287,
+      "unique_resolver_names": 273,
+      "unique_root_resolver_names": 267,
       "unique_provider_resolver_names": 6,
-      "unique_direct_root_dependencies": 14,
-      "direct_root_dependency_slots": 29,
+      "unique_direct_root_dependencies": 11,
+      "direct_root_dependency_slots": 24,
       "provider_consumer_slots": 17,
       "provider_consumer_modules": 12,
-      "repository_replacement_names": 165,
-      "repository_replacement_files": 19
+      "repository_replacement_names": 158,
+      "repository_replacement_files": 18
     },
     "families": {
       "aio": [
@@ -1221,11 +1154,6 @@
       "wildcard_naia": [
         "_bind_wildcard_node_runtime",
         "_bind_naia_node_runtime"
-      ],
-      "lora": [
-        "_bind_lora_metadata_runtime",
-        "_bind_lora_preset_runtime",
-        "_bind_lora_node_runtime"
       ]
     },
     "root_resolver_names": [
@@ -1288,7 +1216,6 @@
       "_AIO_FIRST_PASS_CACHE_ORDER",
       "_HASH_COMMENT_RE",
       "_INLINE_SPACE_RE",
-      "_TRIGGER_WORD_KEYS",
       "_WEIGHTED_TOKEN_RE",
       "_adapter_comfy_clip_loader_types",
       "_adapter_comfy_diffusion_model_names",
@@ -1340,7 +1267,6 @@
       "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
       "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
       "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-      "_apply_lora_syntax_format",
       "_apply_prompt_data_overrides",
       "_apply_regional_field_inputs",
       "_apply_spectrum_anima_mod_guidance",
@@ -1377,25 +1303,19 @@
       "_copy_prompt_data_for_update",
       "_correct_advanced_field_sequence",
       "_correct_builder_prompt",
-      "_correct_style_prompt",
       "_decode_latent_with_comfy",
-      "_dedupe_text_values",
       "_easy_use_anima_input_signature",
       "_encode_artist_clustered",
       "_encode_artist_delta_rms",
       "_encode_image_with_comfy_vae",
       "_encode_prompt_data_positive_conditioning",
       "_expand_advanced_wildcard_fields",
-      "_fallback_lora_path",
       "_filter_metadata_prompt",
       "_find_spectrum_anima_mod_guidance_class",
       "_folder_path_names",
       "_format_strength",
       "_generate_empty_latent_with_comfy",
       "_get_aio_first_pass_cache",
-      "_get_lora_info",
-      "_get_lora_manager_trigger_words",
-      "_get_loras_list",
       "_get_workflow_node",
       "_image_tensor_size",
       "_impact_scheduler_names",
@@ -1409,19 +1329,12 @@
       "_load_checkpoint_with_comfy",
       "_load_clip_with_comfy",
       "_load_diffusion_model_with_comfy",
-      "_load_lora_manager_metadata",
-      "_load_profile_data",
       "_load_upscale_model_with_comfy",
       "_load_vae_with_comfy",
-      "_lora_combo_values",
-      "_lora_manager_trigger_words_from_metadata",
-      "_lora_model_exists",
       "_lora_stack_name",
       "_merge_versioned_settings",
       "_metadata_filter_key",
       "_metadata_filter_keys",
-      "_metadata_json_paths_for_lora",
-      "_missing_lora_display_name",
       "_new_aio_random_seed",
       "_node_output_tuple",
       "_normalize_advanced_fields",
@@ -1449,13 +1362,11 @@
       "_post_random",
       "_preferred_clip_type_default",
       "_preferred_name_default",
-      "_profile_key",
       "_prompt_data_json_safe",
       "_prompt_data_parameter_snapshot",
       "_prompt_tokens",
       "_prompt_translation_change_key",
       "_put_aio_first_pass_cache",
-      "_raise_missing_loras",
       "_ratio_label",
       "_regional_config_json",
       "_regional_fields_json",
@@ -1486,7 +1397,6 @@
       "_save_image_with_comfy",
       "_save_image_with_image_saver",
       "_segs_has_items",
-      "_select_profile_values",
       "_send_aio_preview_event",
       "_set_naia_field_text",
       "_single_value",
@@ -1495,8 +1405,6 @@
       "_tag_aio_preview_images",
       "_translate_prompt_fields",
       "_translate_prompt_text",
-      "_trigger_words_from_value",
-      "_wrap_profile_index",
       "ceil",
       "correct_prompt",
       "expand_wildcard_texts",
@@ -1606,9 +1514,6 @@
       "_AIO_FIRST_PASS_CACHE_ORDER": [
         "tests/test_aio_first_pass_cache.py"
       ],
-      "_TRIGGER_WORD_KEYS": [
-        "tests/test_lora_preset.py"
-      ],
       "_adapter_comfy_clip_loader_types": [
         "tests/test_node_contracts.py"
       ],
@@ -1717,9 +1622,6 @@
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
-      "_apply_lora_syntax_format": [
-        "tests/test_lora_preset.py"
-      ],
       "_apply_spectrum_anima_mod_guidance": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
@@ -1791,10 +1693,6 @@
         "tests/test_node_contracts.py",
         "tests/test_prompt_corrector.py"
       ],
-      "_correct_style_prompt": [
-        "tests/test_lora_preset.py",
-        "tests/test_node_contracts.py"
-      ],
       "_decode_latent_with_comfy": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
@@ -1816,9 +1714,6 @@
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
-      "_fallback_lora_path": [
-        "tests/test_lora_preset.py"
-      ],
       "_filter_metadata_prompt": [
         "tests/test_node_contracts.py"
       ],
@@ -1839,10 +1734,6 @@
       ],
       "_get_aio_first_pass_cache": [
         "tests/test_aio_legacy_generation.py"
-      ],
-      "_get_lora_info": [
-        "tests/test_lora_preset.py",
-        "tests/test_node_contracts.py"
       ],
       "_get_workflow_node": [
         "tests/test_node_contracts.py"
@@ -1889,13 +1780,6 @@
       ],
       "_load_vae_with_comfy": [
         "tests/test_aio_resources.py"
-      ],
-      "_lora_combo_values": [
-        "tests/test_node_contracts.py"
-      ],
-      "_lora_model_exists": [
-        "tests/test_lora_preset.py",
-        "tests/test_node_contracts.py"
       ],
       "_merge_versioned_settings": [
         "tests/test_node_contracts.py"
@@ -3905,162 +3789,6 @@
           "_post_random",
           "resolve_naia_settings"
         ]
-      },
-      {
-        "binder": "_bind_lora_metadata_runtime",
-        "module": "easyuse_anima.lora.metadata",
-        "family": "lora",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "prompt_tokens",
-          "resolve_helper",
-          "resolve_logger"
-        ],
-        "bound_globals": [
-          "_prompt_tokens",
-          "_resolve_helper",
-          "logger"
-        ],
-        "direct_root_dependencies": [
-          "_prompt_tokens",
-          "logger"
-        ],
-        "resolver_names": [
-          "_TRIGGER_WORD_KEYS",
-          "_dedupe_text_values",
-          "_fallback_lora_path",
-          "_get_lora_manager_trigger_words",
-          "_load_lora_manager_metadata",
-          "_lora_manager_trigger_words_from_metadata",
-          "_metadata_json_paths_for_lora",
-          "_trigger_words_from_value"
-        ],
-        "root_resolver_names": [
-          "_TRIGGER_WORD_KEYS",
-          "_dedupe_text_values",
-          "_fallback_lora_path",
-          "_get_lora_manager_trigger_words",
-          "_load_lora_manager_metadata",
-          "_lora_manager_trigger_words_from_metadata",
-          "_metadata_json_paths_for_lora",
-          "_trigger_words_from_value"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_TRIGGER_WORD_KEYS",
-          "_fallback_lora_path",
-          "_prompt_tokens",
-          "logger"
-        ]
-      },
-      {
-        "binder": "_bind_lora_preset_runtime",
-        "module": "easyuse_anima.lora.preset",
-        "family": "lora",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "correct_builder_prompt",
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_correct_builder_prompt",
-          "_resolve_helper"
-        ],
-        "direct_root_dependencies": [
-          "_correct_builder_prompt"
-        ],
-        "resolver_names": [
-          "_as_int",
-          "_get_loras_list",
-          "_load_profile_data",
-          "_profile_key",
-          "_wrap_profile_index"
-        ],
-        "root_resolver_names": [
-          "_as_int",
-          "_get_loras_list",
-          "_load_profile_data",
-          "_profile_key",
-          "_wrap_profile_index"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_as_int",
-          "_correct_builder_prompt"
-        ]
-      },
-      {
-        "binder": "_bind_lora_node_runtime",
-        "module": "easyuse_anima.nodes.lora_nodes",
-        "family": "lora",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "any_type",
-          "flexible_optional_input_type",
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_ANY_TYPE",
-          "_FlexibleOptionalInputType",
-          "_apply_lora_syntax_format",
-          "_as_bool",
-          "_correct_style_prompt",
-          "_format_strength",
-          "_get_lora_info",
-          "_lora_combo_values",
-          "_lora_model_exists",
-          "_lora_stack_name",
-          "_missing_lora_display_name",
-          "_raise_missing_loras",
-          "_select_profile_values",
-          "_stable_change_key"
-        ],
-        "direct_root_dependencies": [
-          "_ANY_TYPE",
-          "_FlexibleOptionalInputType"
-        ],
-        "resolver_names": [
-          "_apply_lora_syntax_format",
-          "_as_bool",
-          "_correct_style_prompt",
-          "_format_strength",
-          "_get_lora_info",
-          "_lora_combo_values",
-          "_lora_model_exists",
-          "_lora_stack_name",
-          "_missing_lora_display_name",
-          "_raise_missing_loras",
-          "_select_profile_values",
-          "_stable_change_key"
-        ],
-        "root_resolver_names": [
-          "_apply_lora_syntax_format",
-          "_as_bool",
-          "_correct_style_prompt",
-          "_format_strength",
-          "_get_lora_info",
-          "_lora_combo_values",
-          "_lora_model_exists",
-          "_lora_stack_name",
-          "_missing_lora_display_name",
-          "_raise_missing_loras",
-          "_select_profile_values",
-          "_stable_change_key"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_apply_lora_syntax_format",
-          "_as_bool",
-          "_correct_style_prompt",
-          "_format_strength",
-          "_get_lora_info",
-          "_lora_combo_values",
-          "_lora_model_exists",
-          "_stable_change_key"
-        ]
       }
     ]
   },
@@ -5383,7 +5111,6 @@
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.lora_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
@@ -5394,7 +5121,6 @@
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.lora_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
@@ -5438,8 +5164,6 @@
         "canonical runtime resolver: easyuse_anima.aio.resources",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.aio.usdu",
-        "canonical runtime resolver: easyuse_anima.lora.preset",
-        "canonical runtime resolver: easyuse_anima.nodes.lora_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
@@ -5459,8 +5183,6 @@
         "AST:easyuse_anima.aio.resources string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.aio.usdu string runtime lookup",
-        "AST:easyuse_anima.lora.preset string runtime lookup",
-        "AST:easyuse_anima.nodes.lora_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
@@ -5704,21 +5426,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.lora.metadata:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_apply_lora_syntax_format": "_apply_lora_syntax_format",
-        "_bind_lora_metadata_runtime": "_bind_lora_metadata_runtime",
-        "_dedupe_text_values": "_dedupe_text_values",
-        "_fallback_lora_path": "_fallback_lora_path",
-        "_get_lora_info": "_get_lora_info",
-        "_get_lora_manager_trigger_words": "_get_lora_manager_trigger_words",
-        "_load_lora_manager_metadata": "_load_lora_manager_metadata",
-        "_lora_combo_values": "_lora_combo_values",
-        "_lora_manager_trigger_words_from_metadata": "_lora_manager_trigger_words_from_metadata",
-        "_lora_model_exists": "_lora_model_exists",
-        "_lora_stack_name": "_lora_stack_name",
-        "_metadata_json_paths_for_lora": "_metadata_json_paths_for_lora",
-        "_missing_lora_display_name": "_missing_lora_display_name",
-        "_raise_missing_loras": "_raise_missing_loras",
-        "_trigger_words_from_value": "_trigger_words_from_value"
+        "_lora_stack_name": "_lora_stack_name"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -5730,16 +5438,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.model_preparation",
-        "canonical runtime resolver: easyuse_anima.lora.metadata",
-        "canonical runtime resolver: easyuse_anima.nodes.lora_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.model_preparation"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.model_preparation string runtime lookup",
-        "AST:easyuse_anima.lora.metadata string runtime lookup",
-        "AST:easyuse_anima.nodes.lora_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.model_preparation string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5749,17 +5451,51 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.lora.metadata:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_apply_lora_syntax_format": "_apply_lora_syntax_format",
+        "_dedupe_text_values": "_dedupe_text_values",
+        "_fallback_lora_path": "_fallback_lora_path",
+        "_get_lora_info": "_get_lora_info",
+        "_get_lora_manager_trigger_words": "_get_lora_manager_trigger_words",
+        "_load_lora_manager_metadata": "_load_lora_manager_metadata",
+        "_lora_combo_values": "_lora_combo_values",
+        "_lora_manager_trigger_words_from_metadata": "_lora_manager_trigger_words_from_metadata",
+        "_lora_model_exists": "_lora_model_exists",
+        "_metadata_json_paths_for_lora": "_metadata_json_paths_for_lora",
+        "_missing_lora_display_name": "_missing_lora_display_name",
+        "_raise_missing_loras": "_raise_missing_loras",
+        "_trigger_words_from_value": "_trigger_words_from_value"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.lora.metadata",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.lora.metadata",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.lora.preset:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_bind_lora_preset_runtime": "_bind_lora_preset_runtime",
-        "_correct_style_prompt": "_correct_style_prompt",
-        "_format_strength": "_format_strength",
-        "_get_loras_list": "_get_loras_list",
-        "_load_profile_data": "_load_profile_data",
-        "_profile_key": "_profile_key",
-        "_select_profile_values": "_select_profile_values",
-        "_wrap_profile_index": "_wrap_profile_index"
+        "_format_strength": "_format_strength"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -5771,16 +5507,10 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
-        "canonical runtime resolver: easyuse_anima.aio.output",
-        "canonical runtime resolver: easyuse_anima.lora.preset",
-        "canonical runtime resolver: easyuse_anima.nodes.lora_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.output"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
-        "AST:easyuse_anima.aio.output string runtime lookup",
-        "AST:easyuse_anima.lora.preset string runtime lookup",
-        "AST:easyuse_anima.nodes.lora_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.output string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5788,6 +5518,40 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.lora.preset:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_correct_style_prompt": "_correct_style_prompt",
+        "_get_loras_list": "_get_loras_list",
+        "_load_profile_data": "_load_profile_data",
+        "_profile_key": "_profile_key",
+        "_select_profile_values": "_select_profile_values",
+        "_wrap_profile_index": "_wrap_profile_index"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.lora.preset",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.lora.preset",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.naia.client:transitional_private_seam",
@@ -5963,7 +5727,6 @@
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.input_types:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_ANY_TYPE": "_ANY_TYPE",
         "_FlexibleOptionalInputType": "_FlexibleOptionalInputType"
       },
       "classification": "transitional_private_seam",
@@ -5992,6 +5755,7 @@
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.input_types:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_ANY_TYPE": "_ANY_TYPE",
         "_AnyType": "_AnyType"
       },
       "classification": "unsupported_test_only",
@@ -6046,34 +5810,6 @@
         "mapping, workflow, and direct identity parity"
       ],
       "lifecycle_state": "supported"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.lora_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_lora_node_runtime": "_bind_lora_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.lora_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.lora_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.naia_nodes:supported_public_reexport",

--- a/tests/test_lora_preset.py
+++ b/tests/test_lora_preset.py
@@ -6,6 +6,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from easyuse_anima.lora import metadata as lora_metadata
+from easyuse_anima.nodes import lora_nodes
 from nodes import (
     EasyUseAnimaLoraPreset,
     _lora_combo_values,
@@ -53,8 +55,8 @@ class LoraPresetTests(unittest.TestCase):
         }
 
         with (
-            patch("nodes._get_lora_info", lambda name: (f"/loras/{name}", [f"{name}_trigger"])),
-            patch("nodes._apply_lora_syntax_format", lambda name: name.replace(".safetensors", "")),
+            patch.object(lora_nodes, "_get_lora_info", lambda name: (f"/loras/{name}", [f"{name}_trigger"])),
+            patch.object(lora_nodes, "_apply_lora_syntax_format", lambda name: name.replace(".safetensors", "")),
         ):
             response = EasyUseAnimaLoraPreset().build(
                 style_prompt="fallback",
@@ -79,8 +81,8 @@ class LoraPresetTests(unittest.TestCase):
         ]
 
         with (
-            patch("nodes._get_lora_info", lambda name: (name, [])),
-            patch("nodes._apply_lora_syntax_format", lambda name: "foo"),
+            patch.object(lora_nodes, "_get_lora_info", lambda name: (name, [])),
+            patch.object(lora_nodes, "_apply_lora_syntax_format", lambda name: "foo"),
         ):
             response = EasyUseAnimaLoraPreset().build(
                 style_prompt="style",
@@ -106,8 +108,8 @@ class LoraPresetTests(unittest.TestCase):
         }
 
         with (
-            patch("nodes._get_lora_info", return_value=("foo.safetensors", [])),
-            patch("nodes._lora_model_exists", return_value=True),
+            patch.object(lora_nodes, "_get_lora_info", return_value=("foo.safetensors", [])),
+            patch.object(lora_nodes, "_lora_model_exists", return_value=True),
         ):
             response = EasyUseAnimaLoraPreset().build(
                 style_prompt="fallback",
@@ -133,8 +135,8 @@ class LoraPresetTests(unittest.TestCase):
             return name, ["@new"]
 
         with (
-            patch("nodes._get_lora_info", side_effect=lora_info),
-            patch("nodes._lora_model_exists", return_value=True),
+            patch.object(lora_nodes, "_get_lora_info", side_effect=lora_info),
+            patch.object(lora_nodes, "_lora_model_exists", return_value=True),
         ):
             response = EasyUseAnimaLoraPreset().build(
                 style_prompt="style",
@@ -169,7 +171,7 @@ class LoraPresetTests(unittest.TestCase):
             "trainedWords": "@default",
         }
 
-        with patch("nodes._TRIGGER_WORD_KEYS", ("custom_words",)):
+        with patch.object(lora_metadata, "_TRIGGER_WORD_KEYS", ("custom_words",)):
             self.assertEqual(
                 _lora_manager_trigger_words_from_metadata(metadata),
                 ["@custom"],
@@ -194,8 +196,8 @@ class LoraPresetTests(unittest.TestCase):
         ]
 
         with (
-            patch("nodes._get_lora_info", lambda name: (name, [])),
-            patch("nodes._apply_lora_syntax_format", lambda name: "foo"),
+            patch.object(lora_nodes, "_get_lora_info", lambda name: (name, [])),
+            patch.object(lora_nodes, "_apply_lora_syntax_format", lambda name: "foo"),
         ):
             response = EasyUseAnimaLoraPreset().build(
                 style_prompt="style",
@@ -250,7 +252,7 @@ class LoraPresetTests(unittest.TestCase):
             },
         ]
 
-        with patch("nodes._lora_model_exists", lambda _name: False):
+        with patch.object(lora_nodes, "_lora_model_exists", lambda _name: False):
             with self.assertLogs("ComfyUI-EasyUseAnima", level="ERROR") as logs:
                 with self.assertRaises(RuntimeError) as raised:
                     EasyUseAnimaLoraPreset().build(
@@ -271,7 +273,7 @@ class LoraPresetTests(unittest.TestCase):
         self.assertIn("missing_abs.safetensors", "\n".join(logs.output))
 
     def test_build_corrects_style_prompt_output(self):
-        with patch("nodes._correct_style_prompt", lambda prompt: f"corrected: {prompt}"):
+        with patch.object(lora_nodes, "_correct_style_prompt", lambda prompt: f"corrected: {prompt}"):
             response = EasyUseAnimaLoraPreset().build(
                 style_prompt="@artist, style",
                 profile_index=1,
@@ -293,8 +295,8 @@ class LoraPresetTests(unittest.TestCase):
 
             loras = [{"name": "style/foo.safetensors", "on": True, "strength": 1.0}]
             with (
-                patch("nodes._fallback_lora_path", lambda _name: lora_path),
-                patch("nodes._apply_lora_syntax_format", lambda name: "foo"),
+                patch.object(lora_metadata, "_fallback_lora_path", lambda _name: lora_path),
+                patch.object(lora_nodes, "_apply_lora_syntax_format", lambda name: "foo"),
             ):
                 response = EasyUseAnimaLoraPreset().build(
                     style_prompt="style",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -198,7 +198,6 @@ def _deterministic_comfy_inputs():
         "_comfy_vae_names": lambda: ["contract/vae.safetensors"],
         "_comfy_clip_loader_types": lambda: ["qwen_image", "stable_diffusion"],
         "_impact_scheduler_names": lambda: ["contract_impact_scheduler"],
-        "_lora_combo_values": lambda: ["None", "contract/style.safetensors"],
         "resolve_metadata_filter_words": lambda: ["contract-filter"],
         "_prompt_translation_change_key": lambda: {"enabled": False},
         "wildcard_sources_signature": lambda: {"files": []},
@@ -224,6 +223,11 @@ def _deterministic_comfy_inputs():
             sam3_nodes,
             "_comfy_checkpoint_names",
             return_value=["contract/checkpoint.safetensors"],
+        ),
+        patch.object(
+            lora_nodes,
+            "_lora_combo_values",
+            return_value=["None", "contract/style.safetensors"],
         ),
     ):
         yield

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -11,7 +11,7 @@ import types
 import unittest
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import Mock, call, patch
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -2694,6 +2694,13 @@ class LoraPresetMoveContractTests(unittest.TestCase):
             with self.subTest(module="preset", name=name):
                 self.assertIs(getattr(nodes, name), getattr(lora_preset, name))
         self.assertIs(nodes.EasyUseAnimaLoraPreset, lora_nodes.EasyUseAnimaLoraPreset)
+        for module, binder_name in (
+            (lora_metadata, "_bind_lora_metadata_runtime"),
+            (lora_preset, "_bind_lora_preset_runtime"),
+            (lora_nodes, "_bind_lora_node_runtime"),
+        ):
+            with self.subTest(module=module.__name__, binder=binder_name):
+                self.assertFalse(hasattr(module, binder_name))
 
     def test_package_loaded_root_lora_objects_are_direct_canonical_aliases(self):
         with _loaded_package_entrypoint() as (_, package_nodes):
@@ -2713,12 +2720,12 @@ class LoraPresetMoveContractTests(unittest.TestCase):
                 package_lora_nodes.EasyUseAnimaLoraPreset,
             )
 
-    def test_root_monkeypatches_drive_the_canonical_lora_node(self):
+    def test_canonical_monkeypatches_drive_the_canonical_lora_node(self):
         canonical_node = lora_nodes.EasyUseAnimaLoraPreset()
         with (
-            patch.object(nodes, "_correct_style_prompt", side_effect=lambda value: f"bound:{value}"),
-            patch.object(nodes, "_get_lora_info", return_value=("foo.safetensors", ["@bound"])),
-            patch.object(nodes, "_lora_model_exists", return_value=True),
+            patch.object(lora_nodes, "_correct_style_prompt", side_effect=lambda value: f"bound:{value}"),
+            patch.object(lora_nodes, "_get_lora_info", return_value=("foo.safetensors", ["@bound"])),
+            patch.object(lora_nodes, "_lora_model_exists", return_value=True),
         ):
             result = canonical_node.build(
                 style_prompt="style",
@@ -2729,6 +2736,28 @@ class LoraPresetMoveContractTests(unittest.TestCase):
 
         self.assertEqual(result[0], "bound:style")
         self.assertEqual(result[2], "@bound")
+
+    def test_metadata_and_preset_callbacks_remain_use_time(self):
+        logger = types.SimpleNamespace(warning=Mock())
+        with (
+            patch.object(lora_metadata, "_resolve_logger", return_value=logger),
+            patch.object(prompt_fields, "_prompt_tokens", return_value=["@bound"]) as tokens,
+            patch.object(
+                prompt_fields,
+                "_correct_builder_prompt",
+                return_value="corrected",
+            ) as correct,
+        ):
+            lora_metadata.logger.warning("message")
+            self.assertEqual(
+                lora_metadata._trigger_words_from_value("source"),
+                ["@bound"],
+            )
+            self.assertEqual(lora_preset._correct_style_prompt("style"), "corrected")
+
+        logger.warning.assert_called_once_with("message")
+        tokens.assert_called_once_with("source")
+        correct.assert_called_once_with("style")
 
     def test_fresh_process_direct_imports_do_not_load_root_nodes(self):
         script = f"""

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "c08a5d730f6078a8a2211bcc73ea3ca22a9452fa")
-        # B-11c30a retires only the three Image/SAM3/Impact runtime binder
+        self.assertEqual(report["git_blob_sha1"], "256f87b4e83842437b5993661f42a9259a463e17")
+        # B-11c30b retires only the three LoRA runtime binder
         # imports and calls without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 1)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_820)
+        self.assertEqual(report["line_count"], 1_800)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -114,11 +114,6 @@ RUNTIME_BINDER_FAMILIES = {
         "_bind_wildcard_node_runtime",
         "_bind_naia_node_runtime",
     ),
-    "lora": (
-        "_bind_lora_metadata_runtime",
-        "_bind_lora_preset_runtime",
-        "_bind_lora_node_runtime",
-    ),
 }
 RETIRED_ARTIST_MIX_MODE_BINDINGS = (
     "ARTIST_MIX_CONTROL_KEY",
@@ -2130,6 +2125,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c29b3",
                 "B-11c30",
                 "B-11c30a",
+                "B-11c30b",
             ],
         },
         "enums": {
@@ -2142,14 +2138,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 292,
+            "nodes_canonical_bindings": 289,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 1,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
-            "runtime_binders": 27,
+            "runtime_binders": 24,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2381,7 +2377,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 27)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 24)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2389,22 +2385,22 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 27,
-                "family_count": 4,
+                "binder_count": 24,
+                "family_count": 3,
                 "mode_counts": {
                     "comfy_provider_then_root": 12,
-                    "root_globals": 13,
+                    "root_globals": 10,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 293,
-                "unique_root_resolver_names": 287,
+                "unique_resolver_names": 273,
+                "unique_root_resolver_names": 267,
                 "unique_provider_resolver_names": 6,
-                "unique_direct_root_dependencies": 14,
-                "direct_root_dependency_slots": 29,
+                "unique_direct_root_dependencies": 11,
+                "direct_root_dependency_slots": 24,
                 "provider_consumer_slots": 17,
                 "provider_consumer_modules": 12,
-                "repository_replacement_names": 165,
-                "repository_replacement_files": 19,
+                "repository_replacement_names": 158,
+                "repository_replacement_files": 18,
             },
         )
         self.assertEqual(


### PR DESCRIPTION
## 분류

- Task: B-11c30b
- Owner: #184
- Type: Move
- Base: `dev@3647d3ad35dffb77b35ca423e1b89c6a4d7c3116`
- 검증 head: `1511424945e1392d88082cb8ab939456dccb1f10`
- Production changes: 완료
- Contract/Behavior: 포함하지 않음

## 작업 전 symbol/caller/alias/global-state inventory

- root import/call 3개:
  - `_bind_lora_metadata_runtime`
  - `_bind_lora_preset_runtime`
  - `_bind_lora_node_runtime`
- metadata binder:
  - bound globals 3: `_prompt_tokens`, `_resolve_helper`, `logger`
  - root resolver names 8
  - direct dependencies: `_prompt_tokens`, `logger`
- preset binder:
  - bound globals 2: `_correct_builder_prompt`, `_resolve_helper`
  - root resolver names 5
  - direct dependency: `_correct_builder_prompt`
- node binder:
  - bound globals 14: canonical helper 12 + `_FlexibleOptionalInputType` + `_ANY_TYPE`
  - root resolver names 12
  - direct dependencies: `_FlexibleOptionalInputType`, `_ANY_TYPE`
- 합계: root-name 25 slot / direct dependency 5 slot / bind-time global 19 slot
- repository replacement names: 14
  - LoRA-specific migration은 `tests/test_lora_preset.py`와 LoRA contract section만 소유
  - 다른 owner family의 root replacement는 이동하지 않음
- root helper/input-type alias는 다른 consumer 때문에 이 lane에서 제거하지 않음
- 현재 실제 target은 binder 1회 설치 후 모든 metadata/preset/node 호출에서 use-time 관찰

## Allowed boundary

Production:

- `nodes.py`
- `easyuse_anima/lora/metadata.py`
- `easyuse_anima/lora/preset.py`
- `easyuse_anima/nodes/lora_nodes.py`

Supporting:

- focused LoRA/node-contract tests
- Python compatibility gate/fixtures
- nodes/backend analyzer baselines
- `docs/architecture/*`

## Exit

- root가 세 LoRA binder를 import/call하지 않음
- canonical LoRA module이 root import 없이 내부/cross-module dependency 소유
- logger 및 prompt-token/prompt-correction callback은 use-time 유지
- shared input-type object identity 유지
- helper/class root alias, schema, workflow payload, stack/trigger order, error text, optional dependency timing 불변
- LoRA consumer를 구동하려고 root를 patch하던 tests는 canonical owner를 patch

## 금지 경계

- LoRA profile/metadata/model-discovery behavior 변경
- prompt correction/missing-model policy/schema/workflow 변경
- logger message나 optional import 변경
- 다른 owner의 root alias 제거
- Prompt/Regional, AiO, Wildcard/NAIA binder cleanup

## 검증 상태

- focused:
  - LoRA / LoRA contract / compatibility / backend analyzer / nodes analyzer
  - 61 tests passed
  - sandbox에서는 `TemporaryDirectory` 쓰기·정리 권한 1건이 실패했고, 동일 명령의 비샌드박스 실행은 61 tests 전체 통과
- official full:
  - `tools/check_custom_node.ps1 -Project <absolute PR worktree> -Profile full`
  - Python 965 tests passed
  - frontend 114 JavaScript files passed, TypeScript 6.0.3
  - Pyright baseline and G-03 six-group import boundary passed
  - `git diff --check` passed
  - Ruff 110 findings remain G-01 report-only
- 첫 full은 node contract snapshot builder가 LoRA combo를 root에 patch하던 이관 누락 1건으로 실패했습니다. patch owner를 canonical `lora_nodes`로 옮긴 뒤 versioned fixture는 변경 없이 최종 full이 통과했습니다.
- package/Registry surface 변경 없음
- live ComfyUI smoke는 schema/workflow/behavior 변경이 없는 Move라 실행하지 않음

## 구현 결과

- root binder import/call 3개와 canonical binder 정의 3개 제거
- bind-time global 설치 19 slot 제거
- metadata/preset helper는 canonical module global을 use-time에 관찰
- prompt tokenization/prompt correction은 lazy use-time callback 유지
- logger proxy와 shared input-type identity 유지
- LoRA-specific root patch tests만 canonical owner로 이관
- remaining audit: 24 binders / 3 families
- root `nodes.py`: 1,820 → 1,800 lines

Parent: #184. Closes no issue.
