### PR TITLE
B-11c30c1: Prompt/Regional service binder retirement

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1174,7 +1174,7 @@ Implementation result:
 
 ### B-11c30b — LoRA binder retirement
 
-- **State:** IMPLEMENTED in PR #338
+- **State:** COMPLETE on `dev` in PR #338 / `cdd115d`
 - **Owner:** #184
 - **Type:** Move
 - **Base:** `dev@3647d3ad35dffb77b35ca423e1b89c6a4d7c3116`
@@ -1260,6 +1260,73 @@ Implementation result:
 - focused LoRA, contract, compatibility, and analyzer validation passes 61
   tests.
 
+### B-11c30c — Prompt/Regional binder split gate
+
+- **State:** COMPLETE on `dev` in PR #339 / `d0188b5`
+- **Owner:** #184
+- **Type:** Contract/gate
+
+The production-free gate splits the ten Prompt/Regional binders into six
+feature-service binders and four node-adapter binders. Symbols, callers,
+resolver modes, bound globals, provider/root resolver names, direct
+dependencies, and repository replacement evidence remain unchanged. The two
+subgroups are separate Move and rollback units.
+
+### B-11c30c1 — Prompt/Regional service binder retirement
+
+- **State:** IMPLEMENTED in PR #340
+- **Owner:** #184
+- **Type:** Move
+- **Base:** `dev@d0188b5e687164bdba817c9705c64e23c1262733`
+
+Pre-edit inventory:
+
+- six binders: Regional, Advanced, Conditioning, Artist Mix, Prompt Fields,
+  and Prompt Correction;
+- four root-only and two provider-then-root binders install 21 service globals;
+- 55 root resolver slots cover 46 unique root names, while two provider slots
+  retain `_encode_with_comfy_clip` and `_find_loaded_node_class`;
+- three direct dependency slots cover `_resolve_comfy_host_helper` and
+  `logger`; and
+- repository tests replace 22 unique family names in six files. This is test
+  migration evidence, not public root compatibility.
+
+Allowed production files:
+
+```text
+nodes.py
+easyuse_anima/prompt/regional.py
+easyuse_anima/prompt/advanced.py
+easyuse_anima/prompt/conditioning.py
+easyuse_anima/prompt/artist_mix.py
+easyuse_anima/prompt/fields.py
+easyuse_anima/prompt/correction.py
+```
+
+Implementation result:
+
+- root no longer imports or invokes the six binders, and their canonical
+  definitions and bind-time placeholder state are absent;
+- service-internal calls use canonical module globals and explicit canonical
+  imports without importing root `nodes.py`;
+- Artist Mix CLIP encoding and Conditioning loaded-node discovery resolve the
+  existing E-07 provider directly at call time. The Comfy host ledger remains
+  22 slots across 15 modules;
+- root helper aliases retain direct canonical identity, while service-specific
+  tests replace the owning canonical module;
+- all four Prompt/Regional node-adapter binders remain unchanged for
+  B-11c30c2;
+- the remaining audit is 18 binders in three families: ten
+  provider-then-root, six root-only, and two explicit callbacks; and
+- `nodes.py` is 1,763 lines, down 37 lines from the B-11c30b base.
+
+Forbidden:
+
+- changing Prompt/Regional schema, workflow serialization, mapped-class
+  identity, prompt/conditioning output, seed behavior, provider lookup order,
+  warning-once state, or optional dependency timing; and
+- retiring any of the four node-adapter binders or combining B-11c30c2.
+
 ### B-11d — Final root shim
 
 - **State:** BLOCKED by the remaining B-11c30 family Moves and the separate
@@ -1300,7 +1367,9 @@ COMPLETE: B-11c29d CLIP wrapper retirement / PR #333
 COMPLETE: B-11c29b3 general node lookup retirement / PR #334
 COMPLETE: B-11c30 binder/resolver migration audit / PR #336
 COMPLETE: B-11c30a Image/SAM3/Impact binder Move / PR #337
-IN PROGRESS: B-11c30b LoRA binder Move / PR #338
+COMPLETE: B-11c30b LoRA binder Move / PR #338
+COMPLETE: B-11c30c Prompt/Regional split gate / PR #339
+IN PROGRESS: B-11c30c1 Prompt/Regional service binder Move / PR #340
 BLOCKED:  B-11d final root shim
 
 LATER:    #167 seed reservation

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1308,7 +1308,9 @@ Implementation result:
 - root no longer imports or invokes the six binders, and their canonical
   definitions and bind-time placeholder state are absent;
 - service-internal calls use canonical module globals and explicit canonical
-  imports without importing root `nodes.py`;
+  imports without importing root `nodes.py`; the still-legacy
+  `wildcard_engine` owner remains a call-time import so direct package imports
+  do not eagerly load NumPy before D-12;
 - Artist Mix CLIP encoding and Conditioning loaded-node discovery resolve the
   existing E-07 provider directly at call time. The Comfy host ledger remains
   22 slots across 15 modules;

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -106,8 +106,9 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   Prompt/Regional binders into six feature-service binders and four node-adapter
   binders before either group enters a Move PR. PR #339 / `d0188b5` completes
   that split, producing four audited families without changing the 24-binder
-  total. B-11c30c1 retires only the six feature-service binders; the four
-  node-adapter binders remain for B-11c30c2.
+  total. B-11c30c1 retires only the six feature-service binders in PR #340,
+  leaving 18 binders across AiO, Prompt node adapters, and Wildcard/NAIA. The
+  four Prompt/Regional node-adapter binders remain for B-11c30c2.
 
 ### Current quality baseline
 
@@ -349,7 +350,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c PR #339 / `d0188b5`; B-11c30c1 Prompt/Regional service binder Move is next | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c1 PR #340; B-11c30c2 Prompt/Regional node-adapter binder Move is next | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -31,7 +31,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | Phase | Integrated snapshot / open implementation state | Remaining exit work |
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
-| B - `nodes.py` extraction | Integrated through B-11c30b / PR #338 / `cdd115d` | Split the Prompt/Regional binder family into service and node-adapter lanes, complete binder families, then perform the final root shim as a separate Move |
+| B - `nodes.py` extraction | Integrated through B-11c30c / PR #339 / `d0188b5` | Retire the Prompt/Regional service and node-adapter binder lanes separately, complete the remaining binder families, then perform the final root shim as a separate Move |
 | C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
@@ -104,7 +104,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   LoRA binders in PR #338 / `cdd115d`; 24 binders across three families remain.
   B-11c30c is a production-free Contract/gate that splits the ten remaining
   Prompt/Regional binders into six feature-service binders and four node-adapter
-  binders before either group enters a Move PR.
+  binders before either group enters a Move PR. PR #339 / `d0188b5` completes
+  that split, producing four audited families without changing the 24-binder
+  total. B-11c30c1 retires only the six feature-service binders; the four
+  node-adapter binders remain for B-11c30c2.
 
 ### Current quality baseline
 
@@ -346,7 +349,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30b PR #338 / `cdd115d`; B-11c30c Prompt/Regional split gate is next | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c PR #339 / `d0188b5`; B-11c30c1 Prompt/Regional service binder Move is next | Move/Contract, split PRs | #184 | Residual owners and binders migrate in rollback-sized units before final shim |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1006,6 +1009,13 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     direct dependencies, and repository replacement evidence unchanged. Each
     subgroup must retire in a separate Move PR; no service and adapter binder
     removal may be combined.
+  - B-11c30c1 retires only the six service binders under
+    `easyuse_anima.prompt`: Regional, Advanced, Conditioning, Artist Mix,
+    Prompt Fields, and Prompt Correction. Canonical services resolve canonical
+    feature helpers and the existing E-07 Comfy host provider at call time.
+    Node-adapter binders, schemas, mapped classes, prompt/conditioning behavior,
+    provider lookup order, warning-once state, and saved workflows remain
+    unchanged. B-11c30c2 owns the four node-adapter binders separately.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,9 +8,9 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30a are integrated. B-11c is split into
+- Current state: B-11a through B-11c30c are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c30b retires only the LoRA binder family.
+  root shim; B-11c30c1 retires only the six Prompt/Regional service binders.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -75,7 +75,7 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 295 in B-11c29b3
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 283 in B-11c30c1
   (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
@@ -86,8 +86,8 @@ inferring public support from spelling or test imports:
   owner module without a root alias or backend mapping;
 - root-owned residual implementation: 1 function, 0 classes, and 26 assigned
   globals in B-11c29b3 (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 30 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 284, including
+- import-time runtime binders: 18 exact top-level `_bind_*_runtime` calls;
+- root names reached by those canonical runtime resolvers: 243, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -736,6 +736,32 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - The remaining binder audit contains 24 binders in three owner families. No
   LoRA schema, workflow, stack/trigger order, missing-model policy, or optional
   dependency behavior changes in this Move.
+
+### B-11c30c Prompt/Regional split gate
+
+- PR #339 / `d0188b5` changes no production code. It decomposes the ten
+  Prompt/Regional binders into six feature-service owners and four node-adapter
+  owners without changing their symbols, callers, resolver names, bound
+  globals, provider slots, or replacement evidence.
+- The service and adapter subgroups are separate rollback units. A Move may not
+  retire both subgroups together.
+
+### B-11c30c1 Prompt/Regional service binder retirement
+
+- The six root binder imports/calls and canonical service binder definitions
+  for Regional, Advanced, Conditioning, Artist Mix, Prompt Fields, and Prompt
+  Correction are removed.
+- Canonical service calls now resolve canonical module globals directly.
+  Artist Mix CLIP encoding and Conditioning loaded-node lookup remain direct
+  call-time E-07 provider consumers; the Comfy host ledger remains 22 slots
+  across 15 modules.
+- Root helper aliases remain direct canonical aliases. Tests that replaced root
+  only to drive a canonical service now replace that service owner, while all
+  four node-adapter binders retain their existing root seams for B-11c30c2.
+- The remaining audit is 18 binders in three families: ten
+  provider-then-root, six root-only, and two explicit callbacks. No schema,
+  workflow, prompt/conditioning behavior, provider lookup order, warning-once
+  state, or optional-dependency timing changes in this Move.
 
 ### `nodes.py` public node-class surface
 

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -752,6 +752,8 @@ convenience-node compatibility; it remains unmapped and is not public support.
   for Regional, Advanced, Conditioning, Artist Mix, Prompt Fields, and Prompt
   Correction are removed.
 - Canonical service calls now resolve canonical module globals directly.
+  Advanced keeps the still-legacy `wildcard_engine` behind call-time wrappers,
+  preserving the package skeleton's no-eager-NumPy import boundary before D-12.
   Artist Mix CLIP encoding and Conditioning loaded-node lookup remain direct
   call-time E-07 provider consumers; the Comfy host ledger remains 22 slots
   across 15 modules.

--- a/easyuse_anima/prompt/advanced.py
+++ b/easyuse_anima/prompt/advanced.py
@@ -44,21 +44,9 @@ from .fields import (
 try:
     from ...prompt_translation import has_prompt_translation_markers
     from ...settings import resolve_metadata_filter_words
-    from ...wildcard_engine import (
-        expand_wildcard_texts,
-        has_wildcard_syntax,
-        normalize_prompt_studio_wildcard_mode,
-        normalize_seed,
-    )
 except ImportError:
     from prompt_translation import has_prompt_translation_markers
     from settings import resolve_metadata_filter_words
-    from wildcard_engine import (
-        expand_wildcard_texts,
-        has_wildcard_syntax,
-        normalize_prompt_studio_wildcard_mode,
-        normalize_seed,
-    )
 
 ADVANCED_FIELD_TYPES = {"quality", "artist", "trigger", "general", "naia"}
 ADVANCED_FIELD_PANES = {"positive", "negative"}
@@ -142,6 +130,34 @@ PROMPT_STUDIO_ADVANCED_RETURN_NAMES = (
 
 _ADVANCED_FIELD_SOCKET_PREFIX = "field_"
 _ADVANCED_FIELD_SOCKET_RE = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _wildcard_engine_module():
+    try:
+        from ... import wildcard_engine as module
+    except ImportError:
+        import wildcard_engine as module
+
+    return module
+
+
+def normalize_prompt_studio_wildcard_mode(*args, **kwargs):
+    return _wildcard_engine_module().normalize_prompt_studio_wildcard_mode(
+        *args,
+        **kwargs,
+    )
+
+
+def normalize_seed(*args, **kwargs):
+    return _wildcard_engine_module().normalize_seed(*args, **kwargs)
+
+
+def has_wildcard_syntax(*args, **kwargs):
+    return _wildcard_engine_module().has_wildcard_syntax(*args, **kwargs)
+
+
+def expand_wildcard_texts(*args, **kwargs):
+    return _wildcard_engine_module().expand_wildcard_texts(*args, **kwargs)
 
 
 def _normalize_prompt_studio_wildcard_seed_control(

--- a/easyuse_anima/prompt/advanced.py
+++ b/easyuse_anima/prompt/advanced.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable
 from typing import Any
 
+from ..common.values import _as_bool, _as_int, _single_value
 from ..naia.resolution import (
     DEFAULT_ADVANCED_RESOLUTION_BUCKET,
     NAIA_ADVANCED_RESOLUTION_BUCKET,
+    _normalize_resolution_bucket,
 )
 from .artist_mix import (
     ARTIST_MIX_DEFAULT_CLUSTER_COUNT,
@@ -22,9 +23,42 @@ from .artist_mix import (
     ARTIST_MIX_DEFAULT_STYLE_GAIN,
     ARTIST_MIX_MODE_OFF,
     ARTIST_MIX_MODE_PROMPT,
+    _artist_mix_inline_prompt,
+    _artist_tags_from_prompt,
+    _bounded_artist_mix_float,
+    _bounded_artist_mix_int,
+    _join_artist_mix_source_prompts,
+    _normalize_artist_mix_mode,
+    _parse_artist_mix_items,
 )
+from .correction import _translate_prompt_text
 from .data import PROMPT_DATA_SCHEMA, PROMPT_DATA_TYPE, PROMPT_DATA_VERSION
-from .fields import DEFAULT_QUALITY_TAGS, DEFAULT_TRAILING_QUALITY_TAGS
+from .fields import (
+    DEFAULT_QUALITY_TAGS,
+    DEFAULT_TRAILING_QUALITY_TAGS,
+    _correct_builder_prompt,
+    _filter_metadata_prompt,
+    _join_prompt_tokens,
+)
+
+try:
+    from ...prompt_translation import has_prompt_translation_markers
+    from ...settings import resolve_metadata_filter_words
+    from ...wildcard_engine import (
+        expand_wildcard_texts,
+        has_wildcard_syntax,
+        normalize_prompt_studio_wildcard_mode,
+        normalize_seed,
+    )
+except ImportError:
+    from prompt_translation import has_prompt_translation_markers
+    from settings import resolve_metadata_filter_words
+    from wildcard_engine import (
+        expand_wildcard_texts,
+        has_wildcard_syntax,
+        normalize_prompt_studio_wildcard_mode,
+        normalize_seed,
+    )
 
 ADVANCED_FIELD_TYPES = {"quality", "artist", "trigger", "general", "naia"}
 ADVANCED_FIELD_PANES = {"positive", "negative"}
@@ -109,50 +143,6 @@ PROMPT_STUDIO_ADVANCED_RETURN_NAMES = (
 _ADVANCED_FIELD_SOCKET_PREFIX = "field_"
 _ADVANCED_FIELD_SOCKET_RE = re.compile(r"[^A-Za-z0-9_]")
 
-_RuntimeResolver = Callable[[str], Callable[..., Any]]
-_RUNTIME_RESOLVER: _RuntimeResolver | None = None
-_RUNTIME_HELPER_NAMES = (
-    "_as_bool",
-    "_as_int",
-    "_single_value",
-    "_normalize_resolution_bucket",
-    "_artist_mix_inline_prompt",
-    "_correct_builder_prompt",
-    "_join_prompt_tokens",
-    "resolve_metadata_filter_words",
-    "_filter_metadata_prompt",
-    "normalize_prompt_studio_wildcard_mode",
-    "has_wildcard_syntax",
-    "expand_wildcard_texts",
-    "has_prompt_translation_markers",
-    "_translate_prompt_text",
-    "_join_artist_mix_source_prompts",
-    "_normalize_artist_mix_mode",
-    "_artist_tags_from_prompt",
-    "_parse_artist_mix_items",
-    "_bounded_artist_mix_float",
-    "_bounded_artist_mix_int",
-    "normalize_seed",
-)
-
-
-def _runtime_proxy(name: str):
-    def invoke(*args, **kwargs):
-        if _RUNTIME_RESOLVER is None:
-            raise RuntimeError(
-                f"[EasyUseAnima] Advanced Prompt Studio runtime helper is not bound: {name}"
-            )
-        return _RUNTIME_RESOLVER(name)(*args, **kwargs)
-
-    return invoke
-
-
-def _bind_advanced_runtime(*, resolve_helper: _RuntimeResolver) -> None:
-    """Bind late runtime helpers without importing the root compatibility module."""
-
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
-
 
 def _normalize_prompt_studio_wildcard_seed_control(
     value: Any,
@@ -165,31 +155,6 @@ def _normalize_prompt_studio_wildcard_seed_control(
         str(value or "").strip().lower(),
         SEED_CONTROL_FIXED,
     )
-
-
-_as_bool = _runtime_proxy("_as_bool")
-_as_int = _runtime_proxy("_as_int")
-_single_value = _runtime_proxy("_single_value")
-_normalize_resolution_bucket = _runtime_proxy("_normalize_resolution_bucket")
-_artist_mix_inline_prompt = _runtime_proxy("_artist_mix_inline_prompt")
-_correct_builder_prompt = _runtime_proxy("_correct_builder_prompt")
-_join_prompt_tokens = _runtime_proxy("_join_prompt_tokens")
-resolve_metadata_filter_words = _runtime_proxy("resolve_metadata_filter_words")
-_filter_metadata_prompt = _runtime_proxy("_filter_metadata_prompt")
-normalize_prompt_studio_wildcard_mode = _runtime_proxy(
-    "normalize_prompt_studio_wildcard_mode"
-)
-has_wildcard_syntax = _runtime_proxy("has_wildcard_syntax")
-expand_wildcard_texts = _runtime_proxy("expand_wildcard_texts")
-has_prompt_translation_markers = _runtime_proxy("has_prompt_translation_markers")
-_translate_prompt_text = _runtime_proxy("_translate_prompt_text")
-_join_artist_mix_source_prompts = _runtime_proxy("_join_artist_mix_source_prompts")
-_normalize_artist_mix_mode = _runtime_proxy("_normalize_artist_mix_mode")
-_artist_tags_from_prompt = _runtime_proxy("_artist_tags_from_prompt")
-_parse_artist_mix_items = _runtime_proxy("_parse_artist_mix_items")
-_bounded_artist_mix_float = _runtime_proxy("_bounded_artist_mix_float")
-_bounded_artist_mix_int = _runtime_proxy("_bounded_artist_mix_int")
-normalize_seed = _runtime_proxy("normalize_seed")
 
 
 def _translate_prompt_fields(fields: list[dict]) -> list[dict]:

--- a/easyuse_anima/prompt/artist_mix.py
+++ b/easyuse_anima/prompt/artist_mix.py
@@ -6,7 +6,9 @@ from math import isfinite
 from typing import Any
 
 from ..common.values import _as_bool, _as_float, _as_int
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 from .data import _normalize_prompt_data, _prompt_data_nested, _prompt_data_output
+from .fields import _correct_builder_prompt, _join_prompt_tokens
 
 ARTIST_MIX_MODE_FROM_PROMPT_DATA = "prompt_data"
 ARTIST_MIX_MODE_OFF = "off"
@@ -108,33 +110,35 @@ _ARTIST_GROUP_RE = re.compile(
 )
 _SECTION_SEPARATOR_RE = re.compile(r"^\s*-{6,}\s*$", re.MULTILINE)
 
-_RUNTIME_RESOLVER = None
-_RUNTIME_HELPER_NAMES = (
-    "_advanced_enabled_pane_fields",
-    "_advanced_prompt_with_artist_override",
-    "_correct_builder_prompt",
-    "_encode_with_comfy_clip",
-    "_join_prompt_tokens",
-    "_normalize_advanced_fields",
-)
 
-def _runtime_proxy(name: str):
-    def invoke(*args, **kwargs):
-        if _RUNTIME_RESOLVER is None:
-            raise RuntimeError(f"[EasyUseAnima] Artist mix runtime helper is not bound: {name}")
-        return _RUNTIME_RESOLVER(name)(*args, **kwargs)
-    return invoke
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"Artist Mix Comfy host helper is unavailable: {name}")
 
-def _bind_artist_mix_runtime(*, resolve_helper) -> None:
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
-    for name in _RUNTIME_HELPER_NAMES:
-        globals()[name] = _runtime_proxy(name)
 
-def _runtime_helper(name: str):
-    if _RUNTIME_RESOLVER is None:
-        return globals()[name]
-    return _RUNTIME_RESOLVER(name)
+def _encode_with_comfy_clip(*args, **kwargs):
+    helper = resolve_comfy_host_helper(
+        "_encode_with_comfy_clip",
+        _missing_host_helper,
+    )
+    return helper(*args, **kwargs)
+
+
+def _advanced_enabled_pane_fields(*args, **kwargs):
+    from .advanced import _advanced_enabled_pane_fields as helper
+
+    return helper(*args, **kwargs)
+
+
+def _advanced_prompt_with_artist_override(*args, **kwargs):
+    from .advanced import _advanced_prompt_with_artist_override as helper
+
+    return helper(*args, **kwargs)
+
+
+def _normalize_advanced_fields(*args, **kwargs):
+    from .advanced import _normalize_advanced_fields as helper
+
+    return helper(*args, **kwargs)
 
 def _split_artist_mix_items(text: str) -> list[str]:
     items: list[str] = []
@@ -906,7 +910,7 @@ def _encode_artist_average(
     composite = _encode_with_comfy_clip(clip, composite_prompt)
     if len(composite) != 1:
         composite = None
-    return _runtime_helper("_blend_conditionings")(encoded, mix_weights, composite)
+    return _blend_conditionings(encoded, mix_weights, composite)
 
 def _encode_artist_hybrid(
     clip,
@@ -952,7 +956,7 @@ def _encode_artist_hybrid(
             return _encode_artist_exact(clip, data, base_prompt, sorted_artists, strength_scale=strength_scale)
         try:
             output.extend(
-                _runtime_helper("_encode_artist_delta_rms")(
+                _encode_artist_delta_rms(
                     clip,
                     data,
                     base_prompt,
@@ -1308,7 +1312,7 @@ def _encode_prompt_data_positive_conditioning(
         return _encode_artist_average(clip, data, base_prompt, artists)
     if mode == ARTIST_MIX_MODE_DELTA_RMS:
         return _mark_artist_mix_conditioning(
-            _runtime_helper("_encode_artist_delta_rms")(
+            _encode_artist_delta_rms(
                 clip,
                 data,
                 base_prompt,
@@ -1364,7 +1368,7 @@ def _encode_prompt_data_positive_conditioning(
         )
     if mode == ARTIST_MIX_MODE_CLUSTERED:
         return _mark_artist_mix_conditioning(
-            _runtime_helper("_encode_artist_clustered")(
+            _encode_artist_clustered(
                 clip,
                 data,
                 base_prompt,

--- a/easyuse_anima/prompt/conditioning.py
+++ b/easyuse_anima/prompt/conditioning.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import inspect
+import logging
 
 from ..infrastructure.comfy.invocation import _node_output_tuple
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 
 ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA = "prompt_data"
 ANIMA_MOD_GUIDANCE_MODE_ENABLED = "enabled"
@@ -23,26 +25,26 @@ ANIMA_MOD_GUIDANCE_PROFILES = (
 )
 
 _SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED: set[str] = set()
-_RUNTIME_RESOLVER = None
-_RUNTIME_LOGGER_RESOLVER = None
 
-def _bind_conditioning_runtime(*, resolve_helper, resolve_logger) -> None:
-    global _RUNTIME_RESOLVER, _RUNTIME_LOGGER_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
-    _RUNTIME_LOGGER_RESOLVER = resolve_logger
 
-def _runtime_helper(name: str):
-    if _RUNTIME_RESOLVER is None:
-        raise RuntimeError(f"[EasyUseAnima] Conditioning runtime helper is not bound: {name}")
-    return _RUNTIME_RESOLVER(name)
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"Conditioning Comfy host helper is unavailable: {name}")
+
+
+def _find_loaded_node_class(node_id: str):
+    helper = resolve_comfy_host_helper(
+        "_find_loaded_node_class",
+        _missing_host_helper,
+    )
+    return helper(node_id)
+
 
 def _runtime_logger():
-    if _RUNTIME_LOGGER_RESOLVER is None:
-        raise RuntimeError("[EasyUseAnima] Conditioning logger is not bound.")
-    return _RUNTIME_LOGGER_RESOLVER()
+    return logging.getLogger("ComfyUI-EasyUseAnima")
+
 
 def _find_spectrum_anima_mod_guidance_class():
-    cls = _runtime_helper("_find_loaded_node_class")("AnimaModGuidance")
+    cls = _find_loaded_node_class("AnimaModGuidance")
     if cls is not None:
         return cls
     raise RuntimeError(
@@ -89,7 +91,7 @@ def _apply_spectrum_anima_mod_guidance(
     quality_neg: str,
     mod_w_profile: str,
 ):
-    patcher_cls = _runtime_helper("_find_spectrum_anima_mod_guidance_class")()
+    patcher_cls = _find_spectrum_anima_mod_guidance_class()
     patcher = patcher_cls()
     patch = getattr(patcher, "patch", None)
     if patch is None:

--- a/easyuse_anima/prompt/correction.py
+++ b/easyuse_anima/prompt/correction.py
@@ -10,23 +10,6 @@ except ImportError:
     from settings import resolve_prompt_translation_settings
 
 
-def _bind_prompt_correction_runtime(*, resolve_helper) -> None:
-    global has_prompt_translation_markers, translate_prompt_markers
-    global resolve_prompt_translation_settings
-
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
-
-        return call
-
-    has_prompt_translation_markers = runtime_helper("has_prompt_translation_markers")
-    translate_prompt_markers = runtime_helper("translate_prompt_markers")
-    resolve_prompt_translation_settings = runtime_helper(
-        "resolve_prompt_translation_settings"
-    )
-
-
 def _split_tag_text(value: str) -> list[str]:
     if not value:
         return []

--- a/easyuse_anima/prompt/fields.py
+++ b/easyuse_anima/prompt/fields.py
@@ -23,90 +23,66 @@ DEFAULT_TRAILING_QUALITY_TAGS = (
 _HASH_COMMENT_RE = re.compile(r"^[ \t]*#[^\n]*", re.MULTILINE)
 _INLINE_SPACE_RE = re.compile(r"[ \t]+")
 _WEIGHTED_TOKEN_RE = re.compile(r"^\(([^(),]+):[-+]?\d+(?:\.\d+)?\)$")
-_RUNTIME_HELPER_RESOLVER = None
-
-
-def _bind_prompt_fields_runtime(*, resolve_helper) -> None:
-    global _RUNTIME_HELPER_RESOLVER
-    _RUNTIME_HELPER_RESOLVER = resolve_helper
-
-
-def _runtime_helper(name, fallback):
-    if _RUNTIME_HELPER_RESOLVER is None:
-        return fallback
-    return _RUNTIME_HELPER_RESOLVER(name)
 
 
 def _prompt_tokens(value: str) -> list[str]:
     if not value:
         return []
-    hash_comment_re = _runtime_helper("_HASH_COMMENT_RE", _HASH_COMMENT_RE)
-    inline_space_re = _runtime_helper("_INLINE_SPACE_RE", _INLINE_SPACE_RE)
-    prompt_parser = _runtime_helper("parse_prompt", parse_prompt)
-    cleaned_val = hash_comment_re.sub("", value)
+    cleaned_val = _HASH_COMMENT_RE.sub("", value)
     normalized = str(cleaned_val).replace("\r\n", "\n").replace("\r", "\n")
     normalized = normalized.replace("，", ",").replace("\n", ",")
     tokens: list[str] = []
-    for token in prompt_parser(normalized, profile="prompt").tokens:
-        cleaned = inline_space_re.sub(" ", str(token).strip(" ,\n\t"))
+    for token in parse_prompt(normalized, profile="prompt").tokens:
+        cleaned = _INLINE_SPACE_RE.sub(" ", str(token).strip(" ,\n\t"))
         if cleaned:
             tokens.append(cleaned)
     return tokens
 
 
 def _join_prompt_tokens(*parts: str) -> str:
-    prompt_tokens = _runtime_helper("_prompt_tokens", _prompt_tokens)
     tokens: list[str] = []
     for part in parts:
-        tokens.extend(prompt_tokens(part))
+        tokens.extend(_prompt_tokens(part))
     return ", ".join(tokens)
 
 
 def _correct_builder_prompt(prompt: str, artist_overrides: str = "") -> str:
     if not prompt:
         return ""
-    correction = _runtime_helper("correct_prompt", correct_prompt)
-    knowledge_base_loader = _runtime_helper("load_knowledge_base", load_knowledge_base)
-    prompt_tokens = _runtime_helper("_prompt_tokens", _prompt_tokens)
-    result = correction(
+    result = correct_prompt(
         prompt,
         profile="prompt",
-        knowledge_base=knowledge_base_loader(allow_missing=True),
+        knowledge_base=load_knowledge_base(allow_missing=True),
         validate_artist_tags=False,
-        artist_overrides=prompt_tokens(artist_overrides),
+        artist_overrides=_prompt_tokens(artist_overrides),
     )
     return result.text
 
 
 def _metadata_filter_key(value: str) -> str:
-    inline_space_re = _runtime_helper("_INLINE_SPACE_RE", _INLINE_SPACE_RE)
-    value = inline_space_re.sub(" ", str(value or "").strip(" ,\n\t"))
+    value = _INLINE_SPACE_RE.sub(" ", str(value or "").strip(" ,\n\t"))
     return value.replace("_", " ").casefold()
 
 
 def _metadata_filter_keys(value: str) -> set[str]:
-    metadata_filter_key = _runtime_helper("_metadata_filter_key", _metadata_filter_key)
-    weighted_token_re = _runtime_helper("_WEIGHTED_TOKEN_RE", _WEIGHTED_TOKEN_RE)
-    keys = {metadata_filter_key(value)}
-    weighted = weighted_token_re.match(str(value or "").strip())
+    keys = {_metadata_filter_key(value)}
+    weighted = _WEIGHTED_TOKEN_RE.match(str(value or "").strip())
     if weighted:
-        keys.add(metadata_filter_key(weighted.group(1)))
+        keys.add(_metadata_filter_key(weighted.group(1)))
     return {key for key in keys if key}
 
 
 def _filter_metadata_prompt(prompt: str, filter_words: str) -> str:
-    prompt_tokens = _runtime_helper("_prompt_tokens", _prompt_tokens)
-    metadata_filter_keys = _runtime_helper("_metadata_filter_keys", _metadata_filter_keys)
     filter_keys: set[str] = set()
-    for word in prompt_tokens(filter_words):
-        filter_keys.update(metadata_filter_keys(word))
+    for word in _prompt_tokens(filter_words):
+        filter_keys.update(_metadata_filter_keys(word))
     if not prompt or not filter_keys:
         return prompt
 
     kept = [
         token
-        for token in prompt_tokens(prompt)
-        if metadata_filter_keys(token).isdisjoint(filter_keys)
+        for token in _prompt_tokens(prompt)
+        if _metadata_filter_keys(token).isdisjoint(filter_keys)
     ]
     return ", ".join(kept)
 

--- a/easyuse_anima/prompt/regional.py
+++ b/easyuse_anima/prompt/regional.py
@@ -6,6 +6,22 @@ import json
 import re
 from typing import Any
 
+from ..common.values import _as_bool, _as_float, _as_int, _single_value
+from ..naia.resolution import _ratio_label
+from .advanced import (
+    _advanced_default_fields,
+    _advanced_field_input_values,
+    _advanced_field_socket_name,
+    _as_advanced_height,
+    _correct_advanced_field_sequence,
+)
+from .fields import _filter_metadata_prompt, _join_prompt_tokens
+
+try:
+    from ...settings import resolve_metadata_filter_words
+except ImportError:
+    from settings import resolve_metadata_filter_words
+
 
 REGIONAL_FIELDS_WORKFLOW_PROPERTY = "easyuse_anima_regional_fields"
 REGIONAL_CONFIG_WORKFLOW_PROPERTY = "easyuse_anima_regional_config"
@@ -22,52 +38,6 @@ ADVANCED_FIELD_LABELS = {
     "trigger": "Trigger Words",
     "general": "General Tags",
 }
-
-
-def _unbound_runtime(*_args, **_kwargs):
-    raise RuntimeError("Regional Prompt Studio runtime dependencies are not bound.")
-
-
-_advanced_default_fields = _unbound_runtime
-_single_value = _unbound_runtime
-_as_int = _unbound_runtime
-_as_bool = _unbound_runtime
-_as_float = _unbound_runtime
-_as_advanced_height = _unbound_runtime
-_advanced_field_input_values = _unbound_runtime
-_advanced_field_socket_name = _unbound_runtime
-_ratio_label = _unbound_runtime
-_correct_advanced_field_sequence = _unbound_runtime
-_join_prompt_tokens = _unbound_runtime
-resolve_metadata_filter_words = _unbound_runtime
-_filter_metadata_prompt = _unbound_runtime
-
-
-def _bind_regional_runtime(*, resolve_helper) -> None:
-    global _advanced_default_fields, _single_value, _as_int, _as_bool, _as_float
-    global _as_advanced_height, _advanced_field_input_values, _advanced_field_socket_name
-    global _ratio_label, _correct_advanced_field_sequence, _join_prompt_tokens
-    global resolve_metadata_filter_words, _filter_metadata_prompt
-
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
-
-        return call
-
-    _advanced_default_fields = runtime_helper("_advanced_default_fields")
-    _single_value = runtime_helper("_single_value")
-    _as_int = runtime_helper("_as_int")
-    _as_bool = runtime_helper("_as_bool")
-    _as_float = runtime_helper("_as_float")
-    _as_advanced_height = runtime_helper("_as_advanced_height")
-    _advanced_field_input_values = runtime_helper("_advanced_field_input_values")
-    _advanced_field_socket_name = runtime_helper("_advanced_field_socket_name")
-    _ratio_label = runtime_helper("_ratio_label")
-    _correct_advanced_field_sequence = runtime_helper("_correct_advanced_field_sequence")
-    _join_prompt_tokens = runtime_helper("_join_prompt_tokens")
-    resolve_metadata_filter_words = runtime_helper("resolve_metadata_filter_words")
-    _filter_metadata_prompt = runtime_helper("_filter_metadata_prompt")
 
 
 def _regional_default_fields() -> list[dict]:

--- a/nodes.py
+++ b/nodes.py
@@ -152,7 +152,6 @@ try:
     )
     from .easyuse_anima.workflow import _get_workflow_node as _get_workflow_node
     from .easyuse_anima.prompt.correction import (
-        _bind_prompt_correction_runtime as _bind_prompt_correction_runtime,
         _prompt_translation_change_key as _prompt_translation_change_key,
         _split_tag_text as _split_tag_text,
         _translate_prompt_text as _translate_prompt_text,
@@ -163,7 +162,6 @@ try:
         _HASH_COMMENT_RE as _HASH_COMMENT_RE,
         _INLINE_SPACE_RE as _INLINE_SPACE_RE,
         _WEIGHTED_TOKEN_RE as _WEIGHTED_TOKEN_RE,
-        _bind_prompt_fields_runtime as _bind_prompt_fields_runtime,
         _correct_builder_prompt as _correct_builder_prompt,
         _filter_metadata_prompt as _filter_metadata_prompt,
         _join_prompt_tokens as _join_prompt_tokens,
@@ -214,7 +212,6 @@ try:
         _advanced_uses_naia_resolution as _advanced_uses_naia_resolution,
         _apply_advanced_field_inputs as _apply_advanced_field_inputs,
         _as_advanced_height as _as_advanced_height,
-        _bind_advanced_runtime as _bind_advanced_runtime,
         _build_advanced_prompt_data as _build_advanced_prompt_data,
         _build_advanced_prompts as _build_advanced_prompts,
         _clone_advanced_fields as _clone_advanced_fields,
@@ -234,7 +231,6 @@ try:
         # B-10b17: canonical adapters consume these objects directly.
         # B-10b17: root runtime has no caller for the retired constants.
         _apply_regional_field_inputs as _apply_regional_field_inputs,
-        _bind_regional_runtime as _bind_regional_runtime,
         _build_regional_outputs as _build_regional_outputs,
         _clone_regional_fields as _clone_regional_fields,
         _conditioning_set_values as _conditioning_set_values,
@@ -263,7 +259,6 @@ try:
         ANIMA_MOD_GUIDANCE_PROFILE_OFF as ANIMA_MOD_GUIDANCE_PROFILE_OFF,
         # B-10b15: warning dispatch remains canonical-only.
         _apply_spectrum_anima_mod_guidance as _apply_spectrum_anima_mod_guidance,
-        _bind_conditioning_runtime as _bind_conditioning_runtime,
         _find_spectrum_anima_mod_guidance_class as _find_spectrum_anima_mod_guidance_class,
         _normalize_anima_mod_guidance_profile as _normalize_anima_mod_guidance_profile,
         _resolve_anima_mod_guidance_enabled as _resolve_anima_mod_guidance_enabled,
@@ -310,7 +305,6 @@ try:
         _artist_prompt_with_position as _artist_prompt_with_position,
         _artist_tags_from_prompt as _artist_tags_from_prompt,
         # B-10b18: prompt-data artist variants remain canonical-only.
-        _bind_artist_mix_runtime as _bind_artist_mix_runtime,
         _blend_conditionings as _blend_conditionings,
         _bounded_artist_mix_float as _bounded_artist_mix_float,
         _bounded_artist_mix_int as _bounded_artist_mix_int,
@@ -701,7 +695,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
     )
     from easyuse_anima.workflow import _get_workflow_node as _get_workflow_node
     from easyuse_anima.prompt.correction import (
-        _bind_prompt_correction_runtime as _bind_prompt_correction_runtime,
         _prompt_translation_change_key as _prompt_translation_change_key,
         _split_tag_text as _split_tag_text,
         _translate_prompt_text as _translate_prompt_text,
@@ -712,7 +705,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _HASH_COMMENT_RE as _HASH_COMMENT_RE,
         _INLINE_SPACE_RE as _INLINE_SPACE_RE,
         _WEIGHTED_TOKEN_RE as _WEIGHTED_TOKEN_RE,
-        _bind_prompt_fields_runtime as _bind_prompt_fields_runtime,
         _correct_builder_prompt as _correct_builder_prompt,
         _filter_metadata_prompt as _filter_metadata_prompt,
         _join_prompt_tokens as _join_prompt_tokens,
@@ -763,7 +755,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _advanced_uses_naia_resolution as _advanced_uses_naia_resolution,
         _apply_advanced_field_inputs as _apply_advanced_field_inputs,
         _as_advanced_height as _as_advanced_height,
-        _bind_advanced_runtime as _bind_advanced_runtime,
         _build_advanced_prompt_data as _build_advanced_prompt_data,
         _build_advanced_prompts as _build_advanced_prompts,
         _clone_advanced_fields as _clone_advanced_fields,
@@ -783,7 +774,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         # B-10b17: canonical adapters consume these objects directly.
         # B-10b17: root runtime has no caller for the retired constants.
         _apply_regional_field_inputs as _apply_regional_field_inputs,
-        _bind_regional_runtime as _bind_regional_runtime,
         _build_regional_outputs as _build_regional_outputs,
         _clone_regional_fields as _clone_regional_fields,
         _conditioning_set_values as _conditioning_set_values,
@@ -812,7 +802,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         ANIMA_MOD_GUIDANCE_PROFILE_OFF as ANIMA_MOD_GUIDANCE_PROFILE_OFF,
         # B-10b15: warning dispatch remains canonical-only.
         _apply_spectrum_anima_mod_guidance as _apply_spectrum_anima_mod_guidance,
-        _bind_conditioning_runtime as _bind_conditioning_runtime,
         _find_spectrum_anima_mod_guidance_class as _find_spectrum_anima_mod_guidance_class,
         _normalize_anima_mod_guidance_profile as _normalize_anima_mod_guidance_profile,
         _resolve_anima_mod_guidance_enabled as _resolve_anima_mod_guidance_enabled,
@@ -859,7 +848,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         _artist_prompt_with_position as _artist_prompt_with_position,
         _artist_tags_from_prompt as _artist_tags_from_prompt,
         # B-10b18: prompt-data artist variants remain canonical-only.
-        _bind_artist_mix_runtime as _bind_artist_mix_runtime,
         _blend_conditionings as _blend_conditionings,
         _bounded_artist_mix_float as _bounded_artist_mix_float,
         _bounded_artist_mix_int as _bounded_artist_mix_int,
@@ -1737,18 +1725,12 @@ _bind_aio_conditioning_runtime(
         lambda fallback_name: globals()[fallback_name],
     ),
 )
-_bind_regional_runtime(
-    resolve_helper=lambda name: globals()[name],
-)
 _bind_regional_node_runtime(
     resolve_helper=lambda name: _resolve_comfy_host_helper(
         name,
         lambda fallback_name: globals()[fallback_name],
     ),
     flexible_optional_input_type=_FlexibleOptionalInputType,
-)
-_bind_advanced_runtime(
-    resolve_helper=lambda name: globals()[name],
 )
 _bind_prompt_advanced_node_runtime(
     resolve_helper=lambda name: globals()[name],
@@ -1757,30 +1739,11 @@ _bind_prompt_advanced_node_runtime(
 _bind_aio_node_runtime(
     resolve_helper=lambda name: globals()[name],
 )
-_bind_conditioning_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-    resolve_logger=lambda: logger,
-)
-_bind_artist_mix_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
 _bind_prompt_data_node_runtime(
     resolve_helper=lambda name: _resolve_comfy_host_helper(
         name,
         lambda fallback_name: globals()[fallback_name],
     ),
-)
-_bind_prompt_fields_runtime(
-    resolve_helper=lambda name: globals()[name],
-)
-_bind_prompt_correction_runtime(
-    resolve_helper=lambda name: globals()[name],
 )
 _bind_prompt_node_runtime(
     resolve_helper=lambda name: globals()[name],

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -128,7 +128,7 @@
         },
         {
           "module": "easyuse_anima.prompt.artist_mix",
-          "binder": "_bind_artist_mix_runtime",
+          "binder": null,
           "root_observation": "call_time"
         }
       ],
@@ -283,7 +283,7 @@
       "production_consumers": [
         {
           "module": "easyuse_anima.prompt.conditioning",
-          "binder": "_bind_conditioning_runtime",
+          "binder": null,
           "root_observation": "call_time"
         }
       ],

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -13014,23 +13014,6 @@
       },
       {
         "alias": null,
-        "bound_name": "Callable",
-        "branch_context": [],
-        "classification": "external",
-        "column": 0,
-        "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 7,
-        "name": "Callable",
-        "optional": false,
-        "requested": "collections.abc",
-        "role": "ordinary",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py"
-      },
-      {
-        "alias": null,
         "bound_name": "Any",
         "branch_context": [],
         "classification": "external",
@@ -13038,13 +13021,67 @@
         "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "name": "Any",
         "optional": false,
         "requested": "typing",
         "role": "ordinary",
         "scope": "<module>",
         "source": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/common/values.py"
       },
       {
         "alias": null,
@@ -13084,6 +13121,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_normalize_resolution_bucket",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:_normalize_resolution_bucket",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_normalize_resolution_bucket",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
         "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "branch_context": [],
         "classification": "internal",
@@ -13091,7 +13146,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".artist_mix",
@@ -13109,7 +13164,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".artist_mix",
@@ -13127,7 +13182,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".artist_mix",
@@ -13145,7 +13200,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".artist_mix",
@@ -13163,7 +13218,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".artist_mix",
@@ -13181,7 +13236,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".artist_mix",
@@ -13199,7 +13254,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".artist_mix",
@@ -13217,7 +13272,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".artist_mix",
@@ -13235,7 +13290,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_MODE_OFF",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_MODE_OFF",
         "optional": false,
         "requested": ".artist_mix",
@@ -13253,7 +13308,7 @@
         "conditional": false,
         "imported": ".artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 14,
+        "line": 15,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": ".artist_mix",
@@ -13264,6 +13319,150 @@
       },
       {
         "alias": null,
+        "bound_name": "_artist_mix_inline_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".artist_mix:_artist_mix_inline_prompt",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_artist_mix_inline_prompt",
+        "optional": false,
+        "requested": ".artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_artist_tags_from_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".artist_mix:_artist_tags_from_prompt",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_artist_tags_from_prompt",
+        "optional": false,
+        "requested": ".artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_bounded_artist_mix_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".artist_mix:_bounded_artist_mix_float",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_bounded_artist_mix_float",
+        "optional": false,
+        "requested": ".artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_bounded_artist_mix_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".artist_mix:_bounded_artist_mix_int",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_bounded_artist_mix_int",
+        "optional": false,
+        "requested": ".artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_join_artist_mix_source_prompts",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".artist_mix:_join_artist_mix_source_prompts",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_join_artist_mix_source_prompts",
+        "optional": false,
+        "requested": ".artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_normalize_artist_mix_mode",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".artist_mix:_normalize_artist_mix_mode",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_normalize_artist_mix_mode",
+        "optional": false,
+        "requested": ".artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_parse_artist_mix_items",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".artist_mix:_parse_artist_mix_items",
+        "kind": "static_from",
+        "line": 15,
+        "name": "_parse_artist_mix_items",
+        "optional": false,
+        "requested": ".artist_mix",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_translate_prompt_text",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".correction:_translate_prompt_text",
+        "kind": "static_from",
+        "line": 34,
+        "name": "_translate_prompt_text",
+        "optional": false,
+        "requested": ".correction",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/correction.py"
+      },
+      {
+        "alias": null,
         "bound_name": "PROMPT_DATA_SCHEMA",
         "branch_context": [],
         "classification": "internal",
@@ -13271,7 +13470,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_SCHEMA",
         "kind": "static_from",
-        "line": 26,
+        "line": 35,
         "name": "PROMPT_DATA_SCHEMA",
         "optional": false,
         "requested": ".data",
@@ -13289,7 +13488,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 26,
+        "line": 35,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".data",
@@ -13307,7 +13506,7 @@
         "conditional": false,
         "imported": ".data:PROMPT_DATA_VERSION",
         "kind": "static_from",
-        "line": 26,
+        "line": 35,
         "name": "PROMPT_DATA_VERSION",
         "optional": false,
         "requested": ".data",
@@ -13325,7 +13524,7 @@
         "conditional": false,
         "imported": ".fields:DEFAULT_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 27,
+        "line": 36,
         "name": "DEFAULT_QUALITY_TAGS",
         "optional": false,
         "requested": ".fields",
@@ -13343,7 +13542,7 @@
         "conditional": false,
         "imported": ".fields:DEFAULT_TRAILING_QUALITY_TAGS",
         "kind": "static_from",
-        "line": 27,
+        "line": 36,
         "name": "DEFAULT_TRAILING_QUALITY_TAGS",
         "optional": false,
         "requested": ".fields",
@@ -13351,6 +13550,450 @@
         "scope": "<module>",
         "source": "easyuse_anima/prompt/advanced.py",
         "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_correct_builder_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".fields:_correct_builder_prompt",
+        "kind": "static_from",
+        "line": 36,
+        "name": "_correct_builder_prompt",
+        "optional": false,
+        "requested": ".fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_filter_metadata_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".fields:_filter_metadata_prompt",
+        "kind": "static_from",
+        "line": 36,
+        "name": "_filter_metadata_prompt",
+        "optional": false,
+        "requested": ".fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_join_prompt_tokens",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 36,
+        "name": "_join_prompt_tokens",
+        "optional": false,
+        "requested": ".fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "...prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 45,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": "...prompt_translation",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 46,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 47,
+        "name": "expand_wildcard_texts",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_wildcard_syntax",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_wildcard_syntax",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 47,
+        "name": "has_wildcard_syntax",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_studio_wildcard_mode",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_studio_wildcard_mode",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:normalize_prompt_studio_wildcard_mode",
+        "kind": "static_from",
+        "line": 47,
+        "name": "normalize_prompt_studio_wildcard_mode",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "...wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 47,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "...wildcard_engine",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_prompt_translation_markers",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_prompt_translation_markers",
+          "target": "prompt_translation.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 54,
+        "name": "has_prompt_translation_markers",
+        "optional": false,
+        "requested": "prompt_translation",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 55,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "expand_wildcard_texts",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "expand_wildcard_texts",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 56,
+        "name": "expand_wildcard_texts",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "has_wildcard_syntax",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "has_wildcard_syntax",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 56,
+        "name": "has_wildcard_syntax",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_prompt_studio_wildcard_mode",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_prompt_studio_wildcard_mode",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
+        "kind": "static_from",
+        "line": 56,
+        "name": "normalize_prompt_studio_wildcard_mode",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "normalize_seed",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "normalize_seed",
+          "target": "wildcard_engine.py",
+          "try_line": 44
+        },
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 56,
+        "name": "normalize_seed",
+        "optional": false,
+        "requested": "wildcard_engine",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
       },
       {
         "alias": null,
@@ -13476,6 +14119,24 @@
       },
       {
         "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 9,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/artist_mix.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_normalize_prompt_data",
         "branch_context": [],
         "classification": "internal",
@@ -13483,7 +14144,7 @@
         "conditional": false,
         "imported": ".data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".data",
@@ -13501,7 +14162,7 @@
         "conditional": false,
         "imported": ".data:_prompt_data_nested",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_prompt_data_nested",
         "optional": false,
         "requested": ".data",
@@ -13519,7 +14180,7 @@
         "conditional": false,
         "imported": ".data:_prompt_data_output",
         "kind": "static_from",
-        "line": 9,
+        "line": 10,
         "name": "_prompt_data_output",
         "optional": false,
         "requested": ".data",
@@ -13530,6 +14191,96 @@
       },
       {
         "alias": null,
+        "bound_name": "_correct_builder_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".fields:_correct_builder_prompt",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_correct_builder_prompt",
+        "optional": false,
+        "requested": ".fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/artist_mix.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_join_prompt_tokens",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_join_prompt_tokens",
+        "optional": false,
+        "requested": ".fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/artist_mix.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": "helper",
+        "bound_name": "helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".advanced:_advanced_enabled_pane_fields",
+        "kind": "static_from",
+        "line": 127,
+        "name": "_advanced_enabled_pane_fields",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "_advanced_enabled_pane_fields",
+        "source": "easyuse_anima/prompt/artist_mix.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": "helper",
+        "bound_name": "helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".advanced:_advanced_prompt_with_artist_override",
+        "kind": "static_from",
+        "line": 133,
+        "name": "_advanced_prompt_with_artist_override",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "_advanced_prompt_with_artist_override",
+        "source": "easyuse_anima/prompt/artist_mix.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": "helper",
+        "bound_name": "helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 4,
+        "conditional": false,
+        "imported": ".advanced:_normalize_advanced_fields",
+        "kind": "static_from",
+        "line": 139,
+        "name": "_normalize_advanced_fields",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "_normalize_advanced_fields",
+        "source": "easyuse_anima/prompt/artist_mix.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
         "bound_name": "torch",
         "branch_context": [
           {
@@ -13537,7 +14288,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 405
+            "line": 409
           }
         ],
         "classification": "external",
@@ -13545,7 +14296,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 406,
+        "line": 410,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -13562,7 +14313,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 421
+            "line": 425
           }
         ],
         "classification": "external",
@@ -13570,7 +14321,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 422,
+        "line": 426,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -13587,7 +14338,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 441
+            "line": 445
           }
         ],
         "classification": "external",
@@ -13595,7 +14346,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 442,
+        "line": 446,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -13612,7 +14363,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 516
+            "line": 520
           }
         ],
         "classification": "external",
@@ -13620,7 +14371,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 517,
+        "line": 521,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -13637,7 +14388,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1102
+            "line": 1106
           }
         ],
         "classification": "external",
@@ -13645,7 +14396,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1103,
+        "line": 1107,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -13689,6 +14440,23 @@
       },
       {
         "alias": null,
+        "bound_name": "logging",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
+        "name": null,
+        "optional": false,
+        "requested": "logging",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_node_output_tuple",
         "branch_context": [],
         "classification": "internal",
@@ -13696,7 +14464,7 @@
         "conditional": false,
         "imported": "..infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 6,
+        "line": 7,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "..infrastructure.comfy.invocation",
@@ -13704,6 +14472,24 @@
         "scope": "<module>",
         "source": "easyuse_anima/prompt/conditioning.py",
         "target": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 8,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/conditioning.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "alias": null,
@@ -14303,6 +15089,287 @@
       },
       {
         "alias": null,
+        "bound_name": "_as_bool",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_bool",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_bool",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_float",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_float",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_float",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_int",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_as_int",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_as_int",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_single_value",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..common.values:_single_value",
+        "kind": "static_from",
+        "line": 9,
+        "name": "_single_value",
+        "optional": false,
+        "requested": "..common.values",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/common/values.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_ratio_label",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..naia.resolution:_ratio_label",
+        "kind": "static_from",
+        "line": 10,
+        "name": "_ratio_label",
+        "optional": false,
+        "requested": "..naia.resolution",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_default_fields",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".advanced:_advanced_default_fields",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_advanced_default_fields",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_field_input_values",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".advanced:_advanced_field_input_values",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_advanced_field_input_values",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_advanced_field_socket_name",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".advanced:_advanced_field_socket_name",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_advanced_field_socket_name",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_as_advanced_height",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".advanced:_as_advanced_height",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_as_advanced_height",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_correct_advanced_field_sequence",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".advanced:_correct_advanced_field_sequence",
+        "kind": "static_from",
+        "line": 11,
+        "name": "_correct_advanced_field_sequence",
+        "optional": false,
+        "requested": ".advanced",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_filter_metadata_prompt",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".fields:_filter_metadata_prompt",
+        "kind": "static_from",
+        "line": 18,
+        "name": "_filter_metadata_prompt",
+        "optional": false,
+        "requested": ".fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_join_prompt_tokens",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 18,
+        "name": "_join_prompt_tokens",
+        "optional": false,
+        "requested": ".fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
+            "kind": "try",
+            "line": 20
+          }
+        ],
+        "classification": "internal",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 20
+        },
+        "conditional": true,
+        "imported": "...settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 21,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "...settings",
+        "role": "compatibility_primary",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "resolve_metadata_filter_words",
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 22,
+            "kind": "try",
+            "line": 20
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "column": 4,
+        "compatibility_pair": {
+          "bound_name": "resolve_metadata_filter_words",
+          "target": "settings.py",
+          "try_line": 20
+        },
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 23,
+        "name": "resolve_metadata_filter_words",
+        "optional": false,
+        "requested": "settings",
+        "role": "compatibility_fallback",
+        "scope": "<module>",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "settings.py"
+      },
+      {
+        "alias": null,
         "bound_name": "torch",
         "branch_context": [
           {
@@ -14310,7 +15377,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 509
+            "line": 479
           }
         ],
         "classification": "external",
@@ -14318,7 +15385,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 510,
+        "line": 480,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -14335,7 +15402,7 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 547
+            "line": 517
           }
         ],
         "classification": "external",
@@ -14343,7 +15410,7 @@
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 548,
+        "line": 518,
         "name": null,
         "optional": true,
         "requested": "torch",
@@ -18430,37 +19497,6 @@
         "target": "easyuse_anima/workflow.py"
       },
       {
-        "alias": "_bind_prompt_correction_runtime",
-        "bound_name": "_bind_prompt_correction_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_correction_runtime",
-          "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
-        "kind": "static_from",
-        "line": 154,
-        "name": "_bind_prompt_correction_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.correction",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/correction.py"
-      },
-      {
         "alias": "_prompt_translation_change_key",
         "bound_name": "_prompt_translation_change_key",
         "branch_context": [
@@ -18575,7 +19611,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18606,7 +19642,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18637,39 +19673,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_WEIGHTED_TOKEN_RE",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.fields",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
-      },
-      {
-        "alias": "_bind_prompt_fields_runtime",
-        "bound_name": "_bind_prompt_fields_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_fields_runtime",
-          "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
-        "kind": "static_from",
-        "line": 160,
-        "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
         "role": "compatibility_primary",
@@ -18699,7 +19704,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18730,7 +19735,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18761,7 +19766,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18792,7 +19797,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18823,7 +19828,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18854,7 +19859,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 160,
+        "line": 159,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": ".easyuse_anima.prompt.fields",
@@ -18885,7 +19890,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 174,
+        "line": 172,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18916,7 +19921,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 174,
+        "line": 172,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18947,7 +19952,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 174,
+        "line": 172,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -18978,7 +19983,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 174,
+        "line": 172,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -19009,7 +20014,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 174,
+        "line": 172,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -19040,7 +20045,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 174,
+        "line": 172,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -19071,7 +20076,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 174,
+        "line": 172,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": ".easyuse_anima.prompt.data",
@@ -19102,7 +20107,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19133,7 +20138,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19164,7 +20169,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19195,7 +20200,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19226,7 +20231,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19257,7 +20262,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19288,7 +20293,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19319,7 +20324,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19350,7 +20355,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19381,7 +20386,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19412,7 +20417,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19443,39 +20448,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_as_advanced_height",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.advanced",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/advanced.py"
-      },
-      {
-        "alias": "_bind_advanced_runtime",
-        "bound_name": "_bind_advanced_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_advanced_runtime",
-          "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.advanced:_bind_advanced_runtime",
-        "kind": "static_from",
-        "line": 192,
-        "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
         "role": "compatibility_primary",
@@ -19505,7 +20479,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19536,7 +20510,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19567,7 +20541,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19598,7 +20572,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19629,7 +20603,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19660,7 +20634,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19691,7 +20665,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19722,7 +20696,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19753,7 +20727,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 192,
+        "line": 190,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.advanced",
@@ -19784,39 +20758,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_apply_regional_field_inputs",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.regional",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/regional.py"
-      },
-      {
-        "alias": "_bind_regional_runtime",
-        "bound_name": "_bind_regional_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_regional_runtime",
-          "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.regional:_bind_regional_runtime",
-        "kind": "static_from",
-        "line": 228,
-        "name": "_bind_regional_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
         "role": "compatibility_primary",
@@ -19846,7 +20789,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19877,7 +20820,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19908,7 +20851,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19939,7 +20882,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -19970,7 +20913,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20001,7 +20944,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20032,7 +20975,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_parse_json_object",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20063,7 +21006,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_regional_config_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20094,7 +21037,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20125,7 +21068,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20156,7 +21099,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20187,7 +21130,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 228,
+        "line": 225,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": ".easyuse_anima.prompt.regional",
@@ -20218,7 +21161,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -20249,7 +21192,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -20280,7 +21223,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -20311,7 +21254,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -20342,39 +21285,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "_apply_spectrum_anima_mod_guidance",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.conditioning",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "_bind_conditioning_runtime",
-        "bound_name": "_bind_conditioning_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_conditioning_runtime",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
-        "kind": "static_from",
-        "line": 256,
-        "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
         "role": "compatibility_primary",
@@ -20404,7 +21316,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -20435,7 +21347,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -20466,7 +21378,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 256,
+        "line": 252,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": ".easyuse_anima.prompt.conditioning",
@@ -20497,7 +21409,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20528,7 +21440,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20559,7 +21471,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20590,7 +21502,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20621,7 +21533,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20652,7 +21564,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20683,7 +21595,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20714,7 +21626,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20745,7 +21657,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20776,7 +21688,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20807,7 +21719,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20838,7 +21750,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20869,7 +21781,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20900,39 +21812,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_artist_tags_from_prompt",
-        "optional": false,
-        "requested": ".easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_bind_artist_mix_runtime",
-        "bound_name": "_bind_artist_mix_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_artist_mix_runtime",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
-        "kind": "static_from",
-        "line": 272,
-        "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
         "role": "compatibility_primary",
@@ -20962,7 +21843,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -20993,7 +21874,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21024,7 +21905,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21055,7 +21936,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21086,7 +21967,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21117,7 +21998,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21148,7 +22029,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21179,7 +22060,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21210,7 +22091,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21241,7 +22122,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 272,
+        "line": 267,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": ".easyuse_anima.prompt.artist_mix",
@@ -21272,7 +22153,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 352,
+        "line": 346,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21303,7 +22184,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 352,
+        "line": 346,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21334,7 +22215,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 352,
+        "line": 346,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21365,7 +22246,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 352,
+        "line": 346,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_data_nodes",
@@ -21396,7 +22277,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 358,
+        "line": 352,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -21427,7 +22308,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 358,
+        "line": 352,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -21458,7 +22339,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 358,
+        "line": 352,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -21489,7 +22370,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 363,
+        "line": 357,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21520,7 +22401,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 363,
+        "line": 357,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21551,7 +22432,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 363,
+        "line": 357,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -21582,7 +22463,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 369,
+        "line": 363,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21613,7 +22494,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 369,
+        "line": 363,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21644,7 +22525,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 369,
+        "line": 363,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21675,7 +22556,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 369,
+        "line": 363,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21706,7 +22587,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 369,
+        "line": 363,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21737,7 +22618,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 369,
+        "line": 363,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21768,7 +22649,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 369,
+        "line": 363,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -21799,7 +22680,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 378,
+        "line": 372,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21830,7 +22711,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 378,
+        "line": 372,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21861,7 +22742,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 378,
+        "line": 372,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -21892,7 +22773,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 389,
+        "line": 383,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21923,7 +22804,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 389,
+        "line": 383,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21954,7 +22835,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 389,
+        "line": 383,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -21985,7 +22866,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 401,
+        "line": 395,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22016,7 +22897,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 401,
+        "line": 395,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22047,7 +22928,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 403,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22078,7 +22959,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 403,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22109,7 +22990,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 409,
+        "line": 403,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22140,7 +23021,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 415,
+        "line": 409,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22171,7 +23052,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 415,
+        "line": 409,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22202,7 +23083,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 415,
+        "line": 409,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22233,7 +23114,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 420,
+        "line": 414,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22264,7 +23145,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 423,
+        "line": 417,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22295,7 +23176,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 417,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22326,7 +23207,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 417,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22357,7 +23238,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 417,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22388,7 +23269,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 423,
+        "line": 417,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22419,7 +23300,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 431,
+        "line": 425,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22450,7 +23331,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 431,
+        "line": 425,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -22481,7 +23362,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 435,
+        "line": 429,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22512,7 +23393,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 435,
+        "line": 429,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -22543,7 +23424,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 439,
+        "line": 433,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22574,7 +23455,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 439,
+        "line": 433,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22605,7 +23486,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 439,
+        "line": 433,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22636,7 +23517,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 439,
+        "line": 433,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22667,7 +23548,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 439,
+        "line": 433,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -22698,7 +23579,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 446,
+        "line": 440,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22729,7 +23610,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 446,
+        "line": 440,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22760,7 +23641,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 446,
+        "line": 440,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -22791,7 +23672,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 451,
+        "line": 445,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22822,7 +23703,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 451,
+        "line": 445,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22853,7 +23734,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 451,
+        "line": 445,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -22884,7 +23765,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 469,
+        "line": 463,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22915,7 +23796,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 469,
+        "line": 463,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22946,7 +23827,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 469,
+        "line": 463,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -22977,7 +23858,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 469,
+        "line": 463,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23008,7 +23889,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 469,
+        "line": 463,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23039,7 +23920,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 492,
+        "line": 486,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23070,7 +23951,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 492,
+        "line": 486,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23101,7 +23982,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 496,
+        "line": 490,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23132,7 +24013,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 496,
+        "line": 490,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23163,7 +24044,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23194,7 +24075,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23225,7 +24106,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23256,7 +24137,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23287,7 +24168,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23318,7 +24199,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23349,7 +24230,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23380,7 +24261,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23411,7 +24292,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23442,7 +24323,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23473,7 +24354,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23504,7 +24385,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23535,7 +24416,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23566,7 +24447,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 501,
+        "line": 495,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23597,7 +24478,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 517,
+        "line": 511,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23628,7 +24509,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 517,
+        "line": 511,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23659,7 +24540,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 517,
+        "line": 511,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23690,7 +24571,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 517,
+        "line": 511,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23721,7 +24602,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 517,
+        "line": 511,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23752,7 +24633,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 517,
+        "line": 511,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23783,7 +24664,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 517,
+        "line": 511,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -23814,7 +24695,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 526,
+        "line": 520,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -23845,7 +24726,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 529,
+        "line": 523,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23876,7 +24757,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 529,
+        "line": 523,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -23907,7 +24788,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 530,
+        "line": 524,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -23938,7 +24819,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 531,
+        "line": 525,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -23969,7 +24850,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 531,
+        "line": 525,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24000,7 +24881,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 531,
+        "line": 525,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24031,7 +24912,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 536,
+        "line": 530,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24062,7 +24943,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 536,
+        "line": 530,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24093,7 +24974,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24124,7 +25005,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24155,7 +25036,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24186,7 +25067,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24217,7 +25098,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24248,7 +25129,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24279,7 +25160,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24310,7 +25191,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24341,7 +25222,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24372,7 +25253,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24403,7 +25284,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24434,7 +25315,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24465,7 +25346,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24496,7 +25377,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24527,7 +25408,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24558,7 +25439,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24589,7 +25470,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24620,7 +25501,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24651,7 +25532,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 537,
+        "line": 531,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24670,7 +25551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24685,7 +25566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24704,7 +25585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24719,7 +25600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24738,7 +25619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24753,7 +25634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24772,7 +25653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24787,7 +25668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24806,7 +25687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24821,7 +25702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24840,7 +25721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24855,7 +25736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24874,7 +25755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24889,7 +25770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24908,7 +25789,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24923,7 +25804,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -24942,7 +25823,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24957,7 +25838,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -24976,7 +25857,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -24991,7 +25872,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25010,7 +25891,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25025,7 +25906,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25044,7 +25925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25059,7 +25940,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25078,7 +25959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25093,7 +25974,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25112,7 +25993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25127,7 +26008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25146,7 +26027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25161,7 +26042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25180,7 +26061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25195,7 +26076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25214,7 +26095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25229,7 +26110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25248,7 +26129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25263,7 +26144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25282,7 +26163,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25297,7 +26178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25316,7 +26197,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25331,7 +26212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25350,7 +26231,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25365,7 +26246,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25384,7 +26265,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25399,7 +26280,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25418,7 +26299,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25433,7 +26314,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25452,7 +26333,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25467,7 +26348,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25486,7 +26367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25501,7 +26382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25520,7 +26401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25535,7 +26416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25554,7 +26435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25569,7 +26450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25588,7 +26469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25603,7 +26484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25622,7 +26503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25637,7 +26518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25656,7 +26537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25671,7 +26552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25690,7 +26571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25705,7 +26586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25724,7 +26605,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25739,7 +26620,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25758,7 +26639,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25773,7 +26654,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 598,
+        "line": 592,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -25792,7 +26673,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25807,7 +26688,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 601,
+        "line": 595,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25826,7 +26707,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25841,7 +26722,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 601,
+        "line": 595,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25860,7 +26741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25875,7 +26756,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 595,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -25894,7 +26775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25909,7 +26790,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25928,7 +26809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25943,7 +26824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25962,7 +26843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -25977,7 +26858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -25996,7 +26877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26011,7 +26892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26030,7 +26911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26045,7 +26926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26064,7 +26945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26079,7 +26960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26098,7 +26979,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26113,7 +26994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26132,7 +27013,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26147,7 +27028,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26166,7 +27047,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26181,7 +27062,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26200,7 +27081,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26215,7 +27096,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26234,7 +27115,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26249,7 +27130,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26268,7 +27149,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26283,7 +27164,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26302,7 +27183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26317,7 +27198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26336,7 +27217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26351,7 +27232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26370,7 +27251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26385,7 +27266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26404,7 +27285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26419,7 +27300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26438,7 +27319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26453,7 +27334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26472,7 +27353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26487,7 +27368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26506,7 +27387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26521,7 +27402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26540,7 +27421,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26555,7 +27436,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26574,7 +27455,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26589,7 +27470,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26608,7 +27489,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26623,7 +27504,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26642,7 +27523,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26657,7 +27538,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26676,7 +27557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26691,7 +27572,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26710,7 +27591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26725,7 +27606,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26744,7 +27625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26759,7 +27640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26778,7 +27659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26793,7 +27674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26812,7 +27693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26827,7 +27708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26846,7 +27727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26861,7 +27742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26880,7 +27761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26895,7 +27776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26914,7 +27795,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26929,7 +27810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26948,7 +27829,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26963,7 +27844,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -26982,7 +27863,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -26997,7 +27878,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27016,7 +27897,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27031,7 +27912,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27050,7 +27931,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27065,7 +27946,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27084,7 +27965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27099,7 +27980,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27118,7 +27999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27133,7 +28014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27152,7 +28033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27167,7 +28048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27186,7 +28067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27201,7 +28082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27220,7 +28101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27235,7 +28116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27254,7 +28135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27269,7 +28150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27288,7 +28169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27303,7 +28184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27322,7 +28203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27337,7 +28218,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27356,7 +28237,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27371,7 +28252,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27390,7 +28271,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27405,7 +28286,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27424,7 +28305,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27439,7 +28320,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27458,7 +28339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27473,7 +28354,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27492,7 +28373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27507,7 +28388,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27526,7 +28407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27541,7 +28422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27560,7 +28441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27575,7 +28456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27594,7 +28475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27609,7 +28490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27628,7 +28509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27643,7 +28524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27662,7 +28543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27677,7 +28558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27696,7 +28577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27711,7 +28592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -27730,7 +28611,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27745,7 +28626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27764,7 +28645,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27779,7 +28660,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27798,7 +28679,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27813,7 +28694,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27832,7 +28713,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27847,7 +28728,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27866,7 +28747,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27881,7 +28762,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27900,7 +28781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27915,7 +28796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27934,7 +28815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27949,7 +28830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -27968,7 +28849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -27983,7 +28864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28002,7 +28883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28017,7 +28898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28036,7 +28917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28051,7 +28932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28070,7 +28951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28085,7 +28966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28104,7 +28985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28119,7 +29000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28138,7 +29019,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28153,7 +29034,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28172,7 +29053,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28187,7 +29068,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28206,7 +29087,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28221,7 +29102,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28240,7 +29121,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28255,7 +29136,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28274,7 +29155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28289,7 +29170,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 690,
+        "line": 684,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28308,7 +29189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28323,7 +29204,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 690,
+        "line": 684,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28342,7 +29223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28357,7 +29238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 690,
+        "line": 684,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28376,7 +29257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28391,7 +29272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28410,7 +29291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28425,7 +29306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28444,7 +29325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28459,7 +29340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28478,7 +29359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28493,7 +29374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28512,7 +29393,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28527,7 +29408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -28546,7 +29427,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28561,7 +29442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 702,
+        "line": 696,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -28569,40 +29450,6 @@
         "scope": "<module>",
         "source": "nodes.py",
         "target": "easyuse_anima/workflow.py"
-      },
-      {
-        "alias": "_bind_prompt_correction_runtime",
-        "bound_name": "_bind_prompt_correction_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_correction_runtime",
-          "target": "easyuse_anima/prompt/correction.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
-        "kind": "static_from",
-        "line": 703,
-        "name": "_bind_prompt_correction_runtime",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.correction",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/correction.py"
       },
       {
         "alias": "_prompt_translation_change_key",
@@ -28614,7 +29461,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28629,7 +29476,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28648,7 +29495,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28663,7 +29510,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28682,7 +29529,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28697,7 +29544,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -28716,7 +29563,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28731,7 +29578,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28750,7 +29597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28765,7 +29612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28784,7 +29631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28799,42 +29646,8 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_WEIGHTED_TOKEN_RE",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.fields",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
-      },
-      {
-        "alias": "_bind_prompt_fields_runtime",
-        "bound_name": "_bind_prompt_fields_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_fields_runtime",
-          "target": "easyuse_anima/prompt/fields.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
-        "kind": "static_from",
-        "line": 709,
-        "name": "_bind_prompt_fields_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
         "role": "compatibility_fallback",
@@ -28852,7 +29665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28867,7 +29680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28886,7 +29699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28901,7 +29714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28920,7 +29733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28935,7 +29748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28954,7 +29767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -28969,7 +29782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -28988,7 +29801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29003,7 +29816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29022,7 +29835,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29037,7 +29850,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29056,7 +29869,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29071,7 +29884,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29090,7 +29903,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29105,7 +29918,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29124,7 +29937,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29139,7 +29952,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29158,7 +29971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29173,7 +29986,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29192,7 +30005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29207,7 +30020,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29226,7 +30039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29241,7 +30054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29260,7 +30073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29275,7 +30088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29294,7 +30107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29309,7 +30122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29328,7 +30141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29343,7 +30156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29362,7 +30175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29377,7 +30190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29396,7 +30209,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29411,7 +30224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29430,7 +30243,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29445,7 +30258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29464,7 +30277,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29479,7 +30292,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29498,7 +30311,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29513,7 +30326,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29532,7 +30345,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29547,7 +30360,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29566,7 +30379,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29581,7 +30394,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29600,7 +30413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29615,7 +30428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29634,7 +30447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29649,7 +30462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29668,7 +30481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29683,42 +30496,8 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_as_advanced_height",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.advanced",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/advanced.py"
-      },
-      {
-        "alias": "_bind_advanced_runtime",
-        "bound_name": "_bind_advanced_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_advanced_runtime",
-          "target": "easyuse_anima/prompt/advanced.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
-        "kind": "static_from",
-        "line": 741,
-        "name": "_bind_advanced_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
         "role": "compatibility_fallback",
@@ -29736,7 +30515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29751,7 +30530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29770,7 +30549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29785,7 +30564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29804,7 +30583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29819,7 +30598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29838,7 +30617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29853,7 +30632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29872,7 +30651,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29887,7 +30666,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29906,7 +30685,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29921,7 +30700,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29940,7 +30719,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29955,7 +30734,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29974,7 +30753,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -29989,7 +30768,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30008,7 +30787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30023,7 +30802,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30042,7 +30821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30057,42 +30836,8 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_apply_regional_field_inputs",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.regional",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/regional.py"
-      },
-      {
-        "alias": "_bind_regional_runtime",
-        "bound_name": "_bind_regional_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_regional_runtime",
-          "target": "easyuse_anima/prompt/regional.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
-        "kind": "static_from",
-        "line": 777,
-        "name": "_bind_regional_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
         "role": "compatibility_fallback",
@@ -30110,7 +30855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30125,7 +30870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30144,7 +30889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30159,7 +30904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30178,7 +30923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30193,7 +30938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30212,7 +30957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30227,7 +30972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30246,7 +30991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30261,7 +31006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30280,7 +31025,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30295,7 +31040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30314,7 +31059,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30329,7 +31074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30348,7 +31093,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30363,7 +31108,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30382,7 +31127,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30397,7 +31142,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30416,7 +31161,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30431,7 +31176,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30450,7 +31195,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30465,7 +31210,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30484,7 +31229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30499,7 +31244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30518,7 +31263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30533,7 +31278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30552,7 +31297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30567,7 +31312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30586,7 +31331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30601,7 +31346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30620,7 +31365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30635,7 +31380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30654,7 +31399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30669,42 +31414,8 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "_apply_spectrum_anima_mod_guidance",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.conditioning",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "alias": "_bind_conditioning_runtime",
-        "bound_name": "_bind_conditioning_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_conditioning_runtime",
-          "target": "easyuse_anima/prompt/conditioning.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
-        "kind": "static_from",
-        "line": 805,
-        "name": "_bind_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
         "role": "compatibility_fallback",
@@ -30722,7 +31433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30737,7 +31448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30756,7 +31467,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30771,7 +31482,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30790,7 +31501,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30805,7 +31516,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -30824,7 +31535,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30839,7 +31550,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30858,7 +31569,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30873,7 +31584,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30892,7 +31603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30907,7 +31618,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30926,7 +31637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30941,7 +31652,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30960,7 +31671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -30975,7 +31686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -30994,7 +31705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31009,7 +31720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31028,7 +31739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31043,7 +31754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31062,7 +31773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31077,7 +31788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31096,7 +31807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31111,7 +31822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31130,7 +31841,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31145,7 +31856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31164,7 +31875,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31179,7 +31890,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31198,7 +31909,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31213,7 +31924,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31232,7 +31943,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31247,7 +31958,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31266,7 +31977,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31281,42 +31992,8 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_artist_tags_from_prompt",
-        "optional": false,
-        "requested": "easyuse_anima.prompt.artist_mix",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "alias": "_bind_artist_mix_runtime",
-        "bound_name": "_bind_artist_mix_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_artist_mix_runtime",
-          "target": "easyuse_anima/prompt/artist_mix.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
-        "kind": "static_from",
-        "line": 821,
-        "name": "_bind_artist_mix_runtime",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
         "role": "compatibility_fallback",
@@ -31334,7 +32011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31349,7 +32026,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31368,7 +32045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31383,7 +32060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31402,7 +32079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31417,7 +32094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31436,7 +32113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31451,7 +32128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31470,7 +32147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31485,7 +32162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31504,7 +32181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31519,7 +32196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31538,7 +32215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31553,7 +32230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31572,7 +32249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31587,7 +32264,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31606,7 +32283,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31621,7 +32298,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31640,7 +32317,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31655,7 +32332,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31674,7 +32351,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31689,7 +32366,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31708,7 +32385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31723,7 +32400,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31742,7 +32419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31757,7 +32434,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "name": "EasyUseAnimaPromptDataUnpack",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31776,7 +32453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31791,7 +32468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -31810,7 +32487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31825,7 +32502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 907,
+        "line": 895,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31844,7 +32521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31859,7 +32536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 907,
+        "line": 895,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31878,7 +32555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31893,7 +32570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 907,
+        "line": 895,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -31912,7 +32589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31927,7 +32604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 912,
+        "line": 900,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31946,7 +32623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31961,7 +32638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 912,
+        "line": 900,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -31980,7 +32657,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -31995,7 +32672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 900,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32014,7 +32691,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32029,7 +32706,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32048,7 +32725,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32063,7 +32740,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32082,7 +32759,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32097,7 +32774,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32116,7 +32793,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32131,7 +32808,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32150,7 +32827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32165,7 +32842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32184,7 +32861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32199,7 +32876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32218,7 +32895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32233,7 +32910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32252,7 +32929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32267,7 +32944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 927,
+        "line": 915,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32286,7 +32963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32301,7 +32978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 927,
+        "line": 915,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32320,7 +32997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32335,7 +33012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 927,
+        "line": 915,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32354,7 +33031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32369,7 +33046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 938,
+        "line": 926,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32388,7 +33065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32403,7 +33080,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 938,
+        "line": 926,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32422,7 +33099,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32437,7 +33114,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 938,
+        "line": 926,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32456,7 +33133,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32471,7 +33148,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 950,
+        "line": 938,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32490,7 +33167,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32505,7 +33182,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 950,
+        "line": 938,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32524,7 +33201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32539,7 +33216,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 946,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32558,7 +33235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32573,7 +33250,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 946,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32592,7 +33269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32607,7 +33284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 946,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -32626,7 +33303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32641,7 +33318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 964,
+        "line": 952,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32660,7 +33337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32675,7 +33352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 964,
+        "line": 952,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32694,7 +33371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32709,7 +33386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 964,
+        "line": 952,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -32728,7 +33405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32743,7 +33420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 969,
+        "line": 957,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -32762,7 +33439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32777,7 +33454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32796,7 +33473,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32811,7 +33488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32830,7 +33507,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32845,7 +33522,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32864,7 +33541,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32879,7 +33556,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32898,7 +33575,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32913,7 +33590,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -32932,7 +33609,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32947,7 +33624,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 980,
+        "line": 968,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -32966,7 +33643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -32981,7 +33658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 980,
+        "line": 968,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33000,7 +33677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33015,7 +33692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 984,
+        "line": 972,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33034,7 +33711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33049,7 +33726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 984,
+        "line": 972,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33068,7 +33745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33083,7 +33760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33102,7 +33779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33117,7 +33794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33136,7 +33813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33151,7 +33828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33170,7 +33847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33185,7 +33862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "name": "EasyUseAnimaPromptStudio",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33204,7 +33881,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33219,7 +33896,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33238,7 +33915,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33253,7 +33930,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 995,
+        "line": 983,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33272,7 +33949,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33287,7 +33964,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 995,
+        "line": 983,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33306,7 +33983,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33321,7 +33998,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 983,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33340,7 +34017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33355,7 +34032,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1000,
+        "line": 988,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33374,7 +34051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33389,7 +34066,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1000,
+        "line": 988,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33408,7 +34085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33423,7 +34100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1000,
+        "line": 988,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33442,7 +34119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33457,7 +34134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33476,7 +34153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33491,7 +34168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33510,7 +34187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33525,7 +34202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33544,7 +34221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33559,7 +34236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33578,7 +34255,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33593,7 +34270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33612,7 +34289,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33627,7 +34304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1029,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33646,7 +34323,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33661,7 +34338,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1029,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -33680,7 +34357,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33695,7 +34372,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1033,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33714,7 +34391,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33729,7 +34406,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1033,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -33748,7 +34425,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33763,7 +34440,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33782,7 +34459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33797,7 +34474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33816,7 +34493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33831,7 +34508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33850,7 +34527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33865,7 +34542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33884,7 +34561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33899,7 +34576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33918,7 +34595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33933,7 +34610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33952,7 +34629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -33967,7 +34644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -33986,7 +34663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34001,7 +34678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34020,7 +34697,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34035,7 +34712,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34054,7 +34731,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34069,7 +34746,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34088,7 +34765,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34103,7 +34780,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34122,7 +34799,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34137,7 +34814,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34156,7 +34833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34171,7 +34848,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34190,7 +34867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34205,7 +34882,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34224,7 +34901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34239,7 +34916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34258,7 +34935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34273,7 +34950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34292,7 +34969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34307,7 +34984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34326,7 +35003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34341,7 +35018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34360,7 +35037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34375,7 +35052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34394,7 +35071,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34409,7 +35086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34428,7 +35105,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34443,7 +35120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34462,7 +35139,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34477,7 +35154,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1063,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34496,7 +35173,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34511,7 +35188,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1078,
+        "line": 1066,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -34530,7 +35207,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34545,7 +35222,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1078,
+        "line": 1066,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -34564,7 +35241,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34579,7 +35256,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1067,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -34598,7 +35275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34613,7 +35290,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1068,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -34632,7 +35309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34647,7 +35324,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1068,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -34666,7 +35343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34681,7 +35358,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1068,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -34700,7 +35377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34715,7 +35392,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1073,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34734,7 +35411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34749,7 +35426,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1073,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -34768,7 +35445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34783,7 +35460,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34802,7 +35479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34817,7 +35494,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34836,7 +35513,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34851,7 +35528,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34870,7 +35547,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34885,7 +35562,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34904,7 +35581,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34919,7 +35596,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34938,7 +35615,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34953,7 +35630,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -34972,7 +35649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -34987,7 +35664,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35006,7 +35683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35021,7 +35698,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35040,7 +35717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35055,7 +35732,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35074,7 +35751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35089,7 +35766,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35108,7 +35785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35123,7 +35800,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35142,7 +35819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35157,7 +35834,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35176,7 +35853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35191,7 +35868,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35210,7 +35887,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35225,7 +35902,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35244,7 +35921,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35259,7 +35936,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35278,7 +35955,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35293,7 +35970,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35312,7 +35989,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35327,7 +36004,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35346,7 +36023,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35361,7 +36038,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35380,7 +36057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -35395,7 +36072,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37323,11 +38000,19 @@
       },
       {
         "from": "easyuse_anima/prompt/advanced.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/advanced.py",
         "to": "easyuse_anima/naia/resolution.py"
       },
       {
         "from": "easyuse_anima/prompt/advanced.py",
         "to": "easyuse_anima/prompt/artist_mix.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/advanced.py",
+        "to": "easyuse_anima/prompt/correction.py"
       },
       {
         "from": "easyuse_anima/prompt/advanced.py",
@@ -37338,16 +38023,44 @@
         "to": "easyuse_anima/prompt/fields.py"
       },
       {
+        "from": "easyuse_anima/prompt/advanced.py",
+        "to": "prompt_translation.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/advanced.py",
+        "to": "settings.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/advanced.py",
+        "to": "wildcard_engine.py"
+      },
+      {
         "from": "easyuse_anima/prompt/artist_mix.py",
         "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/artist_mix.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/artist_mix.py",
+        "to": "easyuse_anima/prompt/advanced.py"
       },
       {
         "from": "easyuse_anima/prompt/artist_mix.py",
         "to": "easyuse_anima/prompt/data.py"
       },
       {
+        "from": "easyuse_anima/prompt/artist_mix.py",
+        "to": "easyuse_anima/prompt/fields.py"
+      },
+      {
         "from": "easyuse_anima/prompt/conditioning.py",
         "to": "easyuse_anima/infrastructure/comfy/invocation.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/conditioning.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "easyuse_anima/prompt/correction.py",
@@ -37368,6 +38081,26 @@
       {
         "from": "easyuse_anima/prompt/fields.py",
         "to": "anima_prompt/parser.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/regional.py",
+        "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/regional.py",
+        "to": "easyuse_anima/naia/resolution.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/regional.py",
+        "to": "easyuse_anima/prompt/advanced.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/regional.py",
+        "to": "easyuse_anima/prompt/fields.py"
+      },
+      {
+        "from": "easyuse_anima/prompt/regional.py",
+        "to": "settings.py"
       },
       {
         "from": "easyuse_anima/registration.py",
@@ -38070,14 +38803,9 @@
         ]
       },
       {
-        "cyclic": false,
+        "cyclic": true,
         "modules": [
-          "easyuse_anima/prompt/advanced.py"
-        ]
-      },
-      {
-        "cyclic": false,
-        "modules": [
+          "easyuse_anima/prompt/advanced.py",
           "easyuse_anima/prompt/artist_mix.py"
         ]
       },
@@ -39018,49 +39746,49 @@
       },
       {
         "is_package": false,
-        "loc": 893,
+        "loc": 858,
         "module": "easyuse_anima.prompt.advanced",
-        "normalized_git_blob_sha1": "7d6c44979b7164a246a2b4f2ca76cfda86ea92c2",
+        "normalized_git_blob_sha1": "910d0e57e2fbdc3bd79bfaa67c857fae15d8e10d",
         "path": "easyuse_anima/prompt/advanced.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 26,
-          "global_count": 41
+          "function_count": 24,
+          "global_count": 17
         }
       },
       {
         "is_package": false,
-        "loc": 1476,
+        "loc": 1480,
         "module": "easyuse_anima.prompt.artist_mix",
-        "normalized_git_blob_sha1": "62c243471ae55ecede060c1a0d5b5efa10c514b8",
+        "normalized_git_blob_sha1": "506f17d262f5caaf7977affe6ea444516d7a30da",
         "path": "easyuse_anima/prompt/artist_mix.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 49,
-          "global_count": 38
+          "function_count": 51,
+          "global_count": 36
         }
       },
       {
         "is_package": false,
-        "loc": 138,
+        "loc": 140,
         "module": "easyuse_anima.prompt.conditioning",
-        "normalized_git_blob_sha1": "504e43632c1a232fe323f67ddf6b8c3b59139696",
+        "normalized_git_blob_sha1": "4c03c08c93e4c3eaa2dc67e01613995f1e71d0fb",
         "path": "easyuse_anima/prompt/conditioning.py",
         "top_level": {
           "class_count": 0,
           "function_count": 8,
-          "global_count": 11
+          "global_count": 9
         }
       },
       {
         "is_package": false,
-        "loc": 55,
+        "loc": 38,
         "module": "easyuse_anima.prompt.correction",
-        "normalized_git_blob_sha1": "aefbd67e85ae99ad41992aa2b94ee90493c58d68",
+        "normalized_git_blob_sha1": "9547635b9ec0f45c809a325fff88812564b62776",
         "path": "easyuse_anima/prompt/correction.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 4,
+          "function_count": 3,
           "global_count": 1
         }
       },
@@ -39078,26 +39806,26 @@
       },
       {
         "is_package": false,
-        "loc": 114,
+        "loc": 90,
         "module": "easyuse_anima.prompt.fields",
-        "normalized_git_blob_sha1": "1ae653d37fbbc341c9e778c26a79ad183c3c226a",
+        "normalized_git_blob_sha1": "cec3b549074a021d3bb06bbe521a2149260ae247",
         "path": "easyuse_anima/prompt/fields.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 8,
-          "global_count": 7
+          "function_count": 6,
+          "global_count": 6
         }
       },
       {
         "is_package": false,
-        "loc": 586,
+        "loc": 556,
         "module": "easyuse_anima.prompt.regional",
-        "normalized_git_blob_sha1": "9c170e8906905c204b876861faa26f8661a53363",
+        "normalized_git_blob_sha1": "c59d7773bd5010bcfe7060498c5cc9885b688a40",
         "path": "easyuse_anima/prompt/regional.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 20,
-          "global_count": 23
+          "function_count": 18,
+          "global_count": 10
         }
       },
       {
@@ -39138,9 +39866,9 @@
       },
       {
         "is_package": false,
-        "loc": 1800,
+        "loc": 1763,
         "module": "nodes",
-        "normalized_git_blob_sha1": "256f87b4e83842437b5993661f42a9259a463e17",
+        "normalized_git_blob_sha1": "1815fadba3e329f88f95cc8aa29002e86b0b7a24",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -40366,6 +41094,144 @@
             "exceptions": [
               "ImportError"
             ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "prompt_translation:has_prompt_translation_markers",
+        "kind": "static_from",
+        "line": 54,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "prompt_translation.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 55,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:expand_wildcard_texts",
+        "kind": "static_from",
+        "line": 56,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:has_wildcard_syntax",
+        "kind": "static_from",
+        "line": 56,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
+        "kind": "static_from",
+        "line": 56,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 53,
+            "kind": "try",
+            "line": 44
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "wildcard_engine:normalize_seed",
+        "kind": "static_from",
+        "line": 56,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/advanced.py",
+        "target": "wildcard_engine.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
             "handler_line": 8,
             "kind": "try",
             "line": 5
@@ -40504,7 +41370,30 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 22,
+            "kind": "try",
+            "line": 20
+          }
+        ],
+        "classification": "compatibility_fallback",
+        "conditional": true,
+        "imported": "settings:resolve_metadata_filter_words",
+        "kind": "static_from",
+        "line": 23,
+        "optional": false,
+        "role": "compatibility_fallback",
+        "source": "easyuse_anima/prompt/regional.py",
+        "target": "settings.py"
+      },
+      {
+        "branch_context": [
+          {
+            "branch": "except",
+            "catches_import_error": true,
+            "exceptions": [
+              "ImportError"
+            ],
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40513,7 +41402,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40527,7 +41416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40536,7 +41425,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40550,7 +41439,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40559,7 +41448,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40573,7 +41462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40582,7 +41471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40596,7 +41485,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40605,7 +41494,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40619,7 +41508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40628,7 +41517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40642,7 +41531,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40651,7 +41540,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40665,7 +41554,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40674,7 +41563,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 559,
+        "line": 553,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40688,7 +41577,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40697,7 +41586,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40711,7 +41600,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40720,7 +41609,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40734,7 +41623,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40743,7 +41632,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40757,7 +41646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40766,7 +41655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40780,7 +41669,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40789,7 +41678,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40803,7 +41692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40812,7 +41701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40826,7 +41715,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40835,7 +41724,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40849,7 +41738,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40858,7 +41747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 570,
+        "line": 564,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40872,7 +41761,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40881,7 +41770,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40895,7 +41784,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40904,7 +41793,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40918,7 +41807,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40927,7 +41816,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40941,7 +41830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40950,7 +41839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40964,7 +41853,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40973,7 +41862,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -40987,7 +41876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -40996,7 +41885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41010,7 +41899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41019,7 +41908,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41033,7 +41922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41042,7 +41931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41056,7 +41945,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41065,7 +41954,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41079,7 +41968,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41088,7 +41977,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41102,7 +41991,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41111,7 +42000,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41125,7 +42014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41134,7 +42023,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41148,7 +42037,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41157,7 +42046,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41171,7 +42060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41180,7 +42069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41194,7 +42083,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41203,7 +42092,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41217,7 +42106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41226,7 +42115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 580,
+        "line": 574,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41240,7 +42129,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41249,7 +42138,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 598,
+        "line": 592,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41263,7 +42152,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41272,7 +42161,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 601,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41286,7 +42175,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41295,7 +42184,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 601,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41309,7 +42198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41318,7 +42207,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 601,
+        "line": 595,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41332,7 +42221,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41341,7 +42230,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41355,7 +42244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41364,7 +42253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41378,7 +42267,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41387,7 +42276,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41401,7 +42290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41410,7 +42299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41424,7 +42313,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41433,7 +42322,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 606,
+        "line": 600,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41447,7 +42336,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41456,7 +42345,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41470,7 +42359,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41479,7 +42368,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41493,7 +42382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41502,7 +42391,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41516,7 +42405,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41525,7 +42414,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 607,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41539,7 +42428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41548,7 +42437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41562,7 +42451,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41571,7 +42460,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41585,7 +42474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41594,7 +42483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41608,7 +42497,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41617,7 +42506,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41631,7 +42520,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41640,7 +42529,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41654,7 +42543,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41663,7 +42552,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41677,7 +42566,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41686,7 +42575,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41700,7 +42589,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41709,7 +42598,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41723,7 +42612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41732,7 +42621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41746,7 +42635,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41755,7 +42644,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41769,7 +42658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41778,7 +42667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41792,7 +42681,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41801,7 +42690,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41815,7 +42704,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41824,7 +42713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 619,
+        "line": 613,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41838,7 +42727,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41847,7 +42736,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41861,7 +42750,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41870,7 +42759,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41884,7 +42773,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41893,7 +42782,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41907,7 +42796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41916,7 +42805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41930,7 +42819,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41939,7 +42828,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41953,7 +42842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41962,7 +42851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41976,7 +42865,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -41985,7 +42874,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41999,7 +42888,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42008,7 +42897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42022,7 +42911,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42031,7 +42920,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42045,7 +42934,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42054,7 +42943,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42068,7 +42957,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42077,7 +42966,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42091,7 +42980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42100,7 +42989,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 634,
+        "line": 628,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42114,7 +43003,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42123,7 +43012,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42137,7 +43026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42146,7 +43035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42160,7 +43049,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42169,7 +43058,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42183,7 +43072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42192,7 +43081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42206,7 +43095,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42215,7 +43104,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42229,7 +43118,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42238,7 +43127,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42252,7 +43141,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42261,7 +43150,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42275,7 +43164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42284,7 +43173,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42298,7 +43187,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42307,7 +43196,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42321,7 +43210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42330,7 +43219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 648,
+        "line": 642,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42344,7 +43233,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42353,7 +43242,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42367,7 +43256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42376,7 +43265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42390,7 +43279,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42399,7 +43288,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42413,7 +43302,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42422,7 +43311,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42436,7 +43325,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42445,7 +43334,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42459,7 +43348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42468,7 +43357,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42482,7 +43371,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42491,7 +43380,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42505,7 +43394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42514,7 +43403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42528,7 +43417,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42537,7 +43426,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42551,7 +43440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42560,7 +43449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 660,
+        "line": 654,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42574,7 +43463,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42583,7 +43472,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42597,7 +43486,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42606,7 +43495,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42620,7 +43509,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42629,7 +43518,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42643,7 +43532,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42652,7 +43541,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42666,7 +43555,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42675,7 +43564,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42689,7 +43578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42698,7 +43587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42712,7 +43601,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42721,7 +43610,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42735,7 +43624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42744,7 +43633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42758,7 +43647,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42767,7 +43656,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42781,7 +43670,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42790,7 +43679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42804,7 +43693,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42813,7 +43702,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42827,7 +43716,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42836,7 +43725,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42850,7 +43739,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42859,7 +43748,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42873,7 +43762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42882,7 +43771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42896,7 +43785,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42905,7 +43794,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42919,7 +43808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42928,7 +43817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 672,
+        "line": 666,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42942,7 +43831,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42951,7 +43840,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 690,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42965,7 +43854,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42974,7 +43863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 690,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42988,7 +43877,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -42997,7 +43886,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 690,
+        "line": 684,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43011,7 +43900,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43020,7 +43909,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43034,7 +43923,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43043,7 +43932,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43057,7 +43946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43066,7 +43955,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43080,7 +43969,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43089,7 +43978,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43103,7 +43992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43112,7 +44001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 695,
+        "line": 689,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43126,7 +44015,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43135,7 +44024,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 702,
+        "line": 696,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43149,30 +44038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.correction:_bind_prompt_correction_runtime",
-        "kind": "static_from",
-        "line": 703,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/correction.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43181,7 +44047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43195,7 +44061,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43204,7 +44070,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43218,7 +44084,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43227,7 +44093,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 703,
+        "line": 697,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43241,7 +44107,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43250,7 +44116,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43264,7 +44130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43273,7 +44139,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43287,7 +44153,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43296,7 +44162,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43310,30 +44176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.fields:_bind_prompt_fields_runtime",
-        "kind": "static_from",
-        "line": 709,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/fields.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43342,7 +44185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43356,7 +44199,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43365,7 +44208,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43379,7 +44222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43388,7 +44231,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43402,7 +44245,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43411,7 +44254,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43425,7 +44268,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43434,7 +44277,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43448,7 +44291,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43457,7 +44300,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 709,
+        "line": 702,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43471,7 +44314,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43480,7 +44323,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43494,7 +44337,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43503,7 +44346,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43517,7 +44360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43526,7 +44369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43540,7 +44383,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43549,7 +44392,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43563,7 +44406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43572,7 +44415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43586,7 +44429,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43595,7 +44438,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43609,7 +44452,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43618,7 +44461,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 723,
+        "line": 715,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43632,7 +44475,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43641,7 +44484,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43655,7 +44498,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43664,7 +44507,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43678,7 +44521,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43687,7 +44530,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43701,7 +44544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43710,7 +44553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43724,7 +44567,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43733,7 +44576,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43747,7 +44590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43756,7 +44599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43770,7 +44613,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43779,7 +44622,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43793,7 +44636,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43802,7 +44645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43816,7 +44659,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43825,7 +44668,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43839,7 +44682,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43848,7 +44691,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43862,7 +44705,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43871,7 +44714,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43885,7 +44728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43894,7 +44737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43908,30 +44751,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.advanced:_bind_advanced_runtime",
-        "kind": "static_from",
-        "line": 741,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/advanced.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43940,7 +44760,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43954,7 +44774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43963,7 +44783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43977,7 +44797,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -43986,7 +44806,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44000,7 +44820,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44009,7 +44829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44023,7 +44843,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44032,7 +44852,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44046,7 +44866,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44055,7 +44875,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44069,7 +44889,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44078,7 +44898,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44092,7 +44912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44101,7 +44921,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44115,7 +44935,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44124,7 +44944,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 741,
+        "line": 733,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44138,7 +44958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44147,7 +44967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44161,30 +44981,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.regional:_bind_regional_runtime",
-        "kind": "static_from",
-        "line": 777,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/regional.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44193,7 +44990,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44207,7 +45004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44216,7 +45013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44230,7 +45027,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44239,7 +45036,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44253,7 +45050,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44262,7 +45059,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44276,7 +45073,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44285,7 +45082,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44299,7 +45096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44308,7 +45105,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44322,7 +45119,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44331,7 +45128,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44345,7 +45142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44354,7 +45151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44368,7 +45165,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44377,7 +45174,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44391,7 +45188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44400,7 +45197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44414,7 +45211,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44423,7 +45220,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44437,7 +45234,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44446,7 +45243,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 777,
+        "line": 768,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44460,7 +45257,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44469,7 +45266,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44483,7 +45280,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44492,7 +45289,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44506,7 +45303,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44515,7 +45312,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44529,7 +45326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44538,7 +45335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44552,7 +45349,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44561,7 +45358,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44575,30 +45372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.conditioning:_bind_conditioning_runtime",
-        "kind": "static_from",
-        "line": 805,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/conditioning.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44607,7 +45381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44621,7 +45395,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44630,7 +45404,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44644,7 +45418,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44653,7 +45427,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 805,
+        "line": 795,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44667,7 +45441,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44676,7 +45450,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44690,7 +45464,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44699,7 +45473,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44713,7 +45487,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44722,7 +45496,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44736,7 +45510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44745,7 +45519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44759,7 +45533,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44768,7 +45542,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44782,7 +45556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44791,7 +45565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44805,7 +45579,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44814,7 +45588,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44828,7 +45602,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44837,7 +45611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44851,7 +45625,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44860,7 +45634,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44874,7 +45648,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44883,7 +45657,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44897,7 +45671,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44906,7 +45680,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44920,7 +45694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44929,7 +45703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44943,7 +45717,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44952,7 +45726,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44966,7 +45740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -44975,7 +45749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44989,30 +45763,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.prompt.artist_mix:_bind_artist_mix_runtime",
-        "kind": "static_from",
-        "line": 821,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/prompt/artist_mix.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45021,7 +45772,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45035,7 +45786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45044,7 +45795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45058,7 +45809,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45067,7 +45818,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45081,7 +45832,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45090,7 +45841,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45104,7 +45855,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45113,7 +45864,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45127,7 +45878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45136,7 +45887,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45150,7 +45901,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45159,7 +45910,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45173,7 +45924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45182,7 +45933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45196,7 +45947,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45205,7 +45956,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45219,7 +45970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45228,7 +45979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 821,
+        "line": 810,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45242,7 +45993,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45251,7 +46002,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45265,7 +46016,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45274,7 +46025,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45288,7 +46039,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45297,7 +46048,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45311,7 +46062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45320,7 +46071,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
         "kind": "static_from",
-        "line": 901,
+        "line": 889,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45334,7 +46085,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45343,7 +46094,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 907,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45357,7 +46108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45366,7 +46117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 907,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45380,7 +46131,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45389,7 +46140,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 907,
+        "line": 895,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45403,7 +46154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45412,7 +46163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 912,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45426,7 +46177,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45435,7 +46186,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 912,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45449,7 +46200,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45458,7 +46209,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 912,
+        "line": 900,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45472,7 +46223,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45481,7 +46232,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45495,7 +46246,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45504,7 +46255,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45518,7 +46269,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45527,7 +46278,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45541,7 +46292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45550,7 +46301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45564,7 +46315,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45573,7 +46324,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45587,7 +46338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45596,7 +46347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45610,7 +46361,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45619,7 +46370,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 918,
+        "line": 906,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45633,7 +46384,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45642,7 +46393,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 927,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45656,7 +46407,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45665,7 +46416,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 927,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45679,7 +46430,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45688,7 +46439,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 927,
+        "line": 915,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45702,7 +46453,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45711,7 +46462,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 938,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45725,7 +46476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45734,7 +46485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 938,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45748,7 +46499,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45757,7 +46508,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 938,
+        "line": 926,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45771,7 +46522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45780,7 +46531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 950,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45794,7 +46545,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45803,7 +46554,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 950,
+        "line": 938,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45817,7 +46568,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45826,7 +46577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45840,7 +46591,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45849,7 +46600,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45863,7 +46614,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45872,7 +46623,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 958,
+        "line": 946,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45886,7 +46637,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45895,7 +46646,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 964,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45909,7 +46660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45918,7 +46669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 964,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45932,7 +46683,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45941,7 +46692,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 964,
+        "line": 952,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45955,7 +46706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45964,7 +46715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 969,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45978,7 +46729,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -45987,7 +46738,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46001,7 +46752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46010,7 +46761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46024,7 +46775,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46033,7 +46784,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46047,7 +46798,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46056,7 +46807,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46070,7 +46821,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46079,7 +46830,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 972,
+        "line": 960,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46093,7 +46844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46102,7 +46853,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 980,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46116,7 +46867,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46125,7 +46876,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 980,
+        "line": 968,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46139,7 +46890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46148,7 +46899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 984,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46162,7 +46913,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46171,7 +46922,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 984,
+        "line": 972,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46185,7 +46936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46194,7 +46945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46208,7 +46959,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46217,7 +46968,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46231,7 +46982,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46240,7 +46991,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46254,7 +47005,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46263,7 +47014,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46277,7 +47028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46286,7 +47037,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
         "kind": "static_from",
-        "line": 988,
+        "line": 976,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46300,7 +47051,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46309,7 +47060,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 995,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46323,7 +47074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46332,7 +47083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 995,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46346,7 +47097,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46355,7 +47106,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 995,
+        "line": 983,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46369,7 +47120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46378,7 +47129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 1000,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46392,7 +47143,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46401,7 +47152,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 1000,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46415,7 +47166,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46424,7 +47175,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 1000,
+        "line": 988,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46438,7 +47189,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46447,7 +47198,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46461,7 +47212,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46470,7 +47221,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46484,7 +47235,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46493,7 +47244,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46507,7 +47258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46516,7 +47267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46530,7 +47281,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46539,7 +47290,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1018,
+        "line": 1006,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46553,7 +47304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46562,7 +47313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46576,7 +47327,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46585,7 +47336,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1041,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46599,7 +47350,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46608,7 +47359,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46622,7 +47373,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46631,7 +47382,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1045,
+        "line": 1033,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46645,7 +47396,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46654,7 +47405,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46668,7 +47419,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46677,7 +47428,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46691,7 +47442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46700,7 +47451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46714,7 +47465,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46723,7 +47474,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46737,7 +47488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46746,7 +47497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46760,7 +47511,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46769,7 +47520,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46783,7 +47534,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46792,7 +47543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46806,7 +47557,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46815,7 +47566,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46829,7 +47580,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46838,7 +47589,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46852,7 +47603,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46861,7 +47612,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46875,7 +47626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46884,7 +47635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46898,7 +47649,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46907,7 +47658,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46921,7 +47672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46930,7 +47681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46944,7 +47695,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46953,7 +47704,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1050,
+        "line": 1038,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46967,7 +47718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46976,7 +47727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46990,7 +47741,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -46999,7 +47750,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47013,7 +47764,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47022,7 +47773,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47036,7 +47787,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47045,7 +47796,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47059,7 +47810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47068,7 +47819,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47082,7 +47833,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47091,7 +47842,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47105,7 +47856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47114,7 +47865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1054,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47128,7 +47879,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47137,7 +47888,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1075,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47151,7 +47902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47160,7 +47911,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1078,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47174,7 +47925,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47183,7 +47934,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1078,
+        "line": 1066,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47197,7 +47948,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47206,7 +47957,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1079,
+        "line": 1067,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47220,7 +47971,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47229,7 +47980,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47243,7 +47994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47252,7 +48003,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47266,7 +48017,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47275,7 +48026,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1080,
+        "line": 1068,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47289,7 +48040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47298,7 +48049,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47312,7 +48063,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47321,7 +48072,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1085,
+        "line": 1073,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47335,7 +48086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47344,7 +48095,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47358,7 +48109,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47367,7 +48118,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47381,7 +48132,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47390,7 +48141,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47404,7 +48155,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47413,7 +48164,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47427,7 +48178,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47436,7 +48187,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47450,7 +48201,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47459,7 +48210,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47473,7 +48224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47482,7 +48233,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47496,7 +48247,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47505,7 +48256,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47519,7 +48270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47528,7 +48279,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47542,7 +48293,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47551,7 +48302,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47565,7 +48316,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47574,7 +48325,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47588,7 +48339,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47597,7 +48348,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47611,7 +48362,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47620,7 +48371,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47634,7 +48385,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47643,7 +48394,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47657,7 +48408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47666,7 +48417,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47680,7 +48431,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47689,7 +48440,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47703,7 +48454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47712,7 +48463,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47726,7 +48477,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47735,7 +48486,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47749,7 +48500,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 558,
+            "handler_line": 552,
             "kind": "try",
             "line": 9
           }
@@ -47758,7 +48509,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1086,
+        "line": 1074,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -51248,20 +51999,9 @@
         "branch_context": [],
         "classification": "external",
         "conditional": false,
-        "imported": "collections.abc:Callable",
-        "kind": "static_from",
-        "line": 7,
-        "optional": false,
-        "role": "ordinary",
-        "source": "easyuse_anima/prompt/advanced.py"
-      },
-      {
-        "branch_context": [],
-        "classification": "external",
-        "conditional": false,
         "imported": "typing:Any",
         "kind": "static_from",
-        "line": 8,
+        "line": 7,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/prompt/advanced.py"
@@ -51317,14 +52057,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 405
+            "line": 409
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 406,
+        "line": 410,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -51336,14 +52076,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 421
+            "line": 425
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 422,
+        "line": 426,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -51355,14 +52095,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 441
+            "line": 445
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 442,
+        "line": 446,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -51374,14 +52114,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 516
+            "line": 520
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 517,
+        "line": 521,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -51393,14 +52133,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1102
+            "line": 1106
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1103,
+        "line": 1107,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -51423,6 +52163,17 @@
         "imported": "inspect",
         "kind": "static_import",
         "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/prompt/conditioning.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "logging",
+        "kind": "static_import",
+        "line": 5,
         "optional": false,
         "role": "ordinary",
         "source": "easyuse_anima/prompt/conditioning.py"
@@ -51544,14 +52295,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 509
+            "line": 479
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 510,
+        "line": 480,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -51563,14 +52314,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 547
+            "line": 517
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 548,
+        "line": 518,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -52930,14 +53681,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 405
+            "line": 409
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 406,
+        "line": 410,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -52949,14 +53700,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 421
+            "line": 425
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 422,
+        "line": 426,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -52968,14 +53719,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 441
+            "line": 445
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 442,
+        "line": 446,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -52987,14 +53738,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 516
+            "line": 520
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 517,
+        "line": 521,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -53006,14 +53757,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 1102
+            "line": 1106
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 1103,
+        "line": 1107,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/artist_mix.py"
@@ -53025,14 +53776,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 509
+            "line": 479
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 510,
+        "line": 480,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -53044,14 +53795,14 @@
             "handles_import_failure": true,
             "has_import_fallback_handler": false,
             "kind": "try",
-            "line": 547
+            "line": 517
           }
         ],
         "classification": "external",
         "conditional": true,
         "imported": "torch",
         "kind": "static_import",
-        "line": 548,
+        "line": 518,
         "optional": true,
         "role": "optional_dependency",
         "source": "easyuse_anima/prompt/regional.py"
@@ -54248,196 +54999,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 110,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 11,
-        "context": "assign:_as_bool",
-        "kind": "import_time_call",
-        "line": 170,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 10,
-        "context": "assign:_as_int",
-        "kind": "import_time_call",
-        "line": 171,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 16,
-        "context": "assign:_single_value",
-        "kind": "import_time_call",
-        "line": 172,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 31,
-        "context": "assign:_normalize_resolution_bucket",
-        "kind": "import_time_call",
-        "line": 173,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 28,
-        "context": "assign:_artist_mix_inline_prompt",
-        "kind": "import_time_call",
-        "line": 174,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 26,
-        "context": "assign:_correct_builder_prompt",
-        "kind": "import_time_call",
-        "line": 175,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 22,
-        "context": "assign:_join_prompt_tokens",
-        "kind": "import_time_call",
-        "line": 176,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 32,
-        "context": "assign:resolve_metadata_filter_words",
-        "kind": "import_time_call",
-        "line": 177,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 26,
-        "context": "assign:_filter_metadata_prompt",
-        "kind": "import_time_call",
-        "line": 178,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 40,
-        "context": "assign:normalize_prompt_studio_wildcard_mode",
-        "kind": "import_time_call",
-        "line": 179,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 22,
-        "context": "assign:has_wildcard_syntax",
-        "kind": "import_time_call",
-        "line": 182,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 24,
-        "context": "assign:expand_wildcard_texts",
-        "kind": "import_time_call",
-        "line": 183,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 33,
-        "context": "assign:has_prompt_translation_markers",
-        "kind": "import_time_call",
-        "line": 184,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 25,
-        "context": "assign:_translate_prompt_text",
-        "kind": "import_time_call",
-        "line": 185,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 34,
-        "context": "assign:_join_artist_mix_source_prompts",
-        "kind": "import_time_call",
-        "line": 186,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 29,
-        "context": "assign:_normalize_artist_mix_mode",
-        "kind": "import_time_call",
-        "line": 187,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 27,
-        "context": "assign:_artist_tags_from_prompt",
-        "kind": "import_time_call",
-        "line": 188,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 26,
-        "context": "assign:_parse_artist_mix_items",
-        "kind": "import_time_call",
-        "line": 189,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 28,
-        "context": "assign:_bounded_artist_mix_float",
-        "kind": "import_time_call",
-        "line": 190,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 26,
-        "context": "assign:_bounded_artist_mix_int",
-        "kind": "import_time_call",
-        "line": 191,
-        "module": "easyuse_anima/prompt/advanced.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_runtime_proxy",
-        "column": 17,
-        "context": "assign:normalize_seed",
-        "kind": "import_time_call",
-        "line": 192,
+        "line": 144,
         "module": "easyuse_anima/prompt/advanced.py",
         "scope": "<module>"
       },
@@ -54446,7 +55008,7 @@
         "column": 62,
         "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "import_time_call",
-        "line": 63,
+        "line": 65,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -54455,7 +55017,7 @@
         "column": 22,
         "context": "assign:_WEIGHTED_ARTIST_RE",
         "kind": "import_time_call",
-        "line": 102,
+        "line": 104,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -54464,7 +55026,7 @@
         "column": 19,
         "context": "assign:_ARTIST_GROUP_RE",
         "kind": "import_time_call",
-        "line": 105,
+        "line": 107,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -54473,7 +55035,7 @@
         "column": 24,
         "context": "assign:_SECTION_SEPARATOR_RE",
         "kind": "import_time_call",
-        "line": 109,
+        "line": 111,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "scope": "<module>"
       },
@@ -54482,7 +55044,7 @@
         "column": 62,
         "context": "assign:_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED",
         "kind": "import_time_call",
-        "line": 25,
+        "line": 27,
         "module": "easyuse_anima/prompt/conditioning.py",
         "scope": "<module>"
       },
@@ -54527,7 +55089,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1108,
+        "line": 1096,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54536,7 +55098,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1683,
+        "line": 1671,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54545,7 +55107,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1686,
+        "line": 1674,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54554,7 +55116,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1692,
+        "line": 1680,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54563,7 +55125,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1698,
+        "line": 1686,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54572,7 +55134,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1701,
+        "line": 1689,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54581,7 +55143,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1704,
+        "line": 1692,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54590,7 +55152,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1710,
+        "line": 1698,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54599,7 +55161,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1716,
+        "line": 1704,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54608,7 +55170,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1722,
+        "line": 1710,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54617,7 +55179,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1728,
+        "line": 1716,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54626,16 +55188,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1734,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_regional_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1740,
+        "line": 1722,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54644,16 +55197,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1743,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_advanced_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1750,
+        "line": 1728,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54662,7 +55206,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1753,
+        "line": 1735,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54671,25 +55215,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1757,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_conditioning_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1760,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_artist_mix_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1767,
+        "line": 1739,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54698,25 +55224,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1773,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_prompt_fields_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1779,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_prompt_correction_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1782,
+        "line": 1742,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54725,7 +55233,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1785,
+        "line": 1748,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54734,7 +55242,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1788,
+        "line": 1751,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54743,7 +55251,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1795,
+        "line": 1758,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55167,73 +55675,73 @@
       },
       {
         "kind": "dict",
-        "line": 31,
+        "line": 65,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 30,
+        "line": 64,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 29,
+        "line": 63,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "list",
-        "line": 60,
+        "line": 94,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 54,
+        "line": 88,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES"
       },
       {
         "kind": "dict",
-        "line": 44,
+        "line": 78,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES"
       },
       {
         "kind": "dict",
-        "line": 73,
+        "line": 75,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "name": "ARTIST_MIX_MODE_DESCRIPTIONS"
       },
       {
         "kind": "set",
-        "line": 63,
+        "line": 65,
         "module": "easyuse_anima/prompt/artist_mix.py",
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
       },
       {
         "kind": "set",
-        "line": 25,
+        "line": 27,
         "module": "easyuse_anima/prompt/conditioning.py",
         "name": "_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED"
       },
       {
         "kind": "dict",
-        "line": 19,
+        "line": 35,
         "module": "easyuse_anima/prompt/regional.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 18,
+        "line": 34,
         "module": "easyuse_anima/prompt/regional.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 12,
+        "line": 28,
         "module": "easyuse_anima/prompt/regional.py",
         "name": "REGIONAL_FIELD_TYPES"
       },
@@ -55257,13 +55765,13 @@
       },
       {
         "kind": "dict",
-        "line": 1170,
+        "line": 1158,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1159,
+        "line": 1147,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -13669,130 +13669,6 @@
       },
       {
         "alias": null,
-        "bound_name": "expand_wildcard_texts",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "expand_wildcard_texts",
-          "target": "wildcard_engine.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "...wildcard_engine:expand_wildcard_texts",
-        "kind": "static_from",
-        "line": 47,
-        "name": "expand_wildcard_texts",
-        "optional": false,
-        "requested": "...wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "has_wildcard_syntax",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "has_wildcard_syntax",
-          "target": "wildcard_engine.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "...wildcard_engine:has_wildcard_syntax",
-        "kind": "static_from",
-        "line": 47,
-        "name": "has_wildcard_syntax",
-        "optional": false,
-        "requested": "...wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "normalize_prompt_studio_wildcard_mode",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "normalize_prompt_studio_wildcard_mode",
-          "target": "wildcard_engine.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "...wildcard_engine:normalize_prompt_studio_wildcard_mode",
-        "kind": "static_from",
-        "line": 47,
-        "name": "normalize_prompt_studio_wildcard_mode",
-        "optional": false,
-        "requested": "...wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "normalize_seed",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "normalize_seed",
-          "target": "wildcard_engine.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "...wildcard_engine:normalize_seed",
-        "kind": "static_from",
-        "line": 47,
-        "name": "normalize_seed",
-        "optional": false,
-        "requested": "...wildcard_engine",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
         "bound_name": "has_prompt_translation_markers",
         "branch_context": [
           {
@@ -13801,7 +13677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 47,
             "kind": "try",
             "line": 44
           }
@@ -13816,7 +13692,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 54,
+        "line": 48,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -13835,7 +13711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 47,
             "kind": "try",
             "line": 44
           }
@@ -13850,7 +13726,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 55,
+        "line": 49,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -13860,42 +13736,39 @@
         "target": "settings.py"
       },
       {
-        "alias": null,
-        "bound_name": "expand_wildcard_texts",
+        "alias": "module",
+        "bound_name": "module",
         "branch_context": [
           {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 53,
+            "branch": "body",
+            "handles_import_failure": true,
+            "has_import_fallback_handler": true,
             "kind": "try",
-            "line": 44
+            "line": 136
           }
         ],
-        "classification": "compatibility_fallback",
-        "column": 4,
+        "classification": "internal",
+        "column": 8,
         "compatibility_pair": {
-          "bound_name": "expand_wildcard_texts",
+          "bound_name": "module",
           "target": "wildcard_engine.py",
-          "try_line": 44
+          "try_line": 136
         },
         "conditional": true,
-        "imported": "wildcard_engine:expand_wildcard_texts",
+        "imported": "...:wildcard_engine",
         "kind": "static_from",
-        "line": 56,
-        "name": "expand_wildcard_texts",
+        "line": 137,
+        "name": "wildcard_engine",
         "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
+        "requested": "...",
+        "role": "compatibility_primary",
+        "scope": "_wildcard_engine_module",
         "source": "easyuse_anima/prompt/advanced.py",
         "target": "wildcard_engine.py"
       },
       {
-        "alias": null,
-        "bound_name": "has_wildcard_syntax",
+        "alias": "module",
+        "bound_name": "module",
         "branch_context": [
           {
             "branch": "except",
@@ -13903,95 +13776,27 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 138,
             "kind": "try",
-            "line": 44
+            "line": 136
           }
         ],
         "classification": "compatibility_fallback",
-        "column": 4,
+        "column": 8,
         "compatibility_pair": {
-          "bound_name": "has_wildcard_syntax",
+          "bound_name": "module",
           "target": "wildcard_engine.py",
-          "try_line": 44
+          "try_line": 136
         },
         "conditional": true,
-        "imported": "wildcard_engine:has_wildcard_syntax",
-        "kind": "static_from",
-        "line": 56,
-        "name": "has_wildcard_syntax",
+        "imported": "wildcard_engine",
+        "kind": "static_import",
+        "line": 139,
+        "name": null,
         "optional": false,
         "requested": "wildcard_engine",
         "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "normalize_prompt_studio_wildcard_mode",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 53,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "normalize_prompt_studio_wildcard_mode",
-          "target": "wildcard_engine.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
-        "kind": "static_from",
-        "line": 56,
-        "name": "normalize_prompt_studio_wildcard_mode",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "alias": null,
-        "bound_name": "normalize_seed",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 53,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "normalize_seed",
-          "target": "wildcard_engine.py",
-          "try_line": 44
-        },
-        "conditional": true,
-        "imported": "wildcard_engine:normalize_seed",
-        "kind": "static_from",
-        "line": 56,
-        "name": "normalize_seed",
-        "optional": false,
-        "requested": "wildcard_engine",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
+        "scope": "_wildcard_engine_module",
         "source": "easyuse_anima/prompt/advanced.py",
         "target": "wildcard_engine.py"
       },
@@ -39746,13 +39551,13 @@
       },
       {
         "is_package": false,
-        "loc": 858,
+        "loc": 874,
         "module": "easyuse_anima.prompt.advanced",
-        "normalized_git_blob_sha1": "910d0e57e2fbdc3bd79bfaa67c857fae15d8e10d",
+        "normalized_git_blob_sha1": "8b547c9bc6630fd4f3602b5c687596f75907813f",
         "path": "easyuse_anima/prompt/advanced.py",
         "top_level": {
           "class_count": 0,
-          "function_count": 24,
+          "function_count": 29,
           "global_count": 17
         }
       },
@@ -41094,7 +40899,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 47,
             "kind": "try",
             "line": 44
           }
@@ -41103,7 +40908,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 54,
+        "line": 48,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/prompt/advanced.py",
@@ -41117,7 +40922,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 47,
             "kind": "try",
             "line": 44
           }
@@ -41126,7 +40931,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 55,
+        "line": 49,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/prompt/advanced.py",
@@ -41140,85 +40945,16 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 53,
+            "handler_line": 138,
             "kind": "try",
-            "line": 44
+            "line": 136
           }
         ],
         "classification": "compatibility_fallback",
         "conditional": true,
-        "imported": "wildcard_engine:expand_wildcard_texts",
-        "kind": "static_from",
-        "line": 56,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 53,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "wildcard_engine:has_wildcard_syntax",
-        "kind": "static_from",
-        "line": 56,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 53,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
-        "kind": "static_from",
-        "line": 56,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "easyuse_anima/prompt/advanced.py",
-        "target": "wildcard_engine.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 53,
-            "kind": "try",
-            "line": 44
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "wildcard_engine:normalize_seed",
-        "kind": "static_from",
-        "line": 56,
+        "imported": "wildcard_engine",
+        "kind": "static_import",
+        "line": 139,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "easyuse_anima/prompt/advanced.py",
@@ -54999,7 +54735,7 @@
         "column": 28,
         "context": "assign:_ADVANCED_FIELD_SOCKET_RE",
         "kind": "import_time_call",
-        "line": 144,
+        "line": 132,
         "module": "easyuse_anima/prompt/advanced.py",
         "scope": "<module>"
       },
@@ -55675,37 +55411,37 @@
       },
       {
         "kind": "dict",
-        "line": 65,
+        "line": 53,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_LABELS"
       },
       {
         "kind": "set",
-        "line": 64,
+        "line": 52,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_PANES"
       },
       {
         "kind": "set",
-        "line": 63,
+        "line": 51,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "ADVANCED_FIELD_TYPES"
       },
       {
         "kind": "list",
-        "line": 94,
+        "line": 82,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "EXTEND_PROMPT_SLOT_SPECS"
       },
       {
         "kind": "set",
-        "line": 88,
+        "line": 76,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_LEGACY_FIXED_WILDCARD_MODES"
       },
       {
         "kind": "dict",
-        "line": 78,
+        "line": 66,
         "module": "easyuse_anima/prompt/advanced.py",
         "name": "PROMPT_STUDIO_WILDCARD_SEED_CONTROL_ALIASES"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -67,7 +67,9 @@
       "B-11c29b3",
       "B-11c30",
       "B-11c30a",
-      "B-11c30b"
+      "B-11c30b",
+      "B-11c30c",
+      "B-11c30c1"
     ]
   },
   "enums": {
@@ -102,14 +104,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 289,
+    "nodes_canonical_bindings": 283,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 1,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
-    "runtime_binders": 24,
+    "runtime_binders": 18,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -155,16 +157,10 @@
     "_bind_aio_preview_runtime",
     "_bind_aio_output_runtime",
     "_bind_aio_conditioning_runtime",
-    "_bind_regional_runtime",
     "_bind_regional_node_runtime",
-    "_bind_advanced_runtime",
     "_bind_prompt_advanced_node_runtime",
     "_bind_aio_node_runtime",
-    "_bind_conditioning_runtime",
-    "_bind_artist_mix_runtime",
     "_bind_prompt_data_node_runtime",
-    "_bind_prompt_fields_runtime",
-    "_bind_prompt_correction_runtime",
     "_bind_prompt_node_runtime",
     "_bind_wildcard_node_runtime",
     "_bind_naia_node_runtime"
@@ -356,15 +352,6 @@
     "_AIO_FIRST_PASS_CACHE_ORDER": [
       "easyuse_anima.aio.first_pass_cache"
     ],
-    "_HASH_COMMENT_RE": [
-      "easyuse_anima.prompt.fields"
-    ],
-    "_INLINE_SPACE_RE": [
-      "easyuse_anima.prompt.fields"
-    ],
-    "_WEIGHTED_TOKEN_RE": [
-      "easyuse_anima.prompt.fields"
-    ],
     "_adapter_comfy_clip_loader_types": [
       "easyuse_anima.aio.resources"
     ],
@@ -380,23 +367,15 @@
     "_advanced_artist_field_prompt": [
       "easyuse_anima.aio.conditioning"
     ],
-    "_advanced_default_fields": [
-      "easyuse_anima.prompt.regional"
-    ],
     "_advanced_enabled_naia_panes": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_advanced_enabled_pane_fields": [
-      "easyuse_anima.aio.conditioning",
-      "easyuse_anima.prompt.artist_mix"
+      "easyuse_anima.aio.conditioning"
     ],
     "_advanced_field_input_values": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.prompt.regional"
-    ],
-    "_advanced_field_socket_name": [
-      "easyuse_anima.prompt.regional"
+      "easyuse_anima.nodes.regional_nodes"
     ],
     "_advanced_fields_json": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
@@ -407,9 +386,6 @@
     "_advanced_outputs_from_prompt_data": [
       "easyuse_anima.aio.legacy_generation",
       "easyuse_anima.nodes.prompt_data_nodes"
-    ],
-    "_advanced_prompt_with_artist_override": [
-      "easyuse_anima.prompt.artist_mix"
     ],
     "_advanced_resolution_from_selection": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -533,8 +509,7 @@
       "easyuse_anima.nodes.prompt_data_nodes"
     ],
     "_artist_mix_inline_prompt": [
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.prompt_data_nodes"
     ],
     "_artist_mix_mode_tooltip": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -542,12 +517,6 @@
     ],
     "_artist_prompt_with_position": [
       "easyuse_anima.nodes.prompt_data_nodes"
-    ],
-    "_artist_tags_from_prompt": [
-      "easyuse_anima.prompt.advanced"
-    ],
-    "_as_advanced_height": [
-      "easyuse_anima.prompt.regional"
     ],
     "_as_bool": [
       "easyuse_anima.aio.conditioning",
@@ -561,9 +530,7 @@
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.prompt_data_nodes",
       "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.regional"
+      "easyuse_anima.nodes.regional_nodes"
     ],
     "_as_float": [
       "easyuse_anima.aio.generation_normalization",
@@ -572,8 +539,7 @@
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.postprocess",
       "easyuse_anima.aio.sampling",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.prompt.regional"
+      "easyuse_anima.nodes.regional_nodes"
     ],
     "_as_int": [
       "easyuse_anima.aio.generation_normalization",
@@ -584,24 +550,17 @@
       "easyuse_anima.aio.resources",
       "easyuse_anima.aio.sampling",
       "easyuse_anima.aio.usdu",
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.regional"
-    ],
-    "_blend_conditionings": [
-      "easyuse_anima.prompt.artist_mix"
+      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_bounded_artist_mix_float": [
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.prompt_data_nodes"
     ],
     "_bounded_artist_mix_int": [
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.prompt_data_nodes"
     ],
     "_build_advanced_prompt_data": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
@@ -667,25 +626,16 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_correct_advanced_field_sequence": [
-      "easyuse_anima.aio.conditioning",
-      "easyuse_anima.prompt.regional"
+      "easyuse_anima.aio.conditioning"
     ],
     "_correct_builder_prompt": [
-      "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.artist_mix"
+      "easyuse_anima.nodes.prompt_nodes"
     ],
     "_decode_latent_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
     ],
     "_easy_use_anima_input_signature": [
       "easyuse_anima.nodes.aio_nodes"
-    ],
-    "_encode_artist_clustered": [
-      "easyuse_anima.prompt.artist_mix"
-    ],
-    "_encode_artist_delta_rms": [
-      "easyuse_anima.prompt.artist_mix"
     ],
     "_encode_image_with_comfy_vae": [
       "easyuse_anima.aio.legacy_generation"
@@ -699,12 +649,7 @@
       "easyuse_anima.nodes.regional_nodes"
     ],
     "_filter_metadata_prompt": [
-      "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.regional"
-    ],
-    "_find_spectrum_anima_mod_guidance_class": [
-      "easyuse_anima.prompt.conditioning"
+      "easyuse_anima.nodes.prompt_nodes"
     ],
     "_folder_path_names": [
       "easyuse_anima.aio.resources"
@@ -736,15 +681,11 @@
       "easyuse_anima.aio.generation_normalization"
     ],
     "_join_artist_mix_source_prompts": [
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.prompt_data_nodes"
     ],
     "_join_prompt_tokens": [
       "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.artist_mix",
-      "easyuse_anima.prompt.regional"
+      "easyuse_anima.nodes.prompt_nodes"
     ],
     "_json_clone": [
       "easyuse_anima.aio.generation_normalization",
@@ -781,12 +722,6 @@
     "_merge_versioned_settings": [
       "easyuse_anima.aio.resources"
     ],
-    "_metadata_filter_key": [
-      "easyuse_anima.prompt.fields"
-    ],
-    "_metadata_filter_keys": [
-      "easyuse_anima.prompt.fields"
-    ],
     "_new_aio_random_seed": [
       "easyuse_anima.aio.sampling"
     ],
@@ -798,8 +733,7 @@
     ],
     "_normalize_advanced_fields": [
       "easyuse_anima.aio.conditioning",
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.prompt.artist_mix"
+      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_normalize_aio_civitai_hash_fetchers": [
       "easyuse_anima.aio.generation_normalization",
@@ -838,8 +772,7 @@
     ],
     "_normalize_artist_mix_mode": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.prompt_data_nodes"
     ],
     "_normalize_artist_tag_position": [
       "easyuse_anima.nodes.prompt_data_nodes"
@@ -862,12 +795,6 @@
     ],
     "_normalize_regional_fields": [
       "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_normalize_resolution_bucket": [
-      "easyuse_anima.prompt.advanced"
-    ],
-    "_parse_artist_mix_items": [
-      "easyuse_anima.prompt.advanced"
     ],
     "_parse_json_object": [
       "easyuse_anima.nodes.regional_nodes"
@@ -897,9 +824,6 @@
     "_prompt_data_parameter_snapshot": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
-    "_prompt_tokens": [
-      "easyuse_anima.prompt.fields"
-    ],
     "_prompt_translation_change_key": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.prompt_nodes",
@@ -907,9 +831,6 @@
     ],
     "_put_aio_first_pass_cache": [
       "easyuse_anima.aio.legacy_generation"
-    ],
-    "_ratio_label": [
-      "easyuse_anima.prompt.regional"
     ],
     "_regional_config_json": [
       "easyuse_anima.nodes.regional_nodes"
@@ -1014,9 +935,7 @@
       "easyuse_anima.aio.output",
       "easyuse_anima.aio.preview",
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.regional"
+      "easyuse_anima.nodes.regional_nodes"
     ],
     "_split_tag_text": [
       "easyuse_anima.nodes.prompt_nodes"
@@ -1039,26 +958,13 @@
     ],
     "_translate_prompt_text": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.prompt_nodes"
     ],
     "correct_prompt": [
-      "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.prompt.fields"
-    ],
-    "expand_wildcard_texts": [
-      "easyuse_anima.prompt.advanced"
-    ],
-    "has_prompt_translation_markers": [
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.correction"
-    ],
-    "has_wildcard_syntax": [
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.prompt_nodes"
     ],
     "load_knowledge_base": [
-      "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.prompt.fields"
+      "easyuse_anima.nodes.prompt_nodes"
     ],
     "logger": [
       "easyuse_anima.aio.legacy_generation",
@@ -1073,32 +979,19 @@
     ],
     "normalize_prompt_studio_wildcard_mode": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.prompt.advanced"
+      "easyuse_anima.nodes.regional_nodes"
     ],
     "normalize_seed": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.prompt.advanced"
-    ],
-    "parse_prompt": [
-      "easyuse_anima.prompt.fields"
+      "easyuse_anima.nodes.regional_nodes"
     ],
     "resolve_metadata_filter_words": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.prompt_nodes",
-      "easyuse_anima.nodes.regional_nodes",
-      "easyuse_anima.prompt.advanced",
-      "easyuse_anima.prompt.regional"
+      "easyuse_anima.nodes.regional_nodes"
     ],
     "resolve_naia_settings": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
-    ],
-    "resolve_prompt_translation_settings": [
-      "easyuse_anima.prompt.correction"
-    ],
-    "translate_prompt_markers": [
-      "easyuse_anima.prompt.correction"
     ],
     "wildcard_sources_signature": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -1107,21 +1000,21 @@
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 24,
-      "family_count": 4,
+      "binder_count": 18,
+      "family_count": 3,
       "mode_counts": {
-        "comfy_provider_then_root": 12,
-        "root_globals": 10,
+        "comfy_provider_then_root": 10,
+        "root_globals": 6,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 273,
-      "unique_root_resolver_names": 267,
-      "unique_provider_resolver_names": 6,
-      "unique_direct_root_dependencies": 11,
-      "direct_root_dependency_slots": 24,
-      "provider_consumer_slots": 17,
-      "provider_consumer_modules": 12,
-      "repository_replacement_names": 158,
+      "unique_resolver_names": 248,
+      "unique_root_resolver_names": 243,
+      "unique_provider_resolver_names": 5,
+      "unique_direct_root_dependencies": 10,
+      "direct_root_dependency_slots": 21,
+      "provider_consumer_slots": 15,
+      "provider_consumer_modules": 10,
+      "repository_replacement_names": 148,
       "repository_replacement_files": 18
     },
     "families": {
@@ -1138,14 +1031,6 @@
         "_bind_aio_output_runtime",
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime"
-      ],
-      "prompt_services": [
-        "_bind_regional_runtime",
-        "_bind_advanced_runtime",
-        "_bind_conditioning_runtime",
-        "_bind_artist_mix_runtime",
-        "_bind_prompt_fields_runtime",
-        "_bind_prompt_correction_runtime"
       ],
       "prompt_node_adapters": [
         "_bind_regional_node_runtime",
@@ -1216,23 +1101,17 @@
       "_AIO_DETAILER_RESERVED_KEYS",
       "_AIO_FIRST_PASS_CACHE",
       "_AIO_FIRST_PASS_CACHE_ORDER",
-      "_HASH_COMMENT_RE",
-      "_INLINE_SPACE_RE",
-      "_WEIGHTED_TOKEN_RE",
       "_adapter_comfy_clip_loader_types",
       "_adapter_comfy_diffusion_model_names",
       "_adapter_comfy_text_encoder_names",
       "_adapter_comfy_vae_names",
       "_advanced_artist_field_prompt",
-      "_advanced_default_fields",
       "_advanced_enabled_naia_panes",
       "_advanced_enabled_pane_fields",
       "_advanced_field_input_values",
-      "_advanced_field_socket_name",
       "_advanced_fields_json",
       "_advanced_has_enabled_naia",
       "_advanced_outputs_from_prompt_data",
-      "_advanced_prompt_with_artist_override",
       "_advanced_resolution_from_selection",
       "_advanced_uses_naia_resolution",
       "_aio_detailer_has_enabled_targets",
@@ -1275,12 +1154,9 @@
       "_artist_mix_inline_prompt",
       "_artist_mix_mode_tooltip",
       "_artist_prompt_with_position",
-      "_artist_tags_from_prompt",
-      "_as_advanced_height",
       "_as_bool",
       "_as_float",
       "_as_int",
-      "_blend_conditionings",
       "_bounded_artist_mix_float",
       "_bounded_artist_mix_int",
       "_build_advanced_prompt_data",
@@ -1307,13 +1183,10 @@
       "_correct_builder_prompt",
       "_decode_latent_with_comfy",
       "_easy_use_anima_input_signature",
-      "_encode_artist_clustered",
-      "_encode_artist_delta_rms",
       "_encode_image_with_comfy_vae",
       "_encode_prompt_data_positive_conditioning",
       "_expand_advanced_wildcard_fields",
       "_filter_metadata_prompt",
-      "_find_spectrum_anima_mod_guidance_class",
       "_folder_path_names",
       "_format_strength",
       "_generate_empty_latent_with_comfy",
@@ -1335,8 +1208,6 @@
       "_load_vae_with_comfy",
       "_lora_stack_name",
       "_merge_versioned_settings",
-      "_metadata_filter_key",
-      "_metadata_filter_keys",
       "_new_aio_random_seed",
       "_node_output_tuple",
       "_normalize_advanced_fields",
@@ -1356,8 +1227,6 @@
       "_normalize_prompt_studio_wildcard_seed_control",
       "_normalize_regional_config",
       "_normalize_regional_fields",
-      "_normalize_resolution_bucket",
-      "_parse_artist_mix_items",
       "_parse_json_object",
       "_parse_random_response",
       "_patch_model_sampling_aura_flow",
@@ -1366,10 +1235,8 @@
       "_preferred_name_default",
       "_prompt_data_json_safe",
       "_prompt_data_parameter_snapshot",
-      "_prompt_tokens",
       "_prompt_translation_change_key",
       "_put_aio_first_pass_cache",
-      "_ratio_label",
       "_regional_config_json",
       "_regional_fields_json",
       "_regional_mask_bounds_area",
@@ -1409,29 +1276,22 @@
       "_translate_prompt_text",
       "ceil",
       "correct_prompt",
-      "expand_wildcard_texts",
-      "has_prompt_translation_markers",
-      "has_wildcard_syntax",
       "json",
       "load_knowledge_base",
       "logger",
       "next_seed",
       "normalize_prompt_studio_wildcard_mode",
       "normalize_seed",
-      "parse_prompt",
       "random",
       "resolve_metadata_filter_words",
       "resolve_naia_settings",
-      "resolve_prompt_translation_settings",
       "sqrt",
-      "translate_prompt_markers",
       "wildcard_sources_signature"
     ],
     "provider_resolver_names": [
       "_comfy_max_resolution",
       "_encode_with_comfy_clip",
       "_find_comfy_node_class",
-      "_find_loaded_node_class",
       "_require_any_custom_node_class",
       "_require_custom_node_class"
     ],
@@ -1640,9 +1500,6 @@
       "_as_int": [
         "tests/test_node_contracts.py"
       ],
-      "_blend_conditionings": [
-        "tests/test_prompt_corrector.py"
-      ],
       "_choice": [
         "tests/test_aio_generation_settings.py",
         "tests/test_aio_resources.py",
@@ -1692,8 +1549,7 @@
         "tests/test_aio_nodes.py"
       ],
       "_correct_builder_prompt": [
-        "tests/test_node_contracts.py",
-        "tests/test_prompt_corrector.py"
+        "tests/test_node_contracts.py"
       ],
       "_decode_latent_with_comfy": [
         "tests/test_aio_legacy_generation.py",
@@ -1701,12 +1557,6 @@
       ],
       "_easy_use_anima_input_signature": [
         "tests/test_aio_nodes.py"
-      ],
-      "_encode_artist_clustered": [
-        "tests/test_prompt_corrector.py"
-      ],
-      "_encode_artist_delta_rms": [
-        "tests/test_prompt_corrector.py"
       ],
       "_encode_image_with_comfy_vae": [
         "tests/test_aio_legacy_generation.py",
@@ -1718,9 +1568,6 @@
       ],
       "_filter_metadata_prompt": [
         "tests/test_node_contracts.py"
-      ],
-      "_find_spectrum_anima_mod_guidance_class": [
-        "tests/test_prompt_corrector.py"
       ],
       "_folder_path_names": [
         "tests/test_comfy_adapters.py",
@@ -1837,9 +1684,6 @@
         "tests/test_aio_nodes.py",
         "tests/test_aio_preview.py"
       ],
-      "_prompt_tokens": [
-        "tests/test_node_contracts.py"
-      ],
       "_prompt_translation_change_key": [
         "tests/test_node_contracts.py"
       ],
@@ -1937,14 +1781,8 @@
       "correct_prompt": [
         "tests/test_node_contracts.py"
       ],
-      "expand_wildcard_texts": [
-        "tests/test_wildcards.py"
-      ],
       "expand_wildcards": [
         "tests/test_wildcards.py"
-      ],
-      "has_prompt_translation_markers": [
-        "tests/test_node_contracts.py"
       ],
       "json": [
         "tests/test_node_contracts.py"
@@ -1957,9 +1795,6 @@
       ],
       "next_seed": [
         "tests/test_prompt_studio_regional.py"
-      ],
-      "parse_prompt": [
-        "tests/test_node_contracts.py"
       ],
       "random": [
         "tests/test_aio_legacy_generation.py",
@@ -1974,14 +1809,7 @@
         "tests/test_node_contracts.py",
         "tests/test_prompt_corrector.py"
       ],
-      "resolve_prompt_translation_settings": [
-        "tests/test_node_contracts.py",
-        "tests/test_prompt_corrector.py"
-      ],
       "sqrt": [
-        "tests/test_node_contracts.py"
-      ],
-      "translate_prompt_markers": [
         "tests/test_node_contracts.py"
       ],
       "wildcard_sources_signature": [
@@ -2900,72 +2728,6 @@
         ]
       },
       {
-        "binder": "_bind_regional_runtime",
-        "module": "easyuse_anima.prompt.regional",
-        "family": "prompt_services",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_advanced_default_fields",
-          "_advanced_field_input_values",
-          "_advanced_field_socket_name",
-          "_as_advanced_height",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_correct_advanced_field_sequence",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_ratio_label",
-          "_single_value",
-          "resolve_metadata_filter_words"
-        ],
-        "direct_root_dependencies": [],
-        "resolver_names": [
-          "_advanced_default_fields",
-          "_advanced_field_input_values",
-          "_advanced_field_socket_name",
-          "_as_advanced_height",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_correct_advanced_field_sequence",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_ratio_label",
-          "_single_value",
-          "resolve_metadata_filter_words"
-        ],
-        "root_resolver_names": [
-          "_advanced_default_fields",
-          "_advanced_field_input_values",
-          "_advanced_field_socket_name",
-          "_as_advanced_height",
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_correct_advanced_field_sequence",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_ratio_label",
-          "_single_value",
-          "resolve_metadata_filter_words"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_as_bool",
-          "_as_float",
-          "_as_int",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_single_value",
-          "resolve_metadata_filter_words"
-        ]
-      },
-      {
         "binder": "_bind_regional_node_runtime",
         "module": "easyuse_anima.nodes.regional_nodes",
         "family": "prompt_node_adapters",
@@ -3091,79 +2853,6 @@
           "next_seed",
           "resolve_metadata_filter_words",
           "wildcard_sources_signature"
-        ]
-      },
-      {
-        "binder": "_bind_advanced_runtime",
-        "module": "easyuse_anima.prompt.advanced",
-        "family": "prompt_services",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [],
-        "resolver_names": [
-          "_artist_mix_inline_prompt",
-          "_artist_tags_from_prompt",
-          "_as_bool",
-          "_as_int",
-          "_bounded_artist_mix_float",
-          "_bounded_artist_mix_int",
-          "_correct_builder_prompt",
-          "_filter_metadata_prompt",
-          "_join_artist_mix_source_prompts",
-          "_join_prompt_tokens",
-          "_normalize_artist_mix_mode",
-          "_normalize_resolution_bucket",
-          "_parse_artist_mix_items",
-          "_single_value",
-          "_translate_prompt_text",
-          "expand_wildcard_texts",
-          "has_prompt_translation_markers",
-          "has_wildcard_syntax",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words"
-        ],
-        "root_resolver_names": [
-          "_artist_mix_inline_prompt",
-          "_artist_tags_from_prompt",
-          "_as_bool",
-          "_as_int",
-          "_bounded_artist_mix_float",
-          "_bounded_artist_mix_int",
-          "_correct_builder_prompt",
-          "_filter_metadata_prompt",
-          "_join_artist_mix_source_prompts",
-          "_join_prompt_tokens",
-          "_normalize_artist_mix_mode",
-          "_normalize_resolution_bucket",
-          "_parse_artist_mix_items",
-          "_single_value",
-          "_translate_prompt_text",
-          "expand_wildcard_texts",
-          "has_prompt_translation_markers",
-          "has_wildcard_syntax",
-          "normalize_prompt_studio_wildcard_mode",
-          "normalize_seed",
-          "resolve_metadata_filter_words"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_as_bool",
-          "_as_int",
-          "_correct_builder_prompt",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_single_value",
-          "_translate_prompt_text",
-          "expand_wildcard_texts",
-          "has_prompt_translation_markers",
-          "resolve_metadata_filter_words"
         ]
       },
       {
@@ -3432,86 +3121,6 @@
         ]
       },
       {
-        "binder": "_bind_conditioning_runtime",
-        "module": "easyuse_anima.prompt.conditioning",
-        "family": "prompt_services",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper",
-          "resolve_logger"
-        ],
-        "bound_globals": [
-          "_RUNTIME_LOGGER_RESOLVER",
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper",
-          "logger"
-        ],
-        "resolver_names": [
-          "_find_loaded_node_class",
-          "_find_spectrum_anima_mod_guidance_class"
-        ],
-        "root_resolver_names": [
-          "_find_spectrum_anima_mod_guidance_class"
-        ],
-        "provider_resolver_names": [
-          "_find_loaded_node_class"
-        ],
-        "repository_replacement_names": [
-          "_find_spectrum_anima_mod_guidance_class",
-          "logger"
-        ]
-      },
-      {
-        "binder": "_bind_artist_mix_runtime",
-        "module": "easyuse_anima.prompt.artist_mix",
-        "family": "prompt_services",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "_advanced_enabled_pane_fields",
-          "_advanced_prompt_with_artist_override",
-          "_blend_conditionings",
-          "_correct_builder_prompt",
-          "_encode_artist_clustered",
-          "_encode_artist_delta_rms",
-          "_encode_with_comfy_clip",
-          "_join_prompt_tokens",
-          "_normalize_advanced_fields"
-        ],
-        "root_resolver_names": [
-          "_advanced_enabled_pane_fields",
-          "_advanced_prompt_with_artist_override",
-          "_blend_conditionings",
-          "_correct_builder_prompt",
-          "_encode_artist_clustered",
-          "_encode_artist_delta_rms",
-          "_join_prompt_tokens",
-          "_normalize_advanced_fields"
-        ],
-        "provider_resolver_names": [
-          "_encode_with_comfy_clip"
-        ],
-        "repository_replacement_names": [
-          "_blend_conditionings",
-          "_correct_builder_prompt",
-          "_encode_artist_clustered",
-          "_encode_artist_delta_rms",
-          "_join_prompt_tokens"
-        ]
-      },
-      {
         "binder": "_bind_prompt_data_node_runtime",
         "module": "easyuse_anima.nodes.prompt_data_nodes",
         "family": "prompt_node_adapters",
@@ -3583,81 +3192,6 @@
           "_normalize_prompt_data",
           "_resolve_anima_mod_guidance_enabled",
           "_stable_change_key"
-        ]
-      },
-      {
-        "binder": "_bind_prompt_fields_runtime",
-        "module": "easyuse_anima.prompt.fields",
-        "family": "prompt_services",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_HELPER_RESOLVER"
-        ],
-        "direct_root_dependencies": [],
-        "resolver_names": [
-          "_HASH_COMMENT_RE",
-          "_INLINE_SPACE_RE",
-          "_WEIGHTED_TOKEN_RE",
-          "_metadata_filter_key",
-          "_metadata_filter_keys",
-          "_prompt_tokens",
-          "correct_prompt",
-          "load_knowledge_base",
-          "parse_prompt"
-        ],
-        "root_resolver_names": [
-          "_HASH_COMMENT_RE",
-          "_INLINE_SPACE_RE",
-          "_WEIGHTED_TOKEN_RE",
-          "_metadata_filter_key",
-          "_metadata_filter_keys",
-          "_prompt_tokens",
-          "correct_prompt",
-          "load_knowledge_base",
-          "parse_prompt"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_prompt_tokens",
-          "correct_prompt",
-          "load_knowledge_base",
-          "parse_prompt"
-        ]
-      },
-      {
-        "binder": "_bind_prompt_correction_runtime",
-        "module": "easyuse_anima.prompt.correction",
-        "family": "prompt_services",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "has_prompt_translation_markers",
-          "resolve_prompt_translation_settings",
-          "translate_prompt_markers"
-        ],
-        "direct_root_dependencies": [],
-        "resolver_names": [
-          "has_prompt_translation_markers",
-          "resolve_prompt_translation_settings",
-          "translate_prompt_markers"
-        ],
-        "root_resolver_names": [
-          "has_prompt_translation_markers",
-          "resolve_prompt_translation_settings",
-          "translate_prompt_markers"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "has_prompt_translation_markers",
-          "resolve_prompt_translation_settings",
-          "translate_prompt_markers"
         ]
       },
       {
@@ -5169,9 +4703,7 @@
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.advanced",
-        "canonical runtime resolver: easyuse_anima.prompt.regional"
+        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
@@ -5188,9 +4720,7 @@
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.advanced string runtime lookup",
-        "AST:easyuse_anima.prompt.regional string runtime lookup"
+        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5594,8 +5124,6 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_advanced_resolution_from_selection": "_advanced_resolution_from_selection",
-        "_normalize_resolution_bucket": "_normalize_resolution_bucket",
-        "_ratio_label": "_ratio_label",
         "_resolution_label": "_resolution_label",
         "_resolve_naia_resolution": "_resolve_naia_resolution"
       },
@@ -5610,15 +5138,11 @@
       "first_release": null,
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.advanced",
-        "canonical runtime resolver: easyuse_anima.prompt.regional"
+        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.advanced string runtime lookup",
-        "AST:easyuse_anima.prompt.regional string runtime lookup"
+        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5626,6 +5150,36 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.naia.resolution:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_normalize_resolution_bucket": "_normalize_resolution_bucket",
+        "_ratio_label": "_ratio_label"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.naia.resolution",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.naia.resolution",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.aio_nodes:supported_public_reexport",
@@ -6204,18 +5758,13 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_advanced_artist_field_prompt": "_advanced_artist_field_prompt",
-        "_advanced_default_fields": "_advanced_default_fields",
         "_advanced_enabled_naia_panes": "_advanced_enabled_naia_panes",
         "_advanced_enabled_pane_fields": "_advanced_enabled_pane_fields",
         "_advanced_field_input_values": "_advanced_field_input_values",
-        "_advanced_field_socket_name": "_advanced_field_socket_name",
         "_advanced_fields_json": "_advanced_fields_json",
         "_advanced_has_enabled_naia": "_advanced_has_enabled_naia",
-        "_advanced_prompt_with_artist_override": "_advanced_prompt_with_artist_override",
         "_advanced_uses_naia_resolution": "_advanced_uses_naia_resolution",
         "_apply_advanced_field_inputs": "_apply_advanced_field_inputs",
-        "_as_advanced_height": "_as_advanced_height",
-        "_bind_advanced_runtime": "_bind_advanced_runtime",
         "_build_advanced_prompt_data": "_build_advanced_prompt_data",
         "_build_advanced_prompts": "_build_advanced_prompts",
         "_clone_advanced_fields": "_clone_advanced_fields",
@@ -6236,20 +5785,14 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.conditioning",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.artist_mix",
-        "canonical runtime resolver: easyuse_anima.prompt.regional"
+        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.artist_mix string runtime lookup",
-        "AST:easyuse_anima.prompt.regional string runtime lookup"
+        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6257,6 +5800,38 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.prompt.advanced:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_advanced_default_fields": "_advanced_default_fields",
+        "_advanced_field_socket_name": "_advanced_field_socket_name",
+        "_advanced_prompt_with_artist_override": "_advanced_prompt_with_artist_override",
+        "_as_advanced_height": "_as_advanced_height"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.prompt.advanced",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.prompt.advanced",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.artist_mix:transitional_private_seam",
@@ -6275,18 +5850,12 @@
         "_artist_mix_inline_prompt": "_artist_mix_inline_prompt",
         "_artist_mix_mode_tooltip": "_artist_mix_mode_tooltip",
         "_artist_prompt_with_position": "_artist_prompt_with_position",
-        "_artist_tags_from_prompt": "_artist_tags_from_prompt",
-        "_bind_artist_mix_runtime": "_bind_artist_mix_runtime",
-        "_blend_conditionings": "_blend_conditionings",
         "_bounded_artist_mix_float": "_bounded_artist_mix_float",
         "_bounded_artist_mix_int": "_bounded_artist_mix_int",
-        "_encode_artist_clustered": "_encode_artist_clustered",
-        "_encode_artist_delta_rms": "_encode_artist_delta_rms",
         "_encode_prompt_data_positive_conditioning": "_encode_prompt_data_positive_conditioning",
         "_join_artist_mix_source_prompts": "_join_artist_mix_source_prompts",
         "_normalize_artist_mix_mode": "_normalize_artist_mix_mode",
-        "_normalize_artist_tag_position": "_normalize_artist_tag_position",
-        "_parse_artist_mix_items": "_parse_artist_mix_items"
+        "_normalize_artist_tag_position": "_normalize_artist_tag_position"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -6302,18 +5871,14 @@
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.advanced",
-        "canonical runtime resolver: easyuse_anima.prompt.artist_mix"
+        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.advanced string runtime lookup",
-        "AST:easyuse_anima.prompt.artist_mix string runtime lookup"
+        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6321,6 +5886,39 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_canonical_bindings:easyuse_anima.prompt.artist_mix:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_artist_tags_from_prompt": "_artist_tags_from_prompt",
+        "_blend_conditionings": "_blend_conditionings",
+        "_encode_artist_clustered": "_encode_artist_clustered",
+        "_encode_artist_delta_rms": "_encode_artist_delta_rms",
+        "_parse_artist_mix_items": "_parse_artist_mix_items"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.prompt.artist_mix",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.prompt.artist_mix",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.conditioning:transitional_private_seam",
@@ -6331,8 +5929,6 @@
         "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "ANIMA_MOD_GUIDANCE_PROFILE_OFF": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "_apply_spectrum_anima_mod_guidance": "_apply_spectrum_anima_mod_guidance",
-        "_bind_conditioning_runtime": "_bind_conditioning_runtime",
-        "_find_spectrum_anima_mod_guidance_class": "_find_spectrum_anima_mod_guidance_class",
         "_normalize_anima_mod_guidance_profile": "_normalize_anima_mod_guidance_profile",
         "_resolve_anima_mod_guidance_enabled": "_resolve_anima_mod_guidance_enabled"
       },
@@ -6350,16 +5946,14 @@
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.conditioning"
+        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.conditioning string runtime lookup"
+        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6369,10 +5963,38 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.prompt.conditioning:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_find_spectrum_anima_mod_guidance_class": "_find_spectrum_anima_mod_guidance_class"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.prompt.conditioning",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.prompt.conditioning",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.correction:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_bind_prompt_correction_runtime": "_bind_prompt_correction_runtime",
         "_prompt_translation_change_key": "_prompt_translation_change_key",
         "_split_tag_text": "_split_tag_text",
         "_translate_prompt_text": "_translate_prompt_text"
@@ -6387,18 +6009,14 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.advanced"
+        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.advanced string runtime lookup"
+        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6459,16 +6077,9 @@
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.fields:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_HASH_COMMENT_RE": "_HASH_COMMENT_RE",
-        "_INLINE_SPACE_RE": "_INLINE_SPACE_RE",
-        "_WEIGHTED_TOKEN_RE": "_WEIGHTED_TOKEN_RE",
-        "_bind_prompt_fields_runtime": "_bind_prompt_fields_runtime",
         "_correct_builder_prompt": "_correct_builder_prompt",
         "_filter_metadata_prompt": "_filter_metadata_prompt",
-        "_join_prompt_tokens": "_join_prompt_tokens",
-        "_metadata_filter_key": "_metadata_filter_key",
-        "_metadata_filter_keys": "_metadata_filter_keys",
-        "_prompt_tokens": "_prompt_tokens"
+        "_join_prompt_tokens": "_join_prompt_tokens"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -6480,22 +6091,12 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.advanced",
-        "canonical runtime resolver: easyuse_anima.prompt.artist_mix",
-        "canonical runtime resolver: easyuse_anima.prompt.fields",
-        "canonical runtime resolver: easyuse_anima.prompt.regional"
+        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.advanced string runtime lookup",
-        "AST:easyuse_anima.prompt.artist_mix string runtime lookup",
-        "AST:easyuse_anima.prompt.fields string runtime lookup",
-        "AST:easyuse_anima.prompt.regional string runtime lookup"
+        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6505,11 +6106,44 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.prompt.fields:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_HASH_COMMENT_RE": "_HASH_COMMENT_RE",
+        "_INLINE_SPACE_RE": "_INLINE_SPACE_RE",
+        "_WEIGHTED_TOKEN_RE": "_WEIGHTED_TOKEN_RE",
+        "_metadata_filter_key": "_metadata_filter_key",
+        "_metadata_filter_keys": "_metadata_filter_keys",
+        "_prompt_tokens": "_prompt_tokens"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.prompt.fields",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.prompt.fields",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.regional:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_apply_regional_field_inputs": "_apply_regional_field_inputs",
-        "_bind_regional_runtime": "_bind_regional_runtime",
         "_build_regional_outputs": "_build_regional_outputs",
         "_clone_regional_fields": "_clone_regional_fields",
         "_conditioning_set_values": "_conditioning_set_values",
@@ -6533,11 +6167,9 @@
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
-        "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -6580,32 +6212,33 @@
       "lifecycle_state": "transitional"
     },
     {
-      "id": "nodes_legacy_bindings:anima_prompt.parser:transitional_private_seam",
+      "id": "nodes_legacy_bindings:anima_prompt.parser:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
         "parse_prompt": "parse_prompt"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": null,
       "target_state": "legacy_owner",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "anima_prompt.parser",
       "owner": "#184/#186",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.prompt.fields"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:easyuse_anima.prompt.fields string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_legacy_bindings:anima_prompt:transitional_private_seam",
@@ -6624,12 +6257,10 @@
       "owner": "#184/#186",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.fields"
+        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes"
       ],
       "evidence": [
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.fields string runtime lookup"
+        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6639,43 +6270,41 @@
       "lifecycle_state": "transitional"
     },
     {
-      "id": "nodes_legacy_bindings:prompt_translation:transitional_private_seam",
+      "id": "nodes_legacy_bindings:prompt_translation:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
         "has_prompt_translation_markers": "has_prompt_translation_markers",
         "translate_prompt_markers": "translate_prompt_markers"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": null,
       "target_state": "legacy_owner",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "prompt_translation",
       "owner": "#164/#186",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.prompt.advanced",
-        "canonical runtime resolver: easyuse_anima.prompt.correction"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:easyuse_anima.prompt.advanced string runtime lookup",
-        "AST:easyuse_anima.prompt.correction string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_legacy_bindings:settings:transitional_private_seam",
       "surface": "nodes_legacy_bindings",
       "symbols": {
         "resolve_metadata_filter_words": "resolve_metadata_filter_words",
-        "resolve_naia_settings": "resolve_naia_settings",
-        "resolve_prompt_translation_settings": "resolve_prompt_translation_settings"
+        "resolve_naia_settings": "resolve_naia_settings"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -6690,19 +6319,13 @@
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.advanced",
-        "canonical runtime resolver: easyuse_anima.prompt.correction",
-        "canonical runtime resolver: easyuse_anima.prompt.regional"
+        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.advanced string runtime lookup",
-        "AST:easyuse_anima.prompt.correction string runtime lookup",
-        "AST:easyuse_anima.prompt.regional string runtime lookup"
+        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6710,6 +6333,35 @@
         "separate B-10b or B-11 rollback unit"
       ],
       "lifecycle_state": "transitional"
+    },
+    {
+      "id": "nodes_legacy_bindings:settings:unsupported_test_only",
+      "surface": "nodes_legacy_bindings",
+      "symbols": {
+        "resolve_prompt_translation_settings": "resolve_prompt_translation_settings"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": null,
+      "target_state": "legacy_owner",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "settings",
+      "owner": "#163/#186",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_legacy_bindings:wildcard_engine:transitional_private_seam",
@@ -6725,9 +6377,7 @@
         "WILDCARD_MODE_FIXED": "WILDCARD_MODE_FIXED",
         "WILDCARD_MODE_POPULATE": "WILDCARD_MODE_POPULATE",
         "WILDCARD_MODE_SEQUENTIAL": "WILDCARD_MODE_SEQUENTIAL",
-        "expand_wildcard_texts": "expand_wildcard_texts",
         "expand_wildcards": "expand_wildcards",
-        "has_wildcard_syntax": "has_wildcard_syntax",
         "next_seed": "next_seed",
         "normalize_prompt_studio_wildcard_mode": "normalize_prompt_studio_wildcard_mode",
         "normalize_seed": "normalize_seed",
@@ -6748,16 +6398,14 @@
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes",
-        "canonical runtime resolver: easyuse_anima.prompt.advanced"
+        "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup",
-        "AST:easyuse_anima.prompt.advanced string runtime lookup"
+        "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6770,7 +6418,9 @@
       "id": "nodes_legacy_bindings:wildcard_engine:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
-        "PROMPT_STUDIO_WILDCARD_MODE_LABELS": "PROMPT_STUDIO_WILDCARD_MODE_LABELS"
+        "PROMPT_STUDIO_WILDCARD_MODE_LABELS": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
+        "expand_wildcard_texts": "expand_wildcard_texts",
+        "has_wildcard_syntax": "has_wildcard_syntax"
       },
       "classification": "unsupported_test_only",
       "current_target": "nodes.py",

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -2807,6 +2807,7 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
     )
 
     def test_root_prompt_corrector_objects_are_direct_canonical_aliases(self):
+        self.assertFalse(hasattr(prompt_correction, "_bind_prompt_correction_runtime"))
         for name in self.CORRECTION_HELPERS:
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(prompt_correction, name))
@@ -2831,7 +2832,7 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
                 with self.subTest(name=name):
                     self.assertIs(getattr(package_nodes, name), getattr(package_prompt_nodes, name))
 
-    def test_root_monkeypatches_drive_the_canonical_prompt_corrector_nodes(self):
+    def test_canonical_service_and_root_adapter_monkeypatches_drive_prompt_corrector_nodes(self):
         settings = types.SimpleNamespace(provider="off", source="auto", target="en")
         correction_result = types.SimpleNamespace(
             text="canonical result",
@@ -2844,7 +2845,7 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
 
         with (
             patch.object(
-                nodes,
+                prompt_correction,
                 "resolve_prompt_translation_settings",
                 return_value=settings,
             ) as resolve_settings,
@@ -2888,16 +2889,16 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
             ["changed", "unknown_tags", "duplicate_tags", "warnings", "sections"],
         )
 
-    def test_root_translation_monkeypatches_drive_the_canonical_helper(self):
+    def test_canonical_translation_monkeypatches_drive_the_canonical_helper(self):
         settings = types.SimpleNamespace(provider="off", source="auto", target="en")
 
         with (
             patch.object(
-                nodes,
+                prompt_correction,
                 "has_prompt_translation_markers",
                 return_value=False,
             ) as has_markers,
-            patch.object(nodes, "translate_prompt_markers") as translate_markers,
+            patch.object(prompt_correction, "translate_prompt_markers") as translate_markers,
         ):
             untranslated = nodes._translate_prompt_text("%{abc}")
 
@@ -2907,17 +2908,17 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
 
         with (
             patch.object(
-                nodes,
+                prompt_correction,
                 "has_prompt_translation_markers",
                 return_value=True,
             ) as has_markers,
             patch.object(
-                nodes,
+                prompt_correction,
                 "translate_prompt_markers",
                 return_value="bound",
             ) as translate_markers,
             patch.object(
-                nodes,
+                prompt_correction,
                 "resolve_prompt_translation_settings",
                 return_value=settings,
             ) as resolve_settings,
@@ -3104,6 +3105,8 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
     }
 
     def test_root_prompt_data_conditioning_objects_are_direct_canonical_aliases(self):
+        self.assertFalse(hasattr(prompt_artist_mix, "_bind_artist_mix_runtime"))
+        self.assertFalse(hasattr(prompt_conditioning, "_bind_conditioning_runtime"))
         for name in (
             *self.RETIRED_PROMPT_DATA_ALIASES,
             *self.RETIRED_CONDITIONING_ALIASES,
@@ -3240,6 +3243,7 @@ class PromptBuilderStudioMoveContractTests(unittest.TestCase):
     )
 
     def test_root_prompt_builder_studio_objects_are_direct_canonical_aliases(self):
+        self.assertFalse(hasattr(prompt_fields, "_bind_prompt_fields_runtime"))
         for name in self.RETIRED_FIELD_DEFAULTS:
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))
@@ -3283,20 +3287,32 @@ class PromptBuilderStudioMoveContractTests(unittest.TestCase):
             )
         )
 
-    def test_root_parser_and_correction_monkeypatches_drive_canonical_fields(self):
+    def test_canonical_parser_and_correction_monkeypatches_drive_canonical_fields(self):
         parsed = types.SimpleNamespace(tokens=("  bound_token  ",))
         correction_result = types.SimpleNamespace(text="bound correction")
 
-        with patch.object(nodes, "parse_prompt", return_value=parsed) as parser:
+        with patch.object(prompt_fields, "parse_prompt", return_value=parsed) as parser:
             tokens = prompt_fields._prompt_tokens("source")
 
         self.assertEqual(tokens, ["bound_token"])
         parser.assert_called_once_with("source", profile="prompt")
 
         with (
-            patch.object(nodes, "_prompt_tokens", return_value=["bound_artist"]) as tokens,
-            patch.object(nodes, "load_knowledge_base", return_value="bound kb") as load_kb,
-            patch.object(nodes, "correct_prompt", return_value=correction_result) as correct,
+            patch.object(
+                prompt_fields,
+                "_prompt_tokens",
+                return_value=["bound_artist"],
+            ) as tokens,
+            patch.object(
+                prompt_fields,
+                "load_knowledge_base",
+                return_value="bound kb",
+            ) as load_kb,
+            patch.object(
+                prompt_fields,
+                "correct_prompt",
+                return_value=correction_result,
+            ) as correct,
         ):
             corrected = prompt_fields._correct_builder_prompt("prompt", "artist")
 
@@ -3448,6 +3464,7 @@ class PromptAdvancedMoveContractTests(unittest.TestCase):
     )
 
     def test_root_advanced_objects_are_direct_canonical_aliases(self):
+        self.assertFalse(hasattr(prompt_advanced, "_bind_advanced_runtime"))
         for name in (*self.RETIRED_NODE_CLASSES, *self.RETIRED_ADVANCED_ALIASES):
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))
@@ -3639,7 +3656,6 @@ class RegionalMoveContractTests(unittest.TestCase):
     )
     SERVICE_OBJECTS = (
         "_apply_regional_field_inputs",
-        "_bind_regional_runtime",
         "_build_regional_outputs",
         "_clone_regional_fields",
         "_conditioning_set_values",
@@ -3659,6 +3675,7 @@ class RegionalMoveContractTests(unittest.TestCase):
     )
 
     def test_root_regional_objects_are_direct_canonical_aliases(self):
+        self.assertFalse(hasattr(prompt_regional, "_bind_regional_runtime"))
         for name in self.RETIRED_REGIONAL_ALIASES:
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "256f87b4e83842437b5993661f42a9259a463e17")
-        # B-11c30b retires only the three LoRA runtime binder
+        self.assertEqual(report["git_blob_sha1"], "1815fadba3e329f88f95cc8aa29002e86b0b7a24")
+        # B-11c30c1 retires only the six Prompt/Regional service runtime binder
         # imports and calls without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 1)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_800)
+        self.assertEqual(report["line_count"], 1_763)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -17,6 +17,9 @@ import settings as easyuse_settings
 from easyuse_anima.naia.client import _clean_prompt
 from easyuse_anima.naia.resolution import ADVANCED_RESOLUTION_BUCKETS
 from easyuse_anima.nodes.prompt_advanced_nodes import EasyUseAnimaPromptStudioExtend
+from easyuse_anima.prompt import artist_mix as prompt_artist_mix
+from easyuse_anima.prompt import conditioning as prompt_conditioning
+from easyuse_anima.prompt import correction as prompt_correction
 from easyuse_anima.prompt.advanced import ADVANCED_FIELDS_WORKFLOW_PROPERTY
 from easyuse_anima.prompt.artist_mix import (
     ARTIST_MIX_CONTROL_KEY,
@@ -162,7 +165,11 @@ class PromptCorrectorTests(unittest.TestCase):
             target="ja",
         )
 
-        with patch("nodes.resolve_prompt_translation_settings", return_value=off_settings):
+        with patch.object(
+            prompt_correction,
+            "resolve_prompt_translation_settings",
+            return_value=off_settings,
+        ):
             result = EasyUseAnimaPromptCorrectorSimple().correct("%{long_hair, 1girl}")
             off_key = EasyUseAnimaPromptCorrectorSimple.IS_CHANGED(
                 prompt="%{long_hair, 1girl}"
@@ -171,7 +178,11 @@ class PromptCorrectorTests(unittest.TestCase):
                 prompt="%{long_hair, 1girl}"
             )
 
-        with patch("nodes.resolve_prompt_translation_settings", return_value=google_settings):
+        with patch.object(
+            prompt_correction,
+            "resolve_prompt_translation_settings",
+            return_value=google_settings,
+        ):
             google_key = EasyUseAnimaPromptCorrectorSimple.IS_CHANGED(
                 prompt="%{long_hair, 1girl}"
             )
@@ -193,7 +204,7 @@ class PromptCorrectorTests(unittest.TestCase):
     def test_prompt_correctors_translate_marked_text_before_correction(self):
         with (
             patch(
-                "nodes.resolve_prompt_translation_settings",
+                "easyuse_anima.prompt.correction.resolve_prompt_translation_settings",
                 return_value=PromptTranslationSettings(
                     provider=PROMPT_TRANSLATION_PROVIDER_GOOGLE,
                     source="ko",
@@ -212,7 +223,7 @@ class PromptCorrectorTests(unittest.TestCase):
     def test_prompt_builder_translates_marked_text_before_correction(self):
         with (
             patch(
-                "nodes.resolve_prompt_translation_settings",
+                "easyuse_anima.prompt.correction.resolve_prompt_translation_settings",
                 return_value=PromptTranslationSettings(
                     provider=PROMPT_TRANSLATION_PROVIDER_GOOGLE,
                     source="ko",
@@ -595,7 +606,11 @@ class PromptBuilderTests(unittest.TestCase):
             return [[f"cond:{text}", {"encoded_text": text}]]
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
-            with patch("nodes._correct_builder_prompt", return_value="corrected prompt") as correct_mock:
+            with patch.object(
+                prompt_artist_mix,
+                "_correct_builder_prompt",
+                return_value="corrected prompt",
+            ) as correct_mock:
                 positive = EasyUseAnimaArtistMixConditioning().encode(
                     object(),
                     prompt="1girl",
@@ -609,7 +624,7 @@ class PromptBuilderTests(unittest.TestCase):
 
         encoded_texts.clear()
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
-            with patch("nodes._correct_builder_prompt") as correct_mock:
+            with patch.object(prompt_artist_mix, "_correct_builder_prompt") as correct_mock:
                 front_positive = EasyUseAnimaArtistMixConditioning().encode(
                     object(),
                     prompt="1girl",
@@ -784,8 +799,12 @@ class PromptBuilderTests(unittest.TestCase):
             lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
         ):
             with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
-                with patch("nodes._find_spectrum_anima_mod_guidance_class", lambda: FakeAnimaModGuidance):
-                    with patch("nodes.logger.warning") as warning_mock:
+                with patch.object(
+                    prompt_conditioning,
+                    "_find_spectrum_anima_mod_guidance_class",
+                    lambda: FakeAnimaModGuidance,
+                ):
+                    with patch.object(prompt_conditioning, "_runtime_logger") as runtime_logger:
                         patched_model, positive, negative, latent_image = EasyUseAnimaPromptDataConditioning().apply(
                             model,
                             clip=clip,
@@ -802,6 +821,7 @@ class PromptBuilderTests(unittest.TestCase):
         self.assertEqual(calls[0]["mod_w_profile"], "step_i14")
         self.assertEqual(calls[0]["positive"], positive)
         self.assertEqual(calls[0]["negative"], negative)
+        warning_mock = runtime_logger.return_value.warning
         warning_mock.assert_called_once()
         self.assertIn("old patch() signature", warning_mock.call_args.args[0])
 
@@ -844,8 +864,12 @@ class PromptBuilderTests(unittest.TestCase):
             lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
         ):
             with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
-                with patch("nodes._find_spectrum_anima_mod_guidance_class", lambda: FakeAnimaModGuidance):
-                    with patch("nodes.logger.warning") as warning_mock:
+                with patch.object(
+                    prompt_conditioning,
+                    "_find_spectrum_anima_mod_guidance_class",
+                    lambda: FakeAnimaModGuidance,
+                ):
+                    with patch.object(prompt_conditioning, "_runtime_logger") as runtime_logger:
                         patched_model, _positive, _negative, _latent_image = EasyUseAnimaPromptDataConditioning().apply(
                             object(),
                             clip=object(),
@@ -859,7 +883,7 @@ class PromptBuilderTests(unittest.TestCase):
             "quality_neg": "worst quality",
             "mod_w_profile": "step_i14",
         }])
-        warning_mock.assert_not_called()
+        runtime_logger.return_value.warning.assert_not_called()
 
     def test_prompt_data_conditioning_average_artist_mix_rebuilds_artist_position(self):
         fields = [
@@ -920,7 +944,7 @@ class PromptBuilderTests(unittest.TestCase):
             ]]
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
-            with patch("nodes._blend_conditionings", fake_blend):
+            with patch.object(prompt_artist_mix, "_blend_conditionings", fake_blend):
                 with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                     _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                         object(),
@@ -1028,7 +1052,7 @@ class PromptBuilderTests(unittest.TestCase):
             return [["tail", {"strength": kwargs.get("branch_strength")}]]
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
-            with patch("nodes._encode_artist_delta_rms", fake_delta):
+            with patch.object(prompt_artist_mix, "_encode_artist_delta_rms", fake_delta):
                 with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                     _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                         object(),
@@ -1074,8 +1098,8 @@ class PromptBuilderTests(unittest.TestCase):
             return [["clustered", {}]]
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
-            with patch("nodes._encode_artist_delta_rms", fake_delta):
-                with patch("nodes._encode_artist_clustered", fake_clustered):
+            with patch.object(prompt_artist_mix, "_encode_artist_delta_rms", fake_delta):
+                with patch.object(prompt_artist_mix, "_encode_artist_clustered", fake_clustered):
                     with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
                         _model, delta_positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                             object(),
@@ -1189,7 +1213,7 @@ class PromptBuilderTests(unittest.TestCase):
         ]
         with (
             patch(
-                "nodes.resolve_prompt_translation_settings",
+                "easyuse_anima.prompt.correction.resolve_prompt_translation_settings",
                 return_value=PromptTranslationSettings(
                     provider=PROMPT_TRANSLATION_PROVIDER_GOOGLE,
                     source="ko",

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -112,7 +112,6 @@ RUNTIME_BINDER_FAMILIES = {
         "_bind_aio_conditioning_runtime",
         "_bind_aio_node_runtime",
     ),
-    "prompt_services": PROMPT_SERVICE_RUNTIME_BINDERS,
     "prompt_node_adapters": PROMPT_NODE_ADAPTER_RUNTIME_BINDERS,
     "wildcard_naia": (
         "_bind_wildcard_node_runtime",
@@ -2130,6 +2129,8 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30",
                 "B-11c30a",
                 "B-11c30b",
+                "B-11c30c",
+                "B-11c30c1",
             ],
         },
         "enums": {
@@ -2142,14 +2143,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 289,
+            "nodes_canonical_bindings": 283,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 1,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
-            "runtime_binders": 24,
+            "runtime_binders": 18,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2381,7 +2382,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 24)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 18)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2389,21 +2390,21 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 24,
-                "family_count": 4,
+                "binder_count": 18,
+                "family_count": 3,
                 "mode_counts": {
-                    "comfy_provider_then_root": 12,
-                    "root_globals": 10,
+                    "comfy_provider_then_root": 10,
+                    "root_globals": 6,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 273,
-                "unique_root_resolver_names": 267,
-                "unique_provider_resolver_names": 6,
-                "unique_direct_root_dependencies": 11,
-                "direct_root_dependency_slots": 24,
-                "provider_consumer_slots": 17,
-                "provider_consumer_modules": 12,
-                "repository_replacement_names": 158,
+                "unique_resolver_names": 248,
+                "unique_root_resolver_names": 243,
+                "unique_provider_resolver_names": 5,
+                "unique_direct_root_dependencies": 10,
+                "direct_root_dependency_slots": 21,
+                "provider_consumer_slots": 15,
+                "provider_consumer_modules": 10,
+                "repository_replacement_names": 148,
                 "repository_replacement_files": 18,
             },
         )
@@ -2411,7 +2412,10 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             audit["provider_resolver_names"],
             sorted(
                 set(COMFY_HOST_WRAPPERS)
-                - {"_find_comfy_node_mapping_class"}
+                - {
+                    "_find_comfy_node_mapping_class",
+                    "_find_loaded_node_class",
+                }
             ),
         )
         self.assertEqual(
@@ -2468,53 +2472,43 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                     "call_time_resolver",
                 )
 
-    def test_prompt_regional_retirement_subgroups_are_exact(self):
+    def test_prompt_service_binders_are_retired_and_node_adapter_group_is_exact(self):
         audit = self.document["runtime_binder_audit"]
         self.assertNotIn("prompt_regional", audit["families"])
-        self.assertEqual(
-            audit["families"]["prompt_services"],
-            list(PROMPT_SERVICE_RUNTIME_BINDERS),
-        )
+        self.assertNotIn("prompt_services", audit["families"])
         self.assertEqual(
             audit["families"]["prompt_node_adapters"],
             list(PROMPT_NODE_ADAPTER_RUNTIME_BINDERS),
         )
+        self.assertTrue(
+            set(PROMPT_SERVICE_RUNTIME_BINDERS).isdisjoint(
+                self.document["runtime_binders"]
+            )
+        )
+        service_modules = {
+            "_bind_regional_runtime": "easyuse_anima.prompt.regional",
+            "_bind_advanced_runtime": "easyuse_anima.prompt.advanced",
+            "_bind_conditioning_runtime": "easyuse_anima.prompt.conditioning",
+            "_bind_artist_mix_runtime": "easyuse_anima.prompt.artist_mix",
+            "_bind_prompt_fields_runtime": "easyuse_anima.prompt.fields",
+            "_bind_prompt_correction_runtime": "easyuse_anima.prompt.correction",
+        }
+        for binder, module in service_modules.items():
+            functions = {
+                node.name
+                for node in _read_tree(_module_path(module)).body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+            with self.subTest(module=module, binder=binder):
+                self.assertNotIn(binder, functions)
         entries = {
             entry["binder"]: (entry["module"], entry["mode"])
             for entry in audit["entries"]
-            if entry["binder"]
-            in {
-                *PROMPT_SERVICE_RUNTIME_BINDERS,
-                *PROMPT_NODE_ADAPTER_RUNTIME_BINDERS,
-            }
+            if entry["binder"] in PROMPT_NODE_ADAPTER_RUNTIME_BINDERS
         }
         self.assertEqual(
             entries,
             {
-                "_bind_regional_runtime": (
-                    "easyuse_anima.prompt.regional",
-                    "root_globals",
-                ),
-                "_bind_advanced_runtime": (
-                    "easyuse_anima.prompt.advanced",
-                    "root_globals",
-                ),
-                "_bind_conditioning_runtime": (
-                    "easyuse_anima.prompt.conditioning",
-                    "comfy_provider_then_root",
-                ),
-                "_bind_artist_mix_runtime": (
-                    "easyuse_anima.prompt.artist_mix",
-                    "comfy_provider_then_root",
-                ),
-                "_bind_prompt_fields_runtime": (
-                    "easyuse_anima.prompt.fields",
-                    "root_globals",
-                ),
-                "_bind_prompt_correction_runtime": (
-                    "easyuse_anima.prompt.correction",
-                    "root_globals",
-                ),
                 "_bind_regional_node_runtime": (
                     "easyuse_anima.nodes.regional_nodes",
                     "comfy_provider_then_root",
@@ -2541,7 +2535,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             "_AIO_FIRST_PASS_CACHE_ORDER",
             "_load_aio_resources_from_input_context",
             "_sample_latent_with_aio_backend",
-            "_advanced_prompt_with_artist_override",
             "_encode_prompt_data_positive_conditioning",
         }
         consumers = self.document["runtime_resolver_consumers"]

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import nodes as nodes_module
+from easyuse_anima.prompt import advanced as prompt_advanced
 from nodes import (
     EasyUseAnimaPromptStudioAdvanced,
     EasyUseAnimaPromptStudioAdvancedV2,
@@ -1026,8 +1027,9 @@ class WildcardNodeTests(unittest.TestCase):
             def expand_from_test_root(texts, *, seed, mode):
                 return expand_wildcard_texts(texts, seed=seed, mode=mode, roots=[root])
 
-            with patch(
-                "nodes.expand_wildcard_texts",
+            with patch.object(
+                prompt_advanced,
+                "expand_wildcard_texts",
                 side_effect=expand_from_test_root,
             ):
                 first, _ = nodes_module._expand_advanced_wildcard_fields(
@@ -1915,8 +1917,9 @@ class WildcardNodeTests(unittest.TestCase):
             }
         }
 
-        with patch(
-            "nodes.expand_wildcard_texts",
+        with patch.object(
+            prompt_advanced,
+            "expand_wildcard_texts",
             return_value=(WildcardExpansionResult(
                 text="expanded style",
                 changed=True,


### PR DESCRIPTION
## 작업

- Task: B-11c30c1
- Owner: #184
- Type: Move
- Base: `dev` / `d0188b5e687164bdba817c9705c64e23c1262733`
- Production boundary:
  - `nodes.py`
  - `easyuse_anima/prompt/regional.py`
  - `easyuse_anima/prompt/advanced.py`
  - `easyuse_anima/prompt/conditioning.py`
  - `easyuse_anima/prompt/artist_mix.py`
  - `easyuse_anima/prompt/fields.py`
  - `easyuse_anima/prompt/correction.py`
- Contract/docs/gate boundary:
  - `docs/architecture/python-backend-execution-roadmap.md`
  - `docs/architecture/comfy-host-provider-bridge.md`
  - `docs/architecture/python-compatibility-shims.md`
  - `tests/test_python_compatibility_surface.py`
  - `tests/fixtures/python_compatibility_surface.v1.json`
  - `tests/fixtures/comfy_host_compatibility.v1.json`
  - `tests/fixtures/python_backend_baseline.json`
  - `tests/test_nodes_module_analyzer.py`
- Focused test migration boundary:
  - `tests/test_node_contracts.py`
  - `tests/test_prompt_corrector.py`
  - `tests/test_wildcards.py`
  - `tests/test_aio_legacy_generation.py`
  - `tests/test_aio_output.py`
  - `tests/test_aio_preview.py`

경계를 넘어야 하면 production 범위를 임의로 확장하지 않고 blocker로 기록합니다.

## 목적

B-11c30c가 분리한 Prompt/Regional feature-service binder 6개만 제거합니다. ComfyUI node-adapter binder 4개는 B-11c30c2에 남기며, Move와 Contract/Behavior를 섞지 않습니다.

## 작업 전 inventory

### Symbol / caller / alias

| Binder | Canonical owner | Mode | Bound globals | Root resolvers | Provider |
| --- | --- | --- | ---: | ---: | --- |
| `_bind_regional_runtime` | `easyuse_anima.prompt.regional` | `root_globals` | 13 | 13 | - |
| `_bind_advanced_runtime` | `easyuse_anima.prompt.advanced` | `root_globals` | 1 | 21 | - |
| `_bind_conditioning_runtime` | `easyuse_anima.prompt.conditioning` | `comfy_provider_then_root` | 2 | 1 | `_find_loaded_node_class` |
| `_bind_artist_mix_runtime` | `easyuse_anima.prompt.artist_mix` | `comfy_provider_then_root` | 1 | 8 | `_encode_with_comfy_clip` |
| `_bind_prompt_fields_runtime` | `easyuse_anima.prompt.fields` | `root_globals` | 1 | 9 | - |
| `_bind_prompt_correction_runtime` | `easyuse_anima.prompt.correction` | `root_globals` | 3 | 3 | - |

- `nodes.py` package/fallback import 분기에 canonical binder 6개가 각각 존재하고 import-time call site가 6개 있습니다.
- binder 6개는 `transitional_private_seam`이며 supported public API가 아닙니다.
- canonical service의 나머지 root re-export identity, mapped classes, node schema, workflow는 유지합니다.

### Global state / resolver

- bind-time global: 21 slot
- root resolver: 55 slot / 46개 고유 이름
- provider resolver: 2 slot / 2개 고유 이름
- direct root dependency: `_resolve_comfy_host_helper`, `logger` 2개 고유 이름 / 3 slot
- repository replacement evidence: 31 slot / 22개 고유 이름 / 6개 테스트 파일
- Conditioning의 `_SPECTRUM_ANIMA_MOD_GUIDANCE_OLD_SIGNATURE_WARNED` mutable set은 canonical owner에 그대로 유지합니다.

### 구현 경계

- same-feature helper는 canonical module에서 직접 또는 call-time canonical import로 해결합니다.
- Advanced ↔ Artist Mix 순환 경계는 module import 순환을 만들지 않는 call-time canonical resolver로 유지합니다.
- `_find_loaded_node_class`와 `_encode_with_comfy_clip`은 기존 E-07 provider wiring을 call time에 사용합니다.
- 두 provider 소비자의 binder → direct call-time 전환은 Comfy host ledger와 아키텍처 문서에 함께 기록합니다.
- logger 이름과 warning-once 동작을 유지합니다.
- repository root patch는 지원 호환성으로 승격하지 않고 필요한 focused test만 canonical owner patch로 이관합니다.

## 금지 경계

- B-11c30c2 node-adapter binder 제거 금지
- prompt/conditioning 결과, 순서, 예외, warning, seed/wildcard, translation behavior 변경 금지
- node schema, mapping, frontend, workflow serialization 변경 금지
- provider lookup order와 flat pre-bootstrap fallback 변경 금지
- 새 RuntimeServices/Behavior contract 도입 금지

## 검증

### 구현 결과

- root package/fallback import와 import-time call에서 service binder 6개를 제거했습니다.
- canonical service에서 binder 정의, placeholder/resolver global을 제거하고 canonical module owner를 직접 사용합니다.
- Advanced의 legacy `wildcard_engine`은 call-time import를 유지해 direct package import에서 NumPy가 eager-load되지 않습니다.
- Artist Mix `_encode_with_comfy_clip`과 Conditioning `_find_loaded_node_class`는 E-07 provider를 call time에 직접 사용합니다.
- Comfy host ledger는 22 slot / 15 module을 유지합니다.
- 남은 audit은 18 binder / 3 family입니다.
  - provider-then-root 10
  - root-only 6
  - explicit callback 2
- Prompt/Regional node-adapter binder 4개는 변경하지 않았습니다.

### Focused

- `tests.test_node_contracts`: 81 passed
- `tests.test_prompt_corrector`: 139 passed
- `tests.test_wildcards`: 70 passed
- `tests.test_aio_legacy_generation`: 17 passed
- `tests.test_aio_output`: 8 passed
- `tests.test_aio_preview`: 8 passed
- `tests.test_python_compatibility_surface`: 21 passed
- `tests.test_python_package_skeleton`: 1 passed
- `tests.test_nodes_module_analyzer`: 4 passed
- `tests.test_python_backend_analyzer`: 18 passed

### Official full

최종 검증 head: `89d90b6b4642136028c5be2f07c7084f4626b114`

```powershell
powershell -ExecutionPolicy Bypass -File D:\ComfyUI\custom_nodes_workplace\tools\check_custom_node.ps1 `
  -Project D:\ComfyUI\custom_nodes_workplace\worktrees\ComfyUI-EasyUseAnima\codex\b11c30c1-prompt-service-binders `
  -Profile full
```

- Python unittest: 966 passed
- Frontend: 114 JavaScript files passed
- Python compile: passed
- Pyright baseline ratchet: passed (69 files)
- Python import boundary gate: passed
- `git diff --check`: passed
- Ruff: G-01 report-only 기존 72 findings, blocking 실행/config 오류 없음
- Live ComfyUI API/browser smoke: 이 Move에는 미실행

첫 full에서 `nodes.py` analyzer gate drift와 Advanced direct import의 eager
NumPy 로드를 발견했습니다. analyzer 기준을 현재 구조로 갱신하고 legacy
`wildcard_engine`을 call-time import로 복원한 뒤 최종 full을 통과했습니다.

## 남은 경계

- B-11c30c2가 Prompt/Regional node-adapter binder 4개를 별도 Move로 소유합니다.
- schema, workflow, prompt/conditioning 결과, seed 동작, provider lookup order 변경은 없습니다.

Parent: #184. Closes no issue.
