### PR TITLE
B-11c30c: Prompt/Regional binder retirement 경계 분할

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30a / PR #337; B-11c30b LoRA binder Move implemented in PR #338 | Complete binder families, then the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c30b / PR #338 / `cdd115d` | Split the Prompt/Regional binder family into service and node-adapter lanes, complete binder families, then perform the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -101,7 +101,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   changes in PR #336 / `02b8c4a`. B-11c30a retires only the three
   Image/SAM3/Impact binders in PR #337 / `3647d3a`; the remaining audit
   contains 27 binders across four families. B-11c30b retires only the three
-  LoRA binders in PR #338; 24 binders across three families remain.
+  LoRA binders in PR #338 / `cdd115d`; 24 binders across three families remain.
+  B-11c30c is a production-free Contract/gate that splits the ten remaining
+  Prompt/Regional binders into six feature-service binders and four node-adapter
+  binders before either group enters a Move PR.
 
 ### Current quality baseline
 
@@ -343,7 +346,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30a PR #337; B-11c30b LoRA binder Move in PR #338 | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30b PR #338 / `cdd115d`; B-11c30c Prompt/Regional split gate is next | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -996,6 +999,13 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     runtime and flat pre-bootstrap consumers resolve the provider method without
     caching or importing optional packs. General lookup and current loaded-module
     order remain unchanged.
+  - B-11c30c changes no production code. It splits the audited Prompt/Regional
+    binder family into the six service owners under `easyuse_anima.prompt` and
+    the four ComfyUI node adapters under `easyuse_anima.nodes`. The gate keeps
+    all ten symbols, callers, modes, provider/root resolver names, bound globals,
+    direct dependencies, and repository replacement evidence unchanged. Each
+    subgroup must retire in a separate Move PR; no service and adapter binder
+    removal may be combined.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -1108,7 +1108,7 @@
   "runtime_binder_audit": {
     "summary": {
       "binder_count": 24,
-      "family_count": 3,
+      "family_count": 4,
       "mode_counts": {
         "comfy_provider_then_root": 12,
         "root_globals": 10,
@@ -1139,16 +1139,18 @@
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime"
       ],
-      "prompt_regional": [
+      "prompt_services": [
         "_bind_regional_runtime",
-        "_bind_regional_node_runtime",
         "_bind_advanced_runtime",
-        "_bind_prompt_advanced_node_runtime",
         "_bind_conditioning_runtime",
         "_bind_artist_mix_runtime",
-        "_bind_prompt_data_node_runtime",
         "_bind_prompt_fields_runtime",
-        "_bind_prompt_correction_runtime",
+        "_bind_prompt_correction_runtime"
+      ],
+      "prompt_node_adapters": [
+        "_bind_regional_node_runtime",
+        "_bind_prompt_advanced_node_runtime",
+        "_bind_prompt_data_node_runtime",
         "_bind_prompt_node_runtime"
       ],
       "wildcard_naia": [
@@ -2900,7 +2902,7 @@
       {
         "binder": "_bind_regional_runtime",
         "module": "easyuse_anima.prompt.regional",
-        "family": "prompt_regional",
+        "family": "prompt_services",
         "mode": "root_globals",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -2966,7 +2968,7 @@
       {
         "binder": "_bind_regional_node_runtime",
         "module": "easyuse_anima.nodes.regional_nodes",
-        "family": "prompt_regional",
+        "family": "prompt_node_adapters",
         "mode": "comfy_provider_then_root",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3094,7 +3096,7 @@
       {
         "binder": "_bind_advanced_runtime",
         "module": "easyuse_anima.prompt.advanced",
-        "family": "prompt_regional",
+        "family": "prompt_services",
         "mode": "root_globals",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3167,7 +3169,7 @@
       {
         "binder": "_bind_prompt_advanced_node_runtime",
         "module": "easyuse_anima.nodes.prompt_advanced_nodes",
-        "family": "prompt_regional",
+        "family": "prompt_node_adapters",
         "mode": "root_globals",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3432,7 +3434,7 @@
       {
         "binder": "_bind_conditioning_runtime",
         "module": "easyuse_anima.prompt.conditioning",
-        "family": "prompt_regional",
+        "family": "prompt_services",
         "mode": "comfy_provider_then_root",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3465,7 +3467,7 @@
       {
         "binder": "_bind_artist_mix_runtime",
         "module": "easyuse_anima.prompt.artist_mix",
-        "family": "prompt_regional",
+        "family": "prompt_services",
         "mode": "comfy_provider_then_root",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3512,7 +3514,7 @@
       {
         "binder": "_bind_prompt_data_node_runtime",
         "module": "easyuse_anima.nodes.prompt_data_nodes",
-        "family": "prompt_regional",
+        "family": "prompt_node_adapters",
         "mode": "comfy_provider_then_root",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3586,7 +3588,7 @@
       {
         "binder": "_bind_prompt_fields_runtime",
         "module": "easyuse_anima.prompt.fields",
-        "family": "prompt_regional",
+        "family": "prompt_services",
         "mode": "root_globals",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3629,7 +3631,7 @@
       {
         "binder": "_bind_prompt_correction_runtime",
         "module": "easyuse_anima.prompt.correction",
-        "family": "prompt_regional",
+        "family": "prompt_services",
         "mode": "root_globals",
         "root_observation": "call_time_resolver",
         "root_keywords": [
@@ -3661,7 +3663,7 @@
       {
         "binder": "_bind_prompt_node_runtime",
         "module": "easyuse_anima.nodes.prompt_nodes",
-        "family": "prompt_regional",
+        "family": "prompt_node_adapters",
         "mode": "root_globals",
         "root_observation": "call_time_resolver",
         "root_keywords": [

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -83,6 +83,20 @@ PREAMBLE_IMPLEMENTATION_BINDINGS = {
     "random": "random:random",
     "sqrt": "math:sqrt",
 }
+PROMPT_SERVICE_RUNTIME_BINDERS = (
+    "_bind_regional_runtime",
+    "_bind_advanced_runtime",
+    "_bind_conditioning_runtime",
+    "_bind_artist_mix_runtime",
+    "_bind_prompt_fields_runtime",
+    "_bind_prompt_correction_runtime",
+)
+PROMPT_NODE_ADAPTER_RUNTIME_BINDERS = (
+    "_bind_regional_node_runtime",
+    "_bind_prompt_advanced_node_runtime",
+    "_bind_prompt_data_node_runtime",
+    "_bind_prompt_node_runtime",
+)
 RUNTIME_BINDER_FAMILIES = {
     "aio": (
         "_bind_aio_first_pass_cache_runtime",
@@ -98,18 +112,8 @@ RUNTIME_BINDER_FAMILIES = {
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime",
     ),
-    "prompt_regional": (
-        "_bind_regional_runtime",
-        "_bind_regional_node_runtime",
-        "_bind_advanced_runtime",
-        "_bind_prompt_advanced_node_runtime",
-        "_bind_conditioning_runtime",
-        "_bind_artist_mix_runtime",
-        "_bind_prompt_data_node_runtime",
-        "_bind_prompt_fields_runtime",
-        "_bind_prompt_correction_runtime",
-        "_bind_prompt_node_runtime",
-    ),
+    "prompt_services": PROMPT_SERVICE_RUNTIME_BINDERS,
+    "prompt_node_adapters": PROMPT_NODE_ADAPTER_RUNTIME_BINDERS,
     "wildcard_naia": (
         "_bind_wildcard_node_runtime",
         "_bind_naia_node_runtime",
@@ -2386,7 +2390,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             audit["summary"],
             {
                 "binder_count": 24,
-                "family_count": 3,
+                "family_count": 4,
                 "mode_counts": {
                     "comfy_provider_then_root": 12,
                     "root_globals": 10,
@@ -2463,6 +2467,72 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                     entry["root_observation"],
                     "call_time_resolver",
                 )
+
+    def test_prompt_regional_retirement_subgroups_are_exact(self):
+        audit = self.document["runtime_binder_audit"]
+        self.assertNotIn("prompt_regional", audit["families"])
+        self.assertEqual(
+            audit["families"]["prompt_services"],
+            list(PROMPT_SERVICE_RUNTIME_BINDERS),
+        )
+        self.assertEqual(
+            audit["families"]["prompt_node_adapters"],
+            list(PROMPT_NODE_ADAPTER_RUNTIME_BINDERS),
+        )
+        entries = {
+            entry["binder"]: (entry["module"], entry["mode"])
+            for entry in audit["entries"]
+            if entry["binder"]
+            in {
+                *PROMPT_SERVICE_RUNTIME_BINDERS,
+                *PROMPT_NODE_ADAPTER_RUNTIME_BINDERS,
+            }
+        }
+        self.assertEqual(
+            entries,
+            {
+                "_bind_regional_runtime": (
+                    "easyuse_anima.prompt.regional",
+                    "root_globals",
+                ),
+                "_bind_advanced_runtime": (
+                    "easyuse_anima.prompt.advanced",
+                    "root_globals",
+                ),
+                "_bind_conditioning_runtime": (
+                    "easyuse_anima.prompt.conditioning",
+                    "comfy_provider_then_root",
+                ),
+                "_bind_artist_mix_runtime": (
+                    "easyuse_anima.prompt.artist_mix",
+                    "comfy_provider_then_root",
+                ),
+                "_bind_prompt_fields_runtime": (
+                    "easyuse_anima.prompt.fields",
+                    "root_globals",
+                ),
+                "_bind_prompt_correction_runtime": (
+                    "easyuse_anima.prompt.correction",
+                    "root_globals",
+                ),
+                "_bind_regional_node_runtime": (
+                    "easyuse_anima.nodes.regional_nodes",
+                    "comfy_provider_then_root",
+                ),
+                "_bind_prompt_advanced_node_runtime": (
+                    "easyuse_anima.nodes.prompt_advanced_nodes",
+                    "root_globals",
+                ),
+                "_bind_prompt_data_node_runtime": (
+                    "easyuse_anima.nodes.prompt_data_nodes",
+                    "comfy_provider_then_root",
+                ),
+                "_bind_prompt_node_runtime": (
+                    "easyuse_anima.nodes.prompt_nodes",
+                    "root_globals",
+                ),
+            },
+        )
 
     def test_string_runtime_resolvers_keep_production_seams_transitional(self):
         representative = {


### PR DESCRIPTION
## 작업

- Task: B-11c30c
- Owner: #184
- Type: Contract/gate
- Base: `dev` / `cdd115d8bd9fa1c1c65b15931b0c748afebc2b5c`
- Production changes: 금지
- Allowed files:
  - `docs/architecture/python-backend-execution-roadmap.md`
  - `tests/test_python_compatibility_surface.py`
  - `tests/fixtures/python_compatibility_surface.v1.json`

## 목적

남은 Prompt/Regional binder 10개를 한 Move PR에서 제거하지 않도록, feature-service 6개와 ComfyUI node-adapter 4개의 독립 retirement lane으로 먼저 고정합니다. 이 PR은 분류와 gate만 변경하며 `nodes.py`와 `easyuse_anima/**` production 코드는 수정하지 않습니다.

## 작업 전 inventory

### Symbol / owner

| 경계 | Binder | Canonical owner | Mode | Bound globals |
| --- | --- | --- | --- | ---: |
| service | `_bind_regional_runtime` | `easyuse_anima.prompt.regional` | `root_globals` | 13 |
| service | `_bind_advanced_runtime` | `easyuse_anima.prompt.advanced` | `root_globals` | 1 |
| service | `_bind_conditioning_runtime` | `easyuse_anima.prompt.conditioning` | `comfy_provider_then_root` | 2 |
| service | `_bind_artist_mix_runtime` | `easyuse_anima.prompt.artist_mix` | `comfy_provider_then_root` | 1 |
| service | `_bind_prompt_fields_runtime` | `easyuse_anima.prompt.fields` | `root_globals` | 1 |
| service | `_bind_prompt_correction_runtime` | `easyuse_anima.prompt.correction` | `root_globals` | 3 |
| node-adapter | `_bind_regional_node_runtime` | `easyuse_anima.nodes.regional_nodes` | `comfy_provider_then_root` | 32 |
| node-adapter | `_bind_prompt_advanced_node_runtime` | `easyuse_anima.nodes.prompt_advanced_nodes` | `root_globals` | 40 |
| node-adapter | `_bind_prompt_data_node_runtime` | `easyuse_anima.nodes.prompt_data_nodes` | `comfy_provider_then_root` | 1 |
| node-adapter | `_bind_prompt_node_runtime` | `easyuse_anima.nodes.prompt_nodes` | `root_globals` | 11 |

합계는 binder 10개, bind-time global 105 slot입니다. service와 node-adapter의 파일 소유권은 겹치지 않습니다.

### Caller / alias

- `nodes.py`는 package/fallback import 분기에서 binder 10개를 각각 같은 canonical symbol로 가져오며, import-time call site 10개를 가집니다.
- canonical binder 10개와 root의 동일 이름은 현재 `transitional_private_seam`입니다. 지원 public API로 승격하지 않습니다.
- mode는 `root_globals` 6개, `comfy_provider_then_root` 4개입니다.
- repository test replacement 증거는 37개 고유 이름 / 10개 파일이며, migration cost 증거일 뿐 compatibility 약속이 아닙니다.

### Global state / provider

- root resolver: 97개 고유 이름
- provider resolver: `_encode_with_comfy_clip`, `_find_loaded_node_class` 2개 고유 이름 / 4 slot
- direct root dependency: `_FlexibleOptionalInputType`, `_resolve_comfy_host_helper`, `logger` 3개 고유 이름 / 7 slot
- 이 PR에서는 binder 설치, resolver 순서, logger lookup, provider fallback, mutable object identity를 변경하지 않습니다.

## 변경

- 기존 `prompt_regional` family를 `prompt_services` 6개와 `prompt_node_adapters` 4개로 분리
- fixture summary의 family count만 실제 분류에 맞게 갱신
- 두 subgroup의 정확한 symbol/module/mode membership을 focused gate로 고정
- 로드맵에 service와 adapter를 별도 Move PR로 진행한다는 금지 경계 기록

## 검증

- focused:
  - `D:\ComfyUI\custom_nodes_workplace\.venv\Scripts\python.exe -B -X utf8 -m unittest tests.test_python_compatibility_surface.PythonCompatibilitySurfaceTests`
  - 14 tests passed
- official full:
  - `powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 -Project <this-worktree> -Profile full`
  - Python 966 tests passed
  - frontend 114 JavaScript files / TypeScript 6.0.3 passed
  - Pyright baseline ratchet: 69 files passed
  - G-03a: 6 package groups / 0 violations
  - git diff check passed
  - Ruff 110 findings are the existing G-01 report-only baseline

## 금지 경계 / 남은 위험

- `nodes.py`, `easyuse_anima/**`, node schema, workflow, prompt/conditioning behavior 변경 금지
- service binder 제거와 node-adapter binder 제거를 같은 PR에서 수행 금지
- provider/root fallback 또는 repository test patch 이관은 후속 Move에서 각각 재검토

Closes no issue. Parent: #184.
