### PR TITLE
B-11c30c2a: Prompt Data·Classic Prompt adapter binder retirement

### DIFF
--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1364,7 +1364,7 @@ All four binders and production callers remain unchanged in this gate.
 
 ### B-11c30c2a — Prompt Data / Classic Prompt adapter Move
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE in PR #342
 - **Owner:** #184
 - **Type:** Move
 - **Base:** `dev@6a21e2667ea5eb8723346d44d8d913444f230b05`
@@ -1388,6 +1388,22 @@ class identity, prompt and conditioning outputs, provider lookup order,
 warning/error behavior, optional-dependency timing, and saved workflows. It
 must not modify the Advanced/Regional adapters, seed reservation, or wildcard
 behavior.
+
+Implementation result:
+
+- root no longer imports or invokes the two binders, and both canonical binder
+  definitions plus their bind-time mutation state are absent;
+- Prompt Data imports canonical prompt/AiO helpers directly and resolves CLIP
+  encoding through the existing E-07 provider at call time;
+- Classic Prompt uses canonical common/prompt helpers and the existing
+  `anima_prompt`/`settings` fallback imports directly;
+- root mapped classes retain direct canonical identity, and adapter tests now
+  replace the canonical adapter/provider seam instead of root-only binder
+  globals;
+- the Comfy host ledger remains 22 slots across 15 modules;
+- the remaining audit is 16 binders in three families: nine
+  provider-then-root, five root-only, and two explicit callbacks; and
+- `nodes.py` is 1,750 lines, down 13 lines from the B-11c30c2 base.
 
 ### B-11d — Final root shim
 
@@ -1433,7 +1449,7 @@ COMPLETE: B-11c30b LoRA binder Move / PR #338
 COMPLETE: B-11c30c Prompt/Regional split gate / PR #339
 COMPLETE: B-11c30c1 Prompt/Regional service binder Move / PR #340
 COMPLETE: B-11c30c2 Prompt/Regional node-adapter split gate / PR #341
-IN PROGRESS: B-11c30c2a Prompt Data / Classic Prompt adapter Move
+COMPLETE: B-11c30c2a Prompt Data / Classic Prompt adapter Move / PR #342
 BLOCKED:  B-11c30c2b Advanced / Regional adapter Move (#167/D-12)
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/comfy-host-provider-bridge.md
+++ b/docs/architecture/comfy-host-provider-bridge.md
@@ -1331,7 +1331,7 @@ Forbidden:
 
 ### B-11c30c2 — Prompt/Regional node-adapter split gate
 
-- **State:** IN PROGRESS
+- **State:** COMPLETE in PR #341 / `6a21e26`
 - **Owner:** #184
 - **Blocker owner:** #167 / D-12
 - **Type:** Contract/gate
@@ -1361,6 +1361,33 @@ Split decision:
 The c2b blocker may not be bypassed with a new callback setter/binder,
 canonical-to-root import, copied reservation logic, or changed seed payload.
 All four binders and production callers remain unchanged in this gate.
+
+### B-11c30c2a — Prompt Data / Classic Prompt adapter Move
+
+- **State:** IN PROGRESS
+- **Owner:** #184
+- **Type:** Move
+- **Base:** `dev@6a21e2667ea5eb8723346d44d8d913444f230b05`
+
+Pre-edit inventory:
+
+- `_bind_prompt_data_node_runtime` and `_bind_prompt_node_runtime` are the only
+  owned binders; Advanced and Regional remain excluded;
+- 12 bind-time global slots cover 12 unique names;
+- 30 root resolver slots cover 27 unique names;
+- Prompt Data has one E-07 provider slot for `_encode_with_comfy_clip` and one
+  direct root dependency on `_resolve_comfy_host_helper`;
+- repository tests replace 20 family slots over 17 unique names; this remains
+  migration-cost evidence, not public compatibility; and
+- neither binder resolves `_consume_reserved_wildcard_next_seed`.
+
+Allowed production files are `nodes.py`,
+`easyuse_anima/nodes/prompt_data_nodes.py`, and
+`easyuse_anima/nodes/prompt_nodes.py`. This Move must preserve schemas, mapped
+class identity, prompt and conditioning outputs, provider lookup order,
+warning/error behavior, optional-dependency timing, and saved workflows. It
+must not modify the Advanced/Regional adapters, seed reservation, or wildcard
+behavior.
 
 ### B-11d — Final root shim
 
@@ -1405,8 +1432,8 @@ COMPLETE: B-11c30a Image/SAM3/Impact binder Move / PR #337
 COMPLETE: B-11c30b LoRA binder Move / PR #338
 COMPLETE: B-11c30c Prompt/Regional split gate / PR #339
 COMPLETE: B-11c30c1 Prompt/Regional service binder Move / PR #340
-IN PROGRESS: B-11c30c2 Prompt/Regional node-adapter split gate
-READY:    B-11c30c2a Prompt Data / Classic Prompt adapter Move
+COMPLETE: B-11c30c2 Prompt/Regional node-adapter split gate / PR #341
+IN PROGRESS: B-11c30c2a Prompt Data / Classic Prompt adapter Move
 BLOCKED:  B-11c30c2b Advanced / Regional adapter Move (#167/D-12)
 BLOCKED:  B-11d final root shim
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -111,7 +111,8 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   Wildcard/NAIA. B-11c30c2 completes the production-free split gate in PR
   #341 / `6a21e26`: c2a owns the Prompt Data and Classic Prompt adapters, while
   c2b owns Advanced and Regional only after #167/D-12 resolves their root
-  seed-reservation dependency. B-11c30c2a is the current Move.
+  seed-reservation dependency. B-11c30c2a completes the unblocked adapter Move
+  in PR #342; c2b remains blocked.
 
 ### Current quality baseline
 
@@ -353,7 +354,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2 PR #341 / `6a21e26`; B-11c30c2a Prompt Data / Classic Prompt adapter Move is current | Move/Contract, split PRs | #184 | c2a is unblocked; c2b waits for #167/D-12 seed reservation ownership |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2a PR #342; the remaining c2b adapters wait on #167/D-12 | Move/Contract, split PRs | #184 | c2b waits for #167/D-12 seed reservation ownership |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1028,11 +1029,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     behavior-preserving owner. Do not add a callback binder, import root
     `nodes.py`, or duplicate seed reservation merely to retire these binders.
   - B-11c30c2a retires only `_bind_prompt_data_node_runtime` and
-    `_bind_prompt_node_runtime`. Prompt Data uses canonical prompt/AiO owners
-    plus the existing E-07 CLIP provider at call time; Classic Prompt uses its
-    canonical prompt, settings, and legacy knowledge-base owners directly.
-    Advanced/Regional binders and seed-reservation behavior remain outside this
-    Move.
+    `_bind_prompt_node_runtime` in PR #342. Prompt Data uses canonical
+    prompt/AiO owners plus the existing E-07 CLIP provider at call time;
+    Classic Prompt uses its canonical prompt, settings, and legacy
+    knowledge-base owners directly. Advanced/Regional binders and
+    seed-reservation behavior remain outside this Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -108,9 +108,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   that split, producing four audited families without changing the 24-binder
   total. B-11c30c1 retires only the six feature-service binders in PR #340 /
   `4cc5cab`, leaving 18 binders across AiO, Prompt node adapters, and
-  Wildcard/NAIA. B-11c30c2 is a production-free split gate: c2a owns the
-  Prompt Data and Classic Prompt adapters, while c2b owns Advanced and Regional
-  only after #167/D-12 resolves their root seed-reservation dependency.
+  Wildcard/NAIA. B-11c30c2 completes the production-free split gate in PR
+  #341 / `6a21e26`: c2a owns the Prompt Data and Classic Prompt adapters, while
+  c2b owns Advanced and Regional only after #167/D-12 resolves their root
+  seed-reservation dependency. B-11c30c2a is the current Move.
 
 ### Current quality baseline
 
@@ -352,7 +353,7 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c1 PR #340 / `4cc5cab`; B-11c30c2 node-adapter split gate is next | Move/Contract, split PRs | #184 | c2a is unblocked; c2b waits for #167/D-12 seed reservation ownership |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2 PR #341 / `6a21e26`; B-11c30c2a Prompt Data / Classic Prompt adapter Move is current | Move/Contract, split PRs | #184 | c2a is unblocked; c2b waits for #167/D-12 seed reservation ownership |
 | 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
@@ -1026,6 +1027,12 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     form B-11c30c2b and remain blocked until #167 S167-01 or D-12 supplies the
     behavior-preserving owner. Do not add a callback binder, import root
     `nodes.py`, or duplicate seed reservation merely to retire these binders.
+  - B-11c30c2a retires only `_bind_prompt_data_node_runtime` and
+    `_bind_prompt_node_runtime`. Prompt Data uses canonical prompt/AiO owners
+    plus the existing E-07 CLIP provider at call time; Classic Prompt uses its
+    canonical prompt, settings, and legacy knowledge-base owners directly.
+    Advanced/Regional binders and seed-reservation behavior remain outside this
+    Move.
   - The final B-11c cutover removes remaining root execution ownership and
     leaves the explicit supported `nodes.py` compatibility shim.
 - Add `easyuse_anima/registration.py` as pure mapping composition. It performs no

--- a/docs/architecture/python-compatibility-shims.md
+++ b/docs/architecture/python-compatibility-shims.md
@@ -8,10 +8,10 @@
 - Policy: [ADR-002](adr-002-compatibility-shims.md)
 - Machine-readable audit:
   [`python_compatibility_surface.v1.json`](../../tests/fixtures/python_compatibility_surface.v1.json)
-- Current state: B-11a through B-11c30c1 are integrated. B-11c is split into
+- Current state: B-11a through B-11c30c2 are integrated. B-11c is split into
   residual-owner Moves and explicit private-contract cleanup before the final
-  root shim; B-11c30c2 separates unblocked adapters from the #167/D-12 seed
-  reservation boundary.
+  root shim; B-11c30c2a retires the unblocked adapters while the #167/D-12 seed
+  reservation boundary remains blocked.
 
 This is an actionable registry, not a removal schedule. `N` means the first
 published Registry release containing both a canonical target and its root
@@ -76,8 +76,8 @@ inferring public support from spelling or test imports:
 - `nodes.py` preamble implementation imports: 5 (`json`, `logging`, `random`,
   `ceil`, and `sqrt`), excluded from compatibility classification
   by an exact AST allowlist and drift gate;
-- `nodes.py` bindings with an `easyuse_anima` canonical target: 283 in B-11c30c1
-  (258 at the integrated B-10b20 baseline), with exact
+- `nodes.py` bindings with an `easyuse_anima` canonical target: 281 in
+  B-11c30c2a (258 at the integrated B-10b20 baseline), with exact
   relative-package/flat-fallback parity;
 - bindings still owned by `anima_prompt`, `settings`, `prompt_translation`, or
   `wildcard_engine`: 27, with the same fallback parity;
@@ -87,8 +87,8 @@ inferring public support from spelling or test imports:
   owner module without a root alias or backend mapping;
 - root-owned residual implementation: 1 function, 0 classes, and 26 assigned
   globals in B-11c29b3 (41/2/33 at the integrated B-10b20 baseline).
-- import-time runtime binders: 18 exact top-level `_bind_*_runtime` calls;
-- root names reached by those canonical runtime resolvers: 243, including
+- import-time runtime binders: 16 exact top-level `_bind_*_runtime` calls;
+- root names reached by those canonical runtime resolvers: 232, including
   literal lookups and binder-owned helper-name/default collections;
 - retired private bindings: `_comfy_checkpoint_names`,
   `_EasyUseAnimaAlignedDetailerHook`, and
@@ -784,6 +784,24 @@ convenience-node compatibility; it remains unmapped and is not public support.
 - Test replacement evidence remains migration cost, not supported-public
   compatibility. Schema, workflow, mapped-class/input-type identity, provider
   timing, and wildcard seed payloads remain unchanged.
+
+### B-11c30c2a Prompt Data / Classic Prompt adapter binder retirement
+
+- Root no longer imports or invokes `_bind_prompt_data_node_runtime` or
+  `_bind_prompt_node_runtime`; their canonical definitions and bind-time
+  mutation state are absent.
+- Prompt Data imports its canonical prompt/AiO helpers directly and keeps CLIP
+  encoding behind the existing call-time E-07 provider. The Comfy host ledger
+  remains 22 slots across 15 modules.
+- Classic Prompt uses canonical common/prompt helpers and the existing
+  `anima_prompt`/`settings` fallback imports directly. Tests that previously
+  patched root only to drive either adapter now patch the adapter owner.
+- The remaining audit is 16 binders in three families: nine
+  provider-then-root, five root-only, and two explicit callbacks.
+- The two Advanced/Regional binders and
+  `_consume_reserved_wildcard_next_seed` stay unchanged under
+  B-11c30c2b/#167/D-12. No schema, saved-workflow, output, provider order,
+  optional-dependency timing, or wildcard seed behavior changes in this Move.
 
 ### `nodes.py` public node-class surface
 

--- a/easyuse_anima/nodes/prompt_data_nodes.py
+++ b/easyuse_anima/nodes/prompt_data_nodes.py
@@ -1,8 +1,10 @@
 """Public adapters for prompt data and artist-mix conditioning."""
 from __future__ import annotations
 
+from ..aio.sampling import _generate_empty_latent_with_comfy
 from ..common.serialization import _stable_change_key
 from ..common.values import _as_bool
+from ..infrastructure.comfy.wiring import resolve_comfy_host_helper
 from ..prompt.artist_mix import (
     ARTIST_MIX_DEFAULT_CLUSTER_COUNT,
     ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION,
@@ -47,48 +49,20 @@ from ..prompt.data import (
     _apply_prompt_data_overrides,
     _normalize_prompt_data,
 )
+from ..prompt.fields import _join_prompt_tokens
 
-_RUNTIME_RESOLVER = None
-_RUNTIME_HELPER_DEFAULTS = {
-    "_as_bool": _as_bool,
-    "_advanced_outputs_from_prompt_data": _advanced_outputs_from_prompt_data,
-    "_apply_prompt_data_overrides": _apply_prompt_data_overrides,
-    "_apply_spectrum_anima_mod_guidance": _apply_spectrum_anima_mod_guidance,
-    "_artist_mix_inline_prompt": _artist_mix_inline_prompt,
-    "_artist_mix_mode_tooltip": _artist_mix_mode_tooltip,
-    "_artist_prompt_with_position": _artist_prompt_with_position,
-    "_bounded_artist_mix_float": _bounded_artist_mix_float,
-    "_bounded_artist_mix_int": _bounded_artist_mix_int,
-    "_encode_prompt_data_positive_conditioning": _encode_prompt_data_positive_conditioning,
-    "_join_artist_mix_source_prompts": _join_artist_mix_source_prompts,
-    "_normalize_anima_mod_guidance_profile": _normalize_anima_mod_guidance_profile,
-    "_normalize_artist_mix_mode": _normalize_artist_mix_mode,
-    "_normalize_artist_tag_position": _normalize_artist_tag_position,
-    "_normalize_prompt_data": _normalize_prompt_data,
-    "_resolve_anima_mod_guidance_enabled": _resolve_anima_mod_guidance_enabled,
-    "_stable_change_key": _stable_change_key,
-}
-_RUNTIME_ONLY_HELPERS = (
-    "_encode_with_comfy_clip",
-    "_generate_empty_latent_with_comfy",
-    "_join_prompt_tokens",
-)
 
-def _runtime_proxy(name: str):
-    def invoke(*args, **kwargs):
-        if _RUNTIME_RESOLVER is not None:
-            return _RUNTIME_RESOLVER(name)(*args, **kwargs)
-        helper = _RUNTIME_HELPER_DEFAULTS.get(name)
-        if helper is None:
-            raise RuntimeError(f"[EasyUseAnima] Prompt data node runtime helper is not bound: {name}")
-        return helper(*args, **kwargs)
-    return invoke
+def _missing_host_helper(name: str):
+    raise RuntimeError(f"Prompt Data Comfy host helper is unavailable: {name}")
 
-def _bind_prompt_data_node_runtime(*, resolve_helper) -> None:
-    global _RUNTIME_RESOLVER
-    _RUNTIME_RESOLVER = resolve_helper
-    for name in (*_RUNTIME_HELPER_DEFAULTS, *_RUNTIME_ONLY_HELPERS):
-        globals()[name] = _runtime_proxy(name)
+
+def _encode_with_comfy_clip(*args, **kwargs):
+    helper = resolve_comfy_host_helper(
+        "_encode_with_comfy_clip",
+        _missing_host_helper,
+    )
+    return helper(*args, **kwargs)
+
 
 class EasyUseAnimaPromptDataUnpack:
     """Expand EASYUSE_ANIMA_PROMPT_DATA into compatibility outputs."""

--- a/easyuse_anima/nodes/prompt_nodes.py
+++ b/easyuse_anima/nodes/prompt_nodes.py
@@ -27,31 +27,6 @@ except ImportError:
     from settings import resolve_metadata_filter_words
 
 
-def _bind_prompt_node_runtime(*, resolve_helper) -> None:
-    global _as_bool, _stable_change_key, _prompt_translation_change_key
-    global _split_tag_text, _translate_prompt_text, correct_prompt, load_knowledge_base
-    global _correct_builder_prompt, _filter_metadata_prompt, _join_prompt_tokens
-    global resolve_metadata_filter_words
-
-    def runtime_helper(name):
-        def call(*args, **kwargs):
-            return resolve_helper(name)(*args, **kwargs)
-
-        return call
-
-    _as_bool = runtime_helper("_as_bool")
-    _stable_change_key = runtime_helper("_stable_change_key")
-    _prompt_translation_change_key = runtime_helper("_prompt_translation_change_key")
-    _split_tag_text = runtime_helper("_split_tag_text")
-    _translate_prompt_text = runtime_helper("_translate_prompt_text")
-    _correct_builder_prompt = runtime_helper("_correct_builder_prompt")
-    _filter_metadata_prompt = runtime_helper("_filter_metadata_prompt")
-    _join_prompt_tokens = runtime_helper("_join_prompt_tokens")
-    correct_prompt = runtime_helper("correct_prompt")
-    load_knowledge_base = runtime_helper("load_knowledge_base")
-    resolve_metadata_filter_words = runtime_helper("resolve_metadata_filter_words")
-
-
 def _correct_prompt_with_report(
     prompt: str,
     artist_overrides: str,

--- a/nodes.py
+++ b/nodes.py
@@ -347,7 +347,6 @@ try:
         EasyUseAnimaArtistMixConditioning as EasyUseAnimaArtistMixConditioning,
         EasyUseAnimaPromptDataConditioning as EasyUseAnimaPromptDataConditioning,
         EasyUseAnimaPromptDataUnpack as EasyUseAnimaPromptDataUnpack,
-        _bind_prompt_data_node_runtime as _bind_prompt_data_node_runtime,
     )
     from .easyuse_anima.nodes.input_types import (
         _ANY_TYPE as _ANY_TYPE,
@@ -435,7 +434,6 @@ try:
         EasyUseAnimaPromptCorrector as EasyUseAnimaPromptCorrector,
         EasyUseAnimaPromptCorrectorSimple as EasyUseAnimaPromptCorrectorSimple,
         EasyUseAnimaPromptStudio as EasyUseAnimaPromptStudio,
-        _bind_prompt_node_runtime as _bind_prompt_node_runtime,
     )
     from .easyuse_anima.nodes.regional_nodes import (
         EasyUseAnimaPromptStudioRegional as EasyUseAnimaPromptStudioRegional,
@@ -890,7 +888,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaArtistMixConditioning as EasyUseAnimaArtistMixConditioning,
         EasyUseAnimaPromptDataConditioning as EasyUseAnimaPromptDataConditioning,
         EasyUseAnimaPromptDataUnpack as EasyUseAnimaPromptDataUnpack,
-        _bind_prompt_data_node_runtime as _bind_prompt_data_node_runtime,
     )
     from easyuse_anima.nodes.input_types import (
         _ANY_TYPE as _ANY_TYPE,
@@ -978,7 +975,6 @@ except ImportError:  # allows simple local import tests outside ComfyUI's packag
         EasyUseAnimaPromptCorrector as EasyUseAnimaPromptCorrector,
         EasyUseAnimaPromptCorrectorSimple as EasyUseAnimaPromptCorrectorSimple,
         EasyUseAnimaPromptStudio as EasyUseAnimaPromptStudio,
-        _bind_prompt_node_runtime as _bind_prompt_node_runtime,
     )
     from easyuse_anima.nodes.regional_nodes import (
         EasyUseAnimaPromptStudioRegional as EasyUseAnimaPromptStudioRegional,
@@ -1737,15 +1733,6 @@ _bind_prompt_advanced_node_runtime(
     flexible_optional_input_type=_FlexibleOptionalInputType,
 )
 _bind_aio_node_runtime(
-    resolve_helper=lambda name: globals()[name],
-)
-_bind_prompt_data_node_runtime(
-    resolve_helper=lambda name: _resolve_comfy_host_helper(
-        name,
-        lambda fallback_name: globals()[fallback_name],
-    ),
-)
-_bind_prompt_node_runtime(
     resolve_helper=lambda name: globals()[name],
 )
 _bind_wildcard_node_runtime(

--- a/tests/fixtures/comfy_host_compatibility.v1.json
+++ b/tests/fixtures/comfy_host_compatibility.v1.json
@@ -113,7 +113,7 @@
         },
         {
           "module": "easyuse_anima.nodes.prompt_data_nodes",
-          "binder": "_bind_prompt_data_node_runtime",
+          "binder": null,
           "root_observation": "call_time"
         },
         {

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -10346,6 +10346,24 @@
       },
       {
         "alias": null,
+        "bound_name": "_generate_empty_latent_with_comfy",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..aio.sampling:_generate_empty_latent_with_comfy",
+        "kind": "static_from",
+        "line": 4,
+        "name": "_generate_empty_latent_with_comfy",
+        "optional": false,
+        "requested": "..aio.sampling",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_data_nodes.py",
+        "target": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "alias": null,
         "bound_name": "_stable_change_key",
         "branch_context": [],
         "classification": "internal",
@@ -10353,7 +10371,7 @@
         "conditional": false,
         "imported": "..common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 4,
+        "line": 5,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "..common.serialization",
@@ -10371,7 +10389,7 @@
         "conditional": false,
         "imported": "..common.values:_as_bool",
         "kind": "static_from",
-        "line": 5,
+        "line": 6,
         "name": "_as_bool",
         "optional": false,
         "requested": "..common.values",
@@ -10382,6 +10400,24 @@
       },
       {
         "alias": null,
+        "bound_name": "resolve_comfy_host_helper",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..infrastructure.comfy.wiring:resolve_comfy_host_helper",
+        "kind": "static_from",
+        "line": 7,
+        "name": "resolve_comfy_host_helper",
+        "optional": false,
+        "requested": "..infrastructure.comfy.wiring",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_data_nodes.py",
+        "target": "easyuse_anima/infrastructure/comfy/wiring.py"
+      },
+      {
+        "alias": null,
         "bound_name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "branch_context": [],
         "classification": "internal",
@@ -10389,7 +10425,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10407,7 +10443,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10425,7 +10461,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10443,7 +10479,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10461,7 +10497,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10479,7 +10515,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10497,7 +10533,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10515,7 +10551,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10533,7 +10569,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10551,7 +10587,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_MODES",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_MODES",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10569,7 +10605,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10587,7 +10623,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_MIX_MODE_PROMPT",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_MIX_MODE_PROMPT",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10605,7 +10641,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_TAG_POSITION_CORRECT",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_TAG_POSITION_CORRECT",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10623,7 +10659,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:ARTIST_TAG_POSITION_MODES",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "ARTIST_TAG_POSITION_MODES",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10641,7 +10677,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10659,7 +10695,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10677,7 +10713,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10695,7 +10731,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10713,7 +10749,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10731,7 +10767,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10749,7 +10785,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10767,7 +10803,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10785,7 +10821,7 @@
         "conditional": false,
         "imported": "..prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 6,
+        "line": 8,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "..prompt.artist_mix",
@@ -10803,7 +10839,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10821,7 +10857,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10839,7 +10875,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10857,7 +10893,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILES",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "ANIMA_MOD_GUIDANCE_PROFILES",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10875,7 +10911,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10893,7 +10929,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10911,7 +10947,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10929,7 +10965,7 @@
         "conditional": false,
         "imported": "..prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 31,
+        "line": 33,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "..prompt.conditioning",
@@ -10947,7 +10983,7 @@
         "conditional": false,
         "imported": "..prompt.data:PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "PROMPT_DATA_COMPAT_OUTPUT_TOOLTIPS",
         "optional": false,
         "requested": "..prompt.data",
@@ -10965,7 +11001,7 @@
         "conditional": false,
         "imported": "..prompt.data:PROMPT_DATA_COMPAT_RETURN_NAMES",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "PROMPT_DATA_COMPAT_RETURN_NAMES",
         "optional": false,
         "requested": "..prompt.data",
@@ -10983,7 +11019,7 @@
         "conditional": false,
         "imported": "..prompt.data:PROMPT_DATA_COMPAT_RETURN_TYPES",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "PROMPT_DATA_COMPAT_RETURN_TYPES",
         "optional": false,
         "requested": "..prompt.data",
@@ -11001,7 +11037,7 @@
         "conditional": false,
         "imported": "..prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "..prompt.data",
@@ -11019,7 +11055,7 @@
         "conditional": false,
         "imported": "..prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "..prompt.data",
@@ -11037,7 +11073,7 @@
         "conditional": false,
         "imported": "..prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "..prompt.data",
@@ -11055,7 +11091,7 @@
         "conditional": false,
         "imported": "..prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 41,
+        "line": 43,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "..prompt.data",
@@ -11063,6 +11099,24 @@
         "scope": "<module>",
         "source": "easyuse_anima/nodes/prompt_data_nodes.py",
         "target": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "_join_prompt_tokens",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": "..prompt.fields:_join_prompt_tokens",
+        "kind": "static_from",
+        "line": 52,
+        "name": "_join_prompt_tokens",
+        "optional": false,
+        "requested": "..prompt.fields",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/nodes/prompt_data_nodes.py",
+        "target": "easyuse_anima/prompt/fields.py"
       },
       {
         "alias": null,
@@ -22030,37 +22084,6 @@
         "target": "easyuse_anima/nodes/prompt_data_nodes.py"
       },
       {
-        "alias": "_bind_prompt_data_node_runtime",
-        "bound_name": "_bind_prompt_data_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_data_node_runtime",
-          "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
-        "kind": "static_from",
-        "line": 346,
-        "name": "_bind_prompt_data_node_runtime",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.prompt_data_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_data_nodes.py"
-      },
-      {
         "alias": "_ANY_TYPE",
         "bound_name": "_ANY_TYPE",
         "branch_context": [
@@ -22082,7 +22105,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 352,
+        "line": 351,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -22113,7 +22136,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 352,
+        "line": 351,
         "name": "_AnyType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -22144,7 +22167,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 352,
+        "line": 351,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": ".easyuse_anima.nodes.input_types",
@@ -22175,7 +22198,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 357,
+        "line": 356,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -22206,7 +22229,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 357,
+        "line": 356,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -22237,7 +22260,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 357,
+        "line": 356,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_advanced_nodes",
@@ -22268,7 +22291,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 363,
+        "line": 362,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22299,7 +22322,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 363,
+        "line": 362,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22330,7 +22353,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 363,
+        "line": 362,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22361,7 +22384,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 363,
+        "line": 362,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22392,7 +22415,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 363,
+        "line": 362,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22423,7 +22446,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 363,
+        "line": 362,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22454,7 +22477,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 363,
+        "line": 362,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": ".easyuse_anima.nodes.aio_nodes",
@@ -22485,7 +22508,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 372,
+        "line": 371,
         "name": "_align_down",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22516,7 +22539,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 372,
+        "line": 371,
         "name": "_align_nearest",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22547,7 +22570,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 372,
+        "line": 371,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": ".easyuse_anima.image.geometry",
@@ -22578,7 +22601,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 383,
+        "line": 382,
         "name": "_context_value",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22609,7 +22632,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 383,
+        "line": 382,
         "name": "_sam3_context",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22640,7 +22663,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 383,
+        "line": 382,
         "name": "_segs_has_items",
         "optional": false,
         "requested": ".easyuse_anima.image.sam3",
@@ -22671,7 +22694,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 395,
+        "line": 394,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22702,7 +22725,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 395,
+        "line": 394,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": ".easyuse_anima.image.scaling",
@@ -22733,7 +22756,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 403,
+        "line": 402,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22764,7 +22787,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 403,
+        "line": 402,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22795,7 +22818,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 403,
+        "line": 402,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.capabilities",
@@ -22826,7 +22849,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 409,
+        "line": 408,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22857,7 +22880,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 409,
+        "line": 408,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22888,7 +22911,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 409,
+        "line": 408,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.invocation",
@@ -22919,7 +22942,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 414,
+        "line": 413,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.wiring",
@@ -22950,7 +22973,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -22981,7 +23004,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23012,7 +23035,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23043,7 +23066,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23074,7 +23097,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 417,
+        "line": 416,
         "name": "_folder_path_names",
         "optional": false,
         "requested": ".easyuse_anima.infrastructure.comfy.resources",
@@ -23105,7 +23128,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 425,
+        "line": 424,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23136,7 +23159,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 425,
+        "line": 424,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.image_nodes",
@@ -23167,7 +23190,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23198,7 +23221,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 429,
+        "line": 428,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": ".easyuse_anima.nodes.sam3_nodes",
@@ -23229,7 +23252,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23260,7 +23283,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23291,7 +23314,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
@@ -23322,39 +23345,8 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 433,
+        "line": 432,
         "name": "EasyUseAnimaPromptStudio",
-        "optional": false,
-        "requested": ".easyuse_anima.nodes.prompt_nodes",
-        "role": "compatibility_primary",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_nodes.py"
-      },
-      {
-        "alias": "_bind_prompt_node_runtime",
-        "bound_name": "_bind_prompt_node_runtime",
-        "branch_context": [
-          {
-            "branch": "body",
-            "handles_import_failure": true,
-            "has_import_fallback_handler": true,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "internal",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_node_runtime",
-          "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": ".easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
-        "kind": "static_from",
-        "line": 433,
-        "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.prompt_nodes",
         "role": "compatibility_primary",
@@ -23384,7 +23376,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 440,
+        "line": 438,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23415,7 +23407,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 440,
+        "line": 438,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23446,7 +23438,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 440,
+        "line": 438,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.regional_nodes",
@@ -23477,7 +23469,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 445,
+        "line": 443,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23508,7 +23500,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 445,
+        "line": 443,
         "name": "_parse_random_response",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23539,7 +23531,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 445,
+        "line": 443,
         "name": "_post_random",
         "optional": false,
         "requested": ".easyuse_anima.naia.client",
@@ -23570,7 +23562,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 463,
+        "line": 461,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23601,7 +23593,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 463,
+        "line": 461,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23632,7 +23624,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 463,
+        "line": 461,
         "name": "_ratio_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23663,7 +23655,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 463,
+        "line": 461,
         "name": "_resolution_label",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23694,7 +23686,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 463,
+        "line": 461,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": ".easyuse_anima.naia.resolution",
@@ -23725,7 +23717,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 486,
+        "line": 484,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23756,7 +23748,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 486,
+        "line": 484,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.naia_nodes",
@@ -23787,7 +23779,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 490,
+        "line": 488,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23818,7 +23810,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 490,
+        "line": 488,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": ".easyuse_anima.nodes.wildcard_nodes",
@@ -23849,7 +23841,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23880,7 +23872,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23911,7 +23903,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23942,7 +23934,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_get_lora_info",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -23973,7 +23965,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24004,7 +23996,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24035,7 +24027,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24066,7 +24058,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24097,7 +24089,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24128,7 +24120,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24159,7 +24151,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24190,7 +24182,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24221,7 +24213,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24252,7 +24244,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 495,
+        "line": 493,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": ".easyuse_anima.lora.metadata",
@@ -24283,7 +24275,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24314,7 +24306,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_format_strength",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24345,7 +24337,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_get_loras_list",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24376,7 +24368,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_load_profile_data",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24407,7 +24399,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_profile_key",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24438,7 +24430,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_select_profile_values",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24469,7 +24461,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 511,
+        "line": 509,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": ".easyuse_anima.lora.preset",
@@ -24500,7 +24492,7 @@
         "conditional": true,
         "imported": ".easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 520,
+        "line": 518,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": ".easyuse_anima.nodes.lora_nodes",
@@ -24531,7 +24523,7 @@
         "conditional": true,
         "imported": ".anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 523,
+        "line": 521,
         "name": "correct_prompt",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24562,7 +24554,7 @@
         "conditional": true,
         "imported": ".anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 523,
+        "line": 521,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": ".anima_prompt",
@@ -24593,7 +24585,7 @@
         "conditional": true,
         "imported": ".anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 524,
+        "line": 522,
         "name": "parse_prompt",
         "optional": false,
         "requested": ".anima_prompt.parser",
@@ -24624,7 +24616,7 @@
         "conditional": true,
         "imported": ".settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 525,
+        "line": 523,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": ".settings",
@@ -24655,7 +24647,7 @@
         "conditional": true,
         "imported": ".settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 523,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": ".settings",
@@ -24686,7 +24678,7 @@
         "conditional": true,
         "imported": ".settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 525,
+        "line": 523,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": ".settings",
@@ -24717,7 +24709,7 @@
         "conditional": true,
         "imported": ".prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 530,
+        "line": 528,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24748,7 +24740,7 @@
         "conditional": true,
         "imported": ".prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 530,
+        "line": 528,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": ".prompt_translation",
@@ -24779,7 +24771,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24810,7 +24802,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24841,7 +24833,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24872,7 +24864,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24903,7 +24895,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24934,7 +24926,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24965,7 +24957,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -24996,7 +24988,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25027,7 +25019,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25058,7 +25050,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25089,7 +25081,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25120,7 +25112,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25151,7 +25143,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "expand_wildcards",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25182,7 +25174,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25213,7 +25205,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "next_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25244,7 +25236,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25275,7 +25267,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "normalize_seed",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25306,7 +25298,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25337,7 +25329,7 @@
         "conditional": true,
         "imported": ".wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 531,
+        "line": 529,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": ".wildcard_engine",
@@ -25356,7 +25348,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25371,7 +25363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25390,7 +25382,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25405,7 +25397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "_AIO_FIRST_PASS_CACHE",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25424,7 +25416,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25439,7 +25431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "_AIO_FIRST_PASS_CACHE_ORDER",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25458,7 +25450,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25473,7 +25465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "_aio_first_pass_cache_key",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25492,7 +25484,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25507,7 +25499,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "_bind_aio_first_pass_cache_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25526,7 +25518,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25541,7 +25533,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "_clone_aio_cache_value",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25560,7 +25552,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25575,7 +25567,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "_get_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25594,7 +25586,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25609,7 +25601,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "name": "_put_aio_first_pass_cache",
         "optional": false,
         "requested": "easyuse_anima.aio.first_pass_cache",
@@ -25628,7 +25620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25643,7 +25635,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_bind_aio_legacy_generation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25662,7 +25654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25677,7 +25669,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_run_aio_detailer_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25696,7 +25688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25711,7 +25703,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_run_aio_detailer_target",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25730,7 +25722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25745,7 +25737,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_run_aio_highres_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25764,7 +25756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25779,7 +25771,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_run_aio_legacy_generation",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25798,7 +25790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25813,7 +25805,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_run_aio_resshift_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25832,7 +25824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25847,7 +25839,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_run_aio_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25866,7 +25858,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25881,7 +25873,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "name": "_run_aio_usdu_upscale_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.legacy_generation",
@@ -25900,7 +25892,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25915,7 +25907,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "AIO_SPECIAL_SEEDS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25934,7 +25926,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25949,7 +25941,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "AIO_SPECIAL_SEED_DECREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -25968,7 +25960,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -25983,7 +25975,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "AIO_SPECIAL_SEED_INCREMENT",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26002,7 +25994,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26017,7 +26009,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "AIO_SPECIAL_SEED_RANDOM",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26036,7 +26028,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26051,7 +26043,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_AIO_DETAILER_CUSTOM_RE",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26070,7 +26062,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26085,7 +26077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_AIO_DETAILER_RESERVED_KEYS",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26104,7 +26096,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26119,7 +26111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_aio_detailer_has_enabled_targets",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26138,7 +26130,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26153,7 +26145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_aio_detailer_target_defaults",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26172,7 +26164,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26187,7 +26179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_aio_detailer_target_order",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26206,7 +26198,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26221,7 +26213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_bind_aio_generation_normalization_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26240,7 +26232,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26255,7 +26247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_is_aio_detailer_target_name",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26274,7 +26266,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26289,7 +26281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_merge_versioned_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26308,7 +26300,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26323,7 +26315,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_normalize_aio_dit_corrections_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26342,7 +26334,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26357,7 +26349,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_normalize_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26376,7 +26368,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26391,7 +26383,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_normalize_aio_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26410,7 +26402,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26425,7 +26417,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "name": "_normalize_aio_spectrum_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_normalization",
@@ -26444,7 +26436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26459,7 +26451,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 590,
         "name": "round_trip_aio_generation_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.generation_settings",
@@ -26478,7 +26470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26493,7 +26485,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "name": "_aio_usdu_auto_tile_dimension",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26512,7 +26504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26527,7 +26519,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "name": "_aio_usdu_tile_plan",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26546,7 +26538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26561,7 +26553,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "name": "_bind_aio_usdu_planning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.usdu",
@@ -26580,7 +26572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26595,7 +26587,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "name": "_aio_final_fit_size",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26614,7 +26606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26629,7 +26621,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "name": "_apply_aio_final_fit",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26648,7 +26640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26663,7 +26655,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "name": "_bind_aio_postprocess_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26682,7 +26674,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26697,7 +26689,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "name": "_resize_image_to_size_if_needed",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26716,7 +26708,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26731,7 +26723,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "name": "_run_aio_postprocess_stage",
         "optional": false,
         "requested": "easyuse_anima.aio.postprocess",
@@ -26750,7 +26742,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26765,7 +26757,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "name": "_aio_prompt_data_fields_for_usdu",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26784,7 +26776,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26799,7 +26791,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "name": "_aio_usdu_conditioning",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26818,7 +26810,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26833,7 +26825,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "name": "_aio_usdu_prompt_without_general",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26852,7 +26844,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26867,7 +26859,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "name": "_bind_aio_conditioning_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.conditioning",
@@ -26886,7 +26878,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26901,7 +26893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_aio_lora_stack_signature",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26920,7 +26912,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26935,7 +26927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_anima_dave_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26954,7 +26946,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -26969,7 +26961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_kj_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -26988,7 +26980,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27003,7 +26995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27022,7 +27014,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27037,7 +27029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_model_patches",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27056,7 +27048,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27071,7 +27063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_safe_pag_patch",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27090,7 +27082,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27105,7 +27097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27124,7 +27116,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27139,7 +27131,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27158,7 +27150,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27173,7 +27165,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27192,7 +27184,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27207,7 +27199,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_bind_aio_model_preparation_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27226,7 +27218,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27241,7 +27233,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_cleanup_aio_ephemeral_model",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27260,7 +27252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27275,7 +27267,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_normalize_aio_lora_stack",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27294,7 +27286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27309,7 +27301,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "name": "_patch_model_sampling_aura_flow",
         "optional": false,
         "requested": "easyuse_anima.aio.model_preparation",
@@ -27328,7 +27320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27343,7 +27335,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_aio_highres_effective_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27362,7 +27354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27377,7 +27369,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_aio_stage_sampler_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27396,7 +27388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27411,7 +27403,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_bind_aio_sampling_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27430,7 +27422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27445,7 +27437,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_decode_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27464,7 +27456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27479,7 +27471,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_encode_image_with_comfy_vae",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27498,7 +27490,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27513,7 +27505,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_generate_empty_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27532,7 +27524,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27547,7 +27539,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_new_aio_random_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27566,7 +27558,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27581,7 +27573,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_resolve_aio_runtime_seed",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27600,7 +27592,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27615,7 +27607,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_sample_latent_with_aio_backend",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27634,7 +27626,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27649,7 +27641,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_sample_latent_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27668,7 +27660,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27683,7 +27675,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_sample_latent_with_spectrum_mod_guidance_advanced",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27702,7 +27694,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27717,7 +27709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "name": "_sample_latent_with_spectrum_spd",
         "optional": false,
         "requested": "easyuse_anima.aio.sampling",
@@ -27736,7 +27728,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27751,7 +27743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "AIO_PREVIEW_CACHE_FORMAT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27770,7 +27762,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27785,7 +27777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "AIO_PREVIEW_CACHE_QUALITY",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27804,7 +27796,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27819,7 +27811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "AIO_PREVIEW_EVENT",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27838,7 +27830,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27853,7 +27845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "AIO_PREVIEW_STAGE_LABELS",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27872,7 +27864,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27887,7 +27879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_aio_preview_base_directory",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27906,7 +27898,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27921,7 +27913,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_aio_preview_file_size_bytes",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27940,7 +27932,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27955,7 +27947,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_bind_aio_preview_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -27974,7 +27966,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -27989,7 +27981,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_save_aio_temp_preview_image",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28008,7 +28000,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28023,7 +28015,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_send_aio_preview_event",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28042,7 +28034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28057,7 +28049,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "name": "_tag_aio_preview_images",
         "optional": false,
         "requested": "easyuse_anima.aio.preview",
@@ -28076,7 +28068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28091,7 +28083,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_aio_image_saver_additional_hashes",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28110,7 +28102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28125,7 +28117,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_aio_image_saver_civitai_hash_fetcher_entries",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28144,7 +28136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28159,7 +28151,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_aio_lora_metadata_name",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28178,7 +28170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28193,7 +28185,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_aio_prompt_with_lora_metadata",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28212,7 +28204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28227,7 +28219,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_aio_save_filename_prefix",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28246,7 +28238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28261,7 +28253,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_bind_aio_output_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28280,7 +28272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28295,7 +28287,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_normalize_aio_civitai_hash_fetchers",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28314,7 +28306,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28329,7 +28321,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_normalize_aio_hash_bundles",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28348,7 +28340,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28363,7 +28355,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_save_image_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28382,7 +28374,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28397,7 +28389,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "name": "_save_image_with_image_saver",
         "optional": false,
         "requested": "easyuse_anima.aio.output",
@@ -28416,7 +28408,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28431,7 +28423,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_bind_aio_resource_runtime",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28450,7 +28442,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28465,7 +28457,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28484,7 +28476,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28499,7 +28491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28518,7 +28510,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28533,7 +28525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28552,7 +28544,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28567,7 +28559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28586,7 +28578,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28601,7 +28593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_load_aio_resources_from_input_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28620,7 +28612,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28635,7 +28627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_load_aio_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28654,7 +28646,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28669,7 +28661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_load_checkpoint_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28688,7 +28680,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28703,7 +28695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_load_clip_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28722,7 +28714,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28737,7 +28729,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_load_diffusion_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28756,7 +28748,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28771,7 +28763,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_load_upscale_model_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28790,7 +28782,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28805,7 +28797,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_load_vae_with_comfy",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28824,7 +28816,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28839,7 +28831,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_normalize_aio_input_settings",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28858,7 +28850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28873,7 +28865,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_preferred_checkpoint_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28892,7 +28884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28907,7 +28899,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_preferred_clip_type_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28926,7 +28918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28941,7 +28933,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "name": "_preferred_name_default",
         "optional": false,
         "requested": "easyuse_anima.aio.resources",
@@ -28960,7 +28952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -28975,7 +28967,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 684,
+        "line": 682,
         "name": "_json_clone",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -28994,7 +28986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29009,7 +29001,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 684,
+        "line": 682,
         "name": "_json_object",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29028,7 +29020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29043,7 +29035,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 684,
+        "line": 682,
         "name": "_stable_change_key",
         "optional": false,
         "requested": "easyuse_anima.common.serialization",
@@ -29062,7 +29054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29077,7 +29069,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "name": "_as_bool",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29096,7 +29088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29111,7 +29103,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "name": "_as_float",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29130,7 +29122,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29145,7 +29137,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "name": "_as_int",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29164,7 +29156,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29179,7 +29171,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "name": "_choice",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29198,7 +29190,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29213,7 +29205,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "name": "_single_value",
         "optional": false,
         "requested": "easyuse_anima.common.values",
@@ -29232,7 +29224,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29247,7 +29239,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 696,
+        "line": 694,
         "name": "_get_workflow_node",
         "optional": false,
         "requested": "easyuse_anima.workflow",
@@ -29266,7 +29258,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29281,7 +29273,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "name": "_prompt_translation_change_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29300,7 +29292,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29315,7 +29307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "name": "_split_tag_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29334,7 +29326,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29349,7 +29341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "name": "_translate_prompt_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.correction",
@@ -29368,7 +29360,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29383,7 +29375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_HASH_COMMENT_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29402,7 +29394,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29417,7 +29409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_INLINE_SPACE_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29436,7 +29428,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29451,7 +29443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_WEIGHTED_TOKEN_RE",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29470,7 +29462,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29485,7 +29477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_correct_builder_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29504,7 +29496,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29519,7 +29511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_filter_metadata_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29538,7 +29530,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29553,7 +29545,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_join_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29572,7 +29564,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29587,7 +29579,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_metadata_filter_key",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29606,7 +29598,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29621,7 +29613,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_metadata_filter_keys",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29640,7 +29632,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29655,7 +29647,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "name": "_prompt_tokens",
         "optional": false,
         "requested": "easyuse_anima.prompt.fields",
@@ -29674,7 +29666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29689,7 +29681,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "PROMPT_DATA_TYPE",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29708,7 +29700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29723,7 +29715,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_advanced_outputs_from_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29742,7 +29734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29757,7 +29749,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_apply_prompt_data_overrides",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29776,7 +29768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29791,7 +29783,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_copy_prompt_data_for_update",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29810,7 +29802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29825,7 +29817,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_normalize_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29844,7 +29836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29859,7 +29851,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_prompt_data_json_safe",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29878,7 +29870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29893,7 +29885,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "name": "_prompt_data_parameter_snapshot",
         "optional": false,
         "requested": "easyuse_anima.prompt.data",
@@ -29912,7 +29904,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29927,7 +29919,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_artist_field_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29946,7 +29938,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29961,7 +29953,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_default_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -29980,7 +29972,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -29995,7 +29987,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_enabled_naia_panes",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30014,7 +30006,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30029,7 +30021,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_enabled_pane_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30048,7 +30040,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30063,7 +30055,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_field_input_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30082,7 +30074,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30097,7 +30089,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_field_socket_name",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30116,7 +30108,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30131,7 +30123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30150,7 +30142,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30165,7 +30157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_has_enabled_naia",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30184,7 +30176,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30199,7 +30191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_prompt_with_artist_override",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30218,7 +30210,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30233,7 +30225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_advanced_uses_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30252,7 +30244,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30267,7 +30259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_apply_advanced_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30286,7 +30278,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30301,7 +30293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_as_advanced_height",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30320,7 +30312,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30335,7 +30327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_build_advanced_prompt_data",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30354,7 +30346,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30369,7 +30361,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_build_advanced_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30388,7 +30380,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30403,7 +30395,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_clone_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30422,7 +30414,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30437,7 +30429,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_correct_advanced_field_sequence",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30456,7 +30448,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30471,7 +30463,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_expand_advanced_wildcard_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30490,7 +30482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30505,7 +30497,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_normalize_advanced_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30524,7 +30516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30539,7 +30531,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_normalize_prompt_studio_wildcard_seed_control",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30558,7 +30550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30573,7 +30565,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_set_naia_field_text",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30592,7 +30584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30607,7 +30599,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "name": "_translate_prompt_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.advanced",
@@ -30626,7 +30618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30641,7 +30633,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_apply_regional_field_inputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30660,7 +30652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30675,7 +30667,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_build_regional_outputs",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30694,7 +30686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30709,7 +30701,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_clone_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30728,7 +30720,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30743,7 +30735,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_conditioning_set_values",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30762,7 +30754,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30777,7 +30769,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_normalize_mask_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30796,7 +30788,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30811,7 +30803,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_normalize_regional_config",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30830,7 +30822,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30845,7 +30837,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_normalize_regional_fields",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30864,7 +30856,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30879,7 +30871,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_parse_json_object",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30898,7 +30890,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30913,7 +30905,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_regional_config_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30932,7 +30924,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30947,7 +30939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_regional_fields_json",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -30966,7 +30958,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -30981,7 +30973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_regional_mask_bounds_area",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31000,7 +30992,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31015,7 +31007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_regional_payload_canvas",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31034,7 +31026,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31049,7 +31041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "name": "_regional_union_mask_for_ids",
         "optional": false,
         "requested": "easyuse_anima.prompt.regional",
@@ -31068,7 +31060,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31083,7 +31075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31102,7 +31094,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31117,7 +31109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "ANIMA_MOD_GUIDANCE_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31136,7 +31128,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31151,7 +31143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31170,7 +31162,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31185,7 +31177,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31204,7 +31196,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31219,7 +31211,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "_apply_spectrum_anima_mod_guidance",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31238,7 +31230,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31253,7 +31245,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "_find_spectrum_anima_mod_guidance_class",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31272,7 +31264,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31287,7 +31279,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "_normalize_anima_mod_guidance_profile",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31306,7 +31298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31321,7 +31313,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "name": "_resolve_anima_mod_guidance_enabled",
         "optional": false,
         "requested": "easyuse_anima.prompt.conditioning",
@@ -31340,7 +31332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31355,7 +31347,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31374,7 +31366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31389,7 +31381,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31408,7 +31400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31423,7 +31415,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31442,7 +31434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31457,7 +31449,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31476,7 +31468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31491,7 +31483,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31510,7 +31502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31525,7 +31517,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_START_PERCENT",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31544,7 +31536,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31559,7 +31551,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31578,7 +31570,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31593,7 +31585,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31612,7 +31604,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31627,7 +31619,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_INPUT_MODES",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31646,7 +31638,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31661,7 +31653,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31680,7 +31672,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31695,7 +31687,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_artist_mix_inline_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31714,7 +31706,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31729,7 +31721,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_artist_mix_mode_tooltip",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31748,7 +31740,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31763,7 +31755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_artist_prompt_with_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31782,7 +31774,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31797,7 +31789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_artist_tags_from_prompt",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31816,7 +31808,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31831,7 +31823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_blend_conditionings",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31850,7 +31842,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31865,7 +31857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_bounded_artist_mix_float",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31884,7 +31876,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31899,7 +31891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_bounded_artist_mix_int",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31918,7 +31910,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31933,7 +31925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_encode_artist_clustered",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31952,7 +31944,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -31967,7 +31959,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_encode_artist_delta_rms",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -31986,7 +31978,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32001,7 +31993,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_encode_prompt_data_positive_conditioning",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32020,7 +32012,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32035,7 +32027,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_join_artist_mix_source_prompts",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32054,7 +32046,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32069,7 +32061,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_normalize_artist_mix_mode",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32088,7 +32080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32103,7 +32095,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_normalize_artist_tag_position",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32122,7 +32114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32137,7 +32129,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "name": "_parse_artist_mix_items",
         "optional": false,
         "requested": "easyuse_anima.prompt.artist_mix",
@@ -32156,7 +32148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32171,7 +32163,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 889,
+        "line": 887,
         "name": "EasyUseAnimaArtistMixConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32190,7 +32182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32205,7 +32197,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 889,
+        "line": 887,
         "name": "EasyUseAnimaPromptDataConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
@@ -32224,7 +32216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32239,42 +32231,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 889,
+        "line": 887,
         "name": "EasyUseAnimaPromptDataUnpack",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.prompt_data_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_data_nodes.py"
-      },
-      {
-        "alias": "_bind_prompt_data_node_runtime",
-        "bound_name": "_bind_prompt_data_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_data_node_runtime",
-          "target": "easyuse_anima/nodes/prompt_data_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
-        "kind": "static_from",
-        "line": 889,
-        "name": "_bind_prompt_data_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_data_nodes",
         "role": "compatibility_fallback",
@@ -32292,7 +32250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32307,7 +32265,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 895,
+        "line": 892,
         "name": "_ANY_TYPE",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32326,7 +32284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32341,7 +32299,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 895,
+        "line": 892,
         "name": "_AnyType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32360,7 +32318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32375,7 +32333,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 895,
+        "line": 892,
         "name": "_FlexibleOptionalInputType",
         "optional": false,
         "requested": "easyuse_anima.nodes.input_types",
@@ -32394,7 +32352,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32409,7 +32367,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 900,
+        "line": 897,
         "name": "EasyUseAnimaPromptStudioAdvanced",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32428,7 +32386,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32443,7 +32401,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 900,
+        "line": 897,
         "name": "EasyUseAnimaPromptStudioAdvancedV2",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32462,7 +32420,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32477,7 +32435,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 897,
         "name": "_bind_prompt_advanced_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -32496,7 +32454,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32511,7 +32469,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "name": "EasyUseAnimaAIOGenerator",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32530,7 +32488,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32545,7 +32503,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "name": "EasyUseAnimaInput",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32564,7 +32522,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32579,7 +32537,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "name": "_aio_generation_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32598,7 +32556,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32613,7 +32571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "name": "_aio_input_settings_json",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32632,7 +32590,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32647,7 +32605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "name": "_bind_aio_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32666,7 +32624,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32681,7 +32639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "name": "_easy_use_anima_input_signature",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32700,7 +32658,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32715,7 +32673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "name": "_require_easy_use_anima_input",
         "optional": false,
         "requested": "easyuse_anima.nodes.aio_nodes",
@@ -32734,7 +32692,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32749,7 +32707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "name": "_align_down",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32768,7 +32726,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32783,7 +32741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "name": "_align_nearest",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32802,7 +32760,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32817,7 +32775,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "name": "_image_tensor_size",
         "optional": false,
         "requested": "easyuse_anima.image.geometry",
@@ -32836,7 +32794,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32851,7 +32809,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 926,
+        "line": 923,
         "name": "_context_value",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32870,7 +32828,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32885,7 +32843,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 926,
+        "line": 923,
         "name": "_sam3_context",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32904,7 +32862,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32919,7 +32877,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 926,
+        "line": 923,
         "name": "_segs_has_items",
         "optional": false,
         "requested": "easyuse_anima.image.sam3",
@@ -32938,7 +32896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32953,7 +32911,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 938,
+        "line": 935,
         "name": "IMAGE_SCALE_MULTIPLES",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -32972,7 +32930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -32987,7 +32945,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 938,
+        "line": 935,
         "name": "IMAGE_UPSCALE_METHODS",
         "optional": false,
         "requested": "easyuse_anima.image.scaling",
@@ -33006,7 +32964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33021,7 +32979,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 943,
         "name": "_comfy_sampler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33040,7 +32998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33055,7 +33013,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 943,
         "name": "_comfy_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33074,7 +33032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33089,7 +33047,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 943,
         "name": "_impact_scheduler_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.capabilities",
@@ -33108,7 +33066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33123,7 +33081,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 952,
+        "line": 949,
         "name": "_call_with_supported_kwargs",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33142,7 +33100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33157,7 +33115,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 952,
+        "line": 949,
         "name": "_common_upscale_image",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33176,7 +33134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33191,7 +33149,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 952,
+        "line": 949,
         "name": "_node_output_tuple",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.invocation",
@@ -33210,7 +33168,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33225,7 +33183,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 957,
+        "line": 954,
         "name": "resolve_comfy_host_helper",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.wiring",
@@ -33244,7 +33202,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33259,7 +33217,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "name": "_comfy_clip_loader_types",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33278,7 +33236,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33293,7 +33251,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "name": "_comfy_diffusion_model_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33312,7 +33270,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33327,7 +33285,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "name": "_comfy_text_encoder_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33346,7 +33304,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33361,7 +33319,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "name": "_comfy_vae_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33380,7 +33338,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33395,7 +33353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "name": "_folder_path_names",
         "optional": false,
         "requested": "easyuse_anima.infrastructure.comfy.resources",
@@ -33414,7 +33372,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33429,7 +33387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 968,
+        "line": 965,
         "name": "EasyUseAnimaDetailerAlignHook",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33448,7 +33406,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33463,7 +33421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 968,
+        "line": 965,
         "name": "EasyUseAnimaImageScaleByMultiple",
         "optional": false,
         "requested": "easyuse_anima.nodes.image_nodes",
@@ -33482,7 +33440,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33497,7 +33455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 972,
+        "line": 969,
         "name": "EasyUseAnimaSAM3Context",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33516,7 +33474,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33531,7 +33489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 972,
+        "line": 969,
         "name": "EasyUseAnimaSAM3Detailer",
         "optional": false,
         "requested": "easyuse_anima.nodes.sam3_nodes",
@@ -33550,7 +33508,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33565,7 +33523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "name": "EasyUseAnimaPromptBuilder",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33584,7 +33542,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33599,7 +33557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "name": "EasyUseAnimaPromptCorrector",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33618,7 +33576,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33633,7 +33591,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "name": "EasyUseAnimaPromptCorrectorSimple",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
@@ -33652,7 +33610,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33667,42 +33625,8 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "name": "EasyUseAnimaPromptStudio",
-        "optional": false,
-        "requested": "easyuse_anima.nodes.prompt_nodes",
-        "role": "compatibility_fallback",
-        "scope": "<module>",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_nodes.py"
-      },
-      {
-        "alias": "_bind_prompt_node_runtime",
-        "bound_name": "_bind_prompt_node_runtime",
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "column": 4,
-        "compatibility_pair": {
-          "bound_name": "_bind_prompt_node_runtime",
-          "target": "easyuse_anima/nodes/prompt_nodes.py",
-          "try_line": 9
-        },
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
-        "kind": "static_from",
-        "line": 976,
-        "name": "_bind_prompt_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.prompt_nodes",
         "role": "compatibility_fallback",
@@ -33720,7 +33644,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33735,7 +33659,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 983,
+        "line": 979,
         "name": "EasyUseAnimaPromptStudioRegional",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33754,7 +33678,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33769,7 +33693,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 983,
+        "line": 979,
         "name": "EasyUseAnimaRegionalConditioning",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33788,7 +33712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33803,7 +33727,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 979,
         "name": "_bind_regional_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.regional_nodes",
@@ -33822,7 +33746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33837,7 +33761,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 988,
+        "line": 984,
         "name": "LATENT_ALIGN",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33856,7 +33780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33871,7 +33795,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 988,
+        "line": 984,
         "name": "_parse_random_response",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33890,7 +33814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33905,7 +33829,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 988,
+        "line": 984,
         "name": "_post_random",
         "optional": false,
         "requested": "easyuse_anima.naia.client",
@@ -33924,7 +33848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33939,7 +33863,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "_advanced_resolution_from_selection",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33958,7 +33882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -33973,7 +33897,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "_normalize_resolution_bucket",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -33992,7 +33916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34007,7 +33931,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "_ratio_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34026,7 +33950,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34041,7 +33965,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "_resolution_label",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34060,7 +33984,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34075,7 +33999,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "name": "_resolve_naia_resolution",
         "optional": false,
         "requested": "easyuse_anima.naia.resolution",
@@ -34094,7 +34018,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34109,7 +34033,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1025,
         "name": "EasyUseAnimaNAIARandomPrompt",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34128,7 +34052,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34143,7 +34067,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1025,
         "name": "_bind_naia_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.naia_nodes",
@@ -34162,7 +34086,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34177,7 +34101,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1029,
         "name": "EasyUseAnimaWildcard",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34196,7 +34120,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34211,7 +34135,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1029,
         "name": "_bind_wildcard_node_runtime",
         "optional": false,
         "requested": "easyuse_anima.nodes.wildcard_nodes",
@@ -34230,7 +34154,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34245,7 +34169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_apply_lora_syntax_format",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34264,7 +34188,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34279,7 +34203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_dedupe_text_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34298,7 +34222,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34313,7 +34237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_fallback_lora_path",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34332,7 +34256,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34347,7 +34271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_get_lora_info",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34366,7 +34290,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34381,7 +34305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_get_lora_manager_trigger_words",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34400,7 +34324,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34415,7 +34339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_load_lora_manager_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34434,7 +34358,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34449,7 +34373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_lora_combo_values",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34468,7 +34392,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34483,7 +34407,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_lora_manager_trigger_words_from_metadata",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34502,7 +34426,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34517,7 +34441,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_lora_model_exists",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34536,7 +34460,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34551,7 +34475,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_lora_stack_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34570,7 +34494,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34585,7 +34509,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_metadata_json_paths_for_lora",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34604,7 +34528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34619,7 +34543,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_missing_lora_display_name",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34638,7 +34562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34653,7 +34577,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_raise_missing_loras",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34672,7 +34596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34687,7 +34611,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "name": "_trigger_words_from_value",
         "optional": false,
         "requested": "easyuse_anima.lora.metadata",
@@ -34706,7 +34630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34721,7 +34645,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "name": "_correct_style_prompt",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34740,7 +34664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34755,7 +34679,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "name": "_format_strength",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34774,7 +34698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34789,7 +34713,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "name": "_get_loras_list",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34808,7 +34732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34823,7 +34747,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "name": "_load_profile_data",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34842,7 +34766,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34857,7 +34781,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "name": "_profile_key",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34876,7 +34800,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34891,7 +34815,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "name": "_select_profile_values",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34910,7 +34834,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34925,7 +34849,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "name": "_wrap_profile_index",
         "optional": false,
         "requested": "easyuse_anima.lora.preset",
@@ -34944,7 +34868,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34959,7 +34883,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1059,
         "name": "EasyUseAnimaLoraPreset",
         "optional": false,
         "requested": "easyuse_anima.nodes.lora_nodes",
@@ -34978,7 +34902,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -34993,7 +34917,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1062,
         "name": "correct_prompt",
         "optional": false,
         "requested": "anima_prompt",
@@ -35012,7 +34936,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35027,7 +34951,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1062,
         "name": "load_knowledge_base",
         "optional": false,
         "requested": "anima_prompt",
@@ -35046,7 +34970,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35061,7 +34985,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "name": "parse_prompt",
         "optional": false,
         "requested": "anima_prompt.parser",
@@ -35080,7 +35004,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35095,7 +35019,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "name": "resolve_metadata_filter_words",
         "optional": false,
         "requested": "settings",
@@ -35114,7 +35038,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35129,7 +35053,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "name": "resolve_naia_settings",
         "optional": false,
         "requested": "settings",
@@ -35148,7 +35072,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35163,7 +35087,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "name": "resolve_prompt_translation_settings",
         "optional": false,
         "requested": "settings",
@@ -35182,7 +35106,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35197,7 +35121,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "has_prompt_translation_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35216,7 +35140,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35231,7 +35155,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "name": "translate_prompt_markers",
         "optional": false,
         "requested": "prompt_translation",
@@ -35250,7 +35174,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35265,7 +35189,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35284,7 +35208,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35299,7 +35223,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35318,7 +35242,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35333,7 +35257,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "PUBLIC_MAX_SEED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35352,7 +35276,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35367,7 +35291,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "SEED_CONTROL_DECREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35386,7 +35310,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35401,7 +35325,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "SEED_CONTROL_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35420,7 +35344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35435,7 +35359,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "SEED_CONTROL_INCREMENT",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35454,7 +35378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35469,7 +35393,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "SEED_CONTROL_MODES",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35488,7 +35412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35503,7 +35427,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "SEED_CONTROL_RANDOMIZE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35522,7 +35446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35537,7 +35461,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "WILDCARD_MODE_FIXED",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35556,7 +35480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35571,7 +35495,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "WILDCARD_MODE_POPULATE",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35590,7 +35514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35605,7 +35529,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "WILDCARD_MODE_SEQUENTIAL",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35624,7 +35548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35639,7 +35563,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "expand_wildcard_texts",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35658,7 +35582,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35673,7 +35597,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "expand_wildcards",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35692,7 +35616,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35707,7 +35631,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "has_wildcard_syntax",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35726,7 +35650,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35741,7 +35665,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "next_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35760,7 +35684,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35775,7 +35699,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "normalize_prompt_studio_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35794,7 +35718,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35809,7 +35733,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "normalize_seed",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35828,7 +35752,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35843,7 +35767,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "normalize_wildcard_mode",
         "optional": false,
         "requested": "wildcard_engine",
@@ -35862,7 +35786,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -35877,7 +35801,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "name": "wildcard_sources_signature",
         "optional": false,
         "requested": "wildcard_engine",
@@ -37701,11 +37625,19 @@
       },
       {
         "from": "easyuse_anima/nodes/prompt_data_nodes.py",
+        "to": "easyuse_anima/aio/sampling.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_data_nodes.py",
         "to": "easyuse_anima/common/serialization.py"
       },
       {
         "from": "easyuse_anima/nodes/prompt_data_nodes.py",
         "to": "easyuse_anima/common/values.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_data_nodes.py",
+        "to": "easyuse_anima/infrastructure/comfy/wiring.py"
       },
       {
         "from": "easyuse_anima/nodes/prompt_data_nodes.py",
@@ -37718,6 +37650,10 @@
       {
         "from": "easyuse_anima/nodes/prompt_data_nodes.py",
         "to": "easyuse_anima/prompt/data.py"
+      },
+      {
+        "from": "easyuse_anima/nodes/prompt_data_nodes.py",
+        "to": "easyuse_anima/prompt/fields.py"
       },
       {
         "from": "easyuse_anima/nodes/prompt_nodes.py",
@@ -39443,25 +39379,25 @@
       },
       {
         "is_package": false,
-        "loc": 710,
+        "loc": 684,
         "module": "easyuse_anima.nodes.prompt_data_nodes",
-        "normalized_git_blob_sha1": "3a719e1a2c5de2abebe607a09b1c74da2d64f21f",
+        "normalized_git_blob_sha1": "731c230f60c67b8c3b1a96a11a364eddf0e7fb51",
         "path": "easyuse_anima/nodes/prompt_data_nodes.py",
         "top_level": {
           "class_count": 3,
           "function_count": 2,
-          "global_count": 4
+          "global_count": 1
         }
       },
       {
         "is_package": false,
-        "loc": 421,
+        "loc": 396,
         "module": "easyuse_anima.nodes.prompt_nodes",
-        "normalized_git_blob_sha1": "780e6d6ec323bc5c74e9daa9d1130b4a14f95c8f",
+        "normalized_git_blob_sha1": "c4f34e7fec7302235ac01e8ed3198493071992be",
         "path": "easyuse_anima/nodes/prompt_nodes.py",
         "top_level": {
           "class_count": 4,
-          "function_count": 2,
+          "function_count": 1,
           "global_count": 1
         }
       },
@@ -39671,9 +39607,9 @@
       },
       {
         "is_package": false,
-        "loc": 1763,
+        "loc": 1750,
         "module": "nodes",
-        "normalized_git_blob_sha1": "1815fadba3e329f88f95cc8aa29002e86b0b7a24",
+        "normalized_git_blob_sha1": "50d59e888edad18fa357a5ed0d9e46ac0b3b521f",
         "path": "nodes.py",
         "top_level": {
           "class_count": 0,
@@ -41129,7 +41065,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41138,7 +41074,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:AIO_FIRST_PASS_CACHE_MAX_ENTRIES",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41152,7 +41088,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41161,7 +41097,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41175,7 +41111,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41184,7 +41120,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_AIO_FIRST_PASS_CACHE_ORDER",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41198,7 +41134,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41207,7 +41143,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_aio_first_pass_cache_key",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41221,7 +41157,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41230,7 +41166,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_bind_aio_first_pass_cache_runtime",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41244,7 +41180,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41253,7 +41189,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_clone_aio_cache_value",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41267,7 +41203,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41276,7 +41212,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_get_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41290,7 +41226,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41299,7 +41235,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.first_pass_cache:_put_aio_first_pass_cache",
         "kind": "static_from",
-        "line": 553,
+        "line": 551,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41313,7 +41249,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41322,7 +41258,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_bind_aio_legacy_generation_runtime",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41336,7 +41272,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41345,7 +41281,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41359,7 +41295,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41368,7 +41304,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_detailer_target",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41382,7 +41318,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41391,7 +41327,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_highres_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41405,7 +41341,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41414,7 +41350,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_legacy_generation",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41428,7 +41364,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41437,7 +41373,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_resshift_upscale_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41451,7 +41387,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41460,7 +41396,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_upscale_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41474,7 +41410,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41483,7 +41419,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.legacy_generation:_run_aio_usdu_upscale_stage",
         "kind": "static_from",
-        "line": 564,
+        "line": 562,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41497,7 +41433,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41506,7 +41442,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEEDS",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41520,7 +41456,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41529,7 +41465,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_DECREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41543,7 +41479,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41552,7 +41488,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_INCREMENT",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41566,7 +41502,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41575,7 +41511,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:AIO_SPECIAL_SEED_RANDOM",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41589,7 +41525,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41598,7 +41534,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_CUSTOM_RE",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41612,7 +41548,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41621,7 +41557,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_AIO_DETAILER_RESERVED_KEYS",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41635,7 +41571,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41644,7 +41580,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_has_enabled_targets",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41658,7 +41594,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41667,7 +41603,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_defaults",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41681,7 +41617,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41690,7 +41626,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_aio_detailer_target_order",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41704,7 +41640,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41713,7 +41649,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_bind_aio_generation_normalization_runtime",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41727,7 +41663,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41736,7 +41672,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_is_aio_detailer_target_name",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41750,7 +41686,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41759,7 +41695,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_merge_versioned_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41773,7 +41709,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41782,7 +41718,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_dit_corrections_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41796,7 +41732,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41805,7 +41741,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_generation_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41819,7 +41755,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41828,7 +41764,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_seed",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41842,7 +41778,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41851,7 +41787,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_normalization:_normalize_aio_spectrum_settings",
         "kind": "static_from",
-        "line": 574,
+        "line": 572,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41865,7 +41801,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41874,7 +41810,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.generation_settings:round_trip_aio_generation_settings",
         "kind": "static_from",
-        "line": 592,
+        "line": 590,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41888,7 +41824,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41897,7 +41833,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_auto_tile_dimension",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41911,7 +41847,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41920,7 +41856,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_aio_usdu_tile_plan",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41934,7 +41870,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41943,7 +41879,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.usdu:_bind_aio_usdu_planning_runtime",
         "kind": "static_from",
-        "line": 595,
+        "line": 593,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41957,7 +41893,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41966,7 +41902,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_aio_final_fit_size",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -41980,7 +41916,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -41989,7 +41925,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_apply_aio_final_fit",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42003,7 +41939,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42012,7 +41948,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_bind_aio_postprocess_runtime",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42026,7 +41962,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42035,7 +41971,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_resize_image_to_size_if_needed",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42049,7 +41985,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42058,7 +41994,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.postprocess:_run_aio_postprocess_stage",
         "kind": "static_from",
-        "line": 600,
+        "line": 598,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42072,7 +42008,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42081,7 +42017,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_prompt_data_fields_for_usdu",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42095,7 +42031,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42104,7 +42040,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_conditioning",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42118,7 +42054,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42127,7 +42063,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_aio_usdu_prompt_without_general",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42141,7 +42077,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42150,7 +42086,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.conditioning:_bind_aio_conditioning_runtime",
         "kind": "static_from",
-        "line": 607,
+        "line": 605,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42164,7 +42100,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42173,7 +42109,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_aio_lora_stack_signature",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42187,7 +42123,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42196,7 +42132,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_anima_dave_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42210,7 +42146,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42219,7 +42155,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_kj_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42233,7 +42169,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42242,7 +42178,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42256,7 +42192,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42265,7 +42201,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_model_patches",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42279,7 +42215,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42288,7 +42224,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_safe_pag_patch",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42302,7 +42238,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42311,7 +42247,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_correction_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42325,7 +42261,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42334,7 +42270,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42348,7 +42284,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42357,7 +42293,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_apply_aio_spectrum_model_patches_for_comfy_sampler",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42371,7 +42307,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42380,7 +42316,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_bind_aio_model_preparation_runtime",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42394,7 +42330,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42403,7 +42339,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_cleanup_aio_ephemeral_model",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42417,7 +42353,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42426,7 +42362,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_normalize_aio_lora_stack",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42440,7 +42376,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42449,7 +42385,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.model_preparation:_patch_model_sampling_aura_flow",
         "kind": "static_from",
-        "line": 613,
+        "line": 611,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42463,7 +42399,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42472,7 +42408,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_highres_effective_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42486,7 +42422,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42495,7 +42431,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_aio_stage_sampler_settings",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42509,7 +42445,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42518,7 +42454,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_bind_aio_sampling_runtime",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42532,7 +42468,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42541,7 +42477,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_decode_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42555,7 +42491,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42564,7 +42500,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_encode_image_with_comfy_vae",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42578,7 +42514,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42587,7 +42523,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_generate_empty_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42601,7 +42537,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42610,7 +42546,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_new_aio_random_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42624,7 +42560,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42633,7 +42569,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_resolve_aio_runtime_seed",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42647,7 +42583,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42656,7 +42592,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_aio_backend",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42670,7 +42606,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42679,7 +42615,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_comfy",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42693,7 +42629,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42702,7 +42638,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_mod_guidance_advanced",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42716,7 +42652,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42725,7 +42661,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.sampling:_sample_latent_with_spectrum_spd",
         "kind": "static_from",
-        "line": 628,
+        "line": 626,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42739,7 +42675,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42748,7 +42684,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_FORMAT",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42762,7 +42698,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42771,7 +42707,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_CACHE_QUALITY",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42785,7 +42721,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42794,7 +42730,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_EVENT",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42808,7 +42744,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42817,7 +42753,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:AIO_PREVIEW_STAGE_LABELS",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42831,7 +42767,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42840,7 +42776,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_base_directory",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42854,7 +42790,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42863,7 +42799,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_aio_preview_file_size_bytes",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42877,7 +42813,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42886,7 +42822,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_bind_aio_preview_runtime",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42900,7 +42836,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42909,7 +42845,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_save_aio_temp_preview_image",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42923,7 +42859,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42932,7 +42868,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_send_aio_preview_event",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42946,7 +42882,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42955,7 +42891,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.preview:_tag_aio_preview_images",
         "kind": "static_from",
-        "line": 642,
+        "line": 640,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42969,7 +42905,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -42978,7 +42914,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_additional_hashes",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -42992,7 +42928,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43001,7 +42937,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_image_saver_civitai_hash_fetcher_entries",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43015,7 +42951,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43024,7 +42960,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_lora_metadata_name",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43038,7 +42974,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43047,7 +42983,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_prompt_with_lora_metadata",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43061,7 +42997,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43070,7 +43006,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_aio_save_filename_prefix",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43084,7 +43020,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43093,7 +43029,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_bind_aio_output_runtime",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43107,7 +43043,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43116,7 +43052,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_civitai_hash_fetchers",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43130,7 +43066,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43139,7 +43075,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_normalize_aio_hash_bundles",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43153,7 +43089,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43162,7 +43098,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_comfy",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43176,7 +43112,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43185,7 +43121,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.output:_save_image_with_image_saver",
         "kind": "static_from",
-        "line": 654,
+        "line": 652,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43199,7 +43135,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43208,7 +43144,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_bind_aio_resource_runtime",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43222,7 +43158,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43231,7 +43167,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43245,7 +43181,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43254,7 +43190,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43268,7 +43204,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43277,7 +43213,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43291,7 +43227,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43300,7 +43236,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43314,7 +43250,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43323,7 +43259,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_resources_from_input_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43337,7 +43273,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43346,7 +43282,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_aio_sam3_context",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43360,7 +43296,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43369,7 +43305,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_checkpoint_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43383,7 +43319,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43392,7 +43328,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_clip_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43406,7 +43342,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43415,7 +43351,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_diffusion_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43429,7 +43365,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43438,7 +43374,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_upscale_model_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43452,7 +43388,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43461,7 +43397,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_load_vae_with_comfy",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43475,7 +43411,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43484,7 +43420,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_normalize_aio_input_settings",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43498,7 +43434,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43507,7 +43443,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_checkpoint_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43521,7 +43457,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43530,7 +43466,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_clip_type_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43544,7 +43480,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43553,7 +43489,7 @@
         "conditional": true,
         "imported": "easyuse_anima.aio.resources:_preferred_name_default",
         "kind": "static_from",
-        "line": 666,
+        "line": 664,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43567,7 +43503,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43576,7 +43512,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_clone",
         "kind": "static_from",
-        "line": 684,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43590,7 +43526,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43599,7 +43535,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_json_object",
         "kind": "static_from",
-        "line": 684,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43613,7 +43549,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43622,7 +43558,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.serialization:_stable_change_key",
         "kind": "static_from",
-        "line": 684,
+        "line": 682,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43636,7 +43572,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43645,7 +43581,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_bool",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43659,7 +43595,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43668,7 +43604,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_float",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43682,7 +43618,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43691,7 +43627,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_as_int",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43705,7 +43641,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43714,7 +43650,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_choice",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43728,7 +43664,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43737,7 +43673,7 @@
         "conditional": true,
         "imported": "easyuse_anima.common.values:_single_value",
         "kind": "static_from",
-        "line": 689,
+        "line": 687,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43751,7 +43687,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43760,7 +43696,7 @@
         "conditional": true,
         "imported": "easyuse_anima.workflow:_get_workflow_node",
         "kind": "static_from",
-        "line": 696,
+        "line": 694,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43774,7 +43710,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43783,7 +43719,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_prompt_translation_change_key",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43797,7 +43733,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43806,7 +43742,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_split_tag_text",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43820,7 +43756,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43829,7 +43765,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.correction:_translate_prompt_text",
         "kind": "static_from",
-        "line": 697,
+        "line": 695,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43843,7 +43779,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43852,7 +43788,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_HASH_COMMENT_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43866,7 +43802,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43875,7 +43811,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_INLINE_SPACE_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43889,7 +43825,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43898,7 +43834,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_WEIGHTED_TOKEN_RE",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43912,7 +43848,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43921,7 +43857,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_correct_builder_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43935,7 +43871,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43944,7 +43880,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_filter_metadata_prompt",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43958,7 +43894,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43967,7 +43903,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_join_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -43981,7 +43917,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -43990,7 +43926,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_key",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44004,7 +43940,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44013,7 +43949,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_metadata_filter_keys",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44027,7 +43963,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44036,7 +43972,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.fields:_prompt_tokens",
         "kind": "static_from",
-        "line": 702,
+        "line": 700,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44050,7 +43986,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44059,7 +43995,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:PROMPT_DATA_TYPE",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44073,7 +44009,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44082,7 +44018,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_advanced_outputs_from_prompt_data",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44096,7 +44032,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44105,7 +44041,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_apply_prompt_data_overrides",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44119,7 +44055,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44128,7 +44064,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_copy_prompt_data_for_update",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44142,7 +44078,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44151,7 +44087,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_normalize_prompt_data",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44165,7 +44101,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44174,7 +44110,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_json_safe",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44188,7 +44124,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44197,7 +44133,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.data:_prompt_data_parameter_snapshot",
         "kind": "static_from",
-        "line": 715,
+        "line": 713,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44211,7 +44147,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44220,7 +44156,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_artist_field_prompt",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44234,7 +44170,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44243,7 +44179,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_default_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44257,7 +44193,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44266,7 +44202,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_naia_panes",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44280,7 +44216,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44289,7 +44225,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_enabled_pane_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44303,7 +44239,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44312,7 +44248,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_input_values",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44326,7 +44262,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44335,7 +44271,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_field_socket_name",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44349,7 +44285,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44358,7 +44294,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_fields_json",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44372,7 +44308,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44381,7 +44317,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_has_enabled_naia",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44395,7 +44331,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44404,7 +44340,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_prompt_with_artist_override",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44418,7 +44354,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44427,7 +44363,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_advanced_uses_naia_resolution",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44441,7 +44377,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44450,7 +44386,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_apply_advanced_field_inputs",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44464,7 +44400,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44473,7 +44409,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_as_advanced_height",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44487,7 +44423,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44496,7 +44432,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompt_data",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44510,7 +44446,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44519,7 +44455,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_build_advanced_prompts",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44533,7 +44469,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44542,7 +44478,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_clone_advanced_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44556,7 +44492,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44565,7 +44501,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_correct_advanced_field_sequence",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44579,7 +44515,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44588,7 +44524,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_expand_advanced_wildcard_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44602,7 +44538,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44611,7 +44547,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_advanced_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44625,7 +44561,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44634,7 +44570,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_normalize_prompt_studio_wildcard_seed_control",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44648,7 +44584,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44657,7 +44593,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_set_naia_field_text",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44671,7 +44607,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44680,7 +44616,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.advanced:_translate_prompt_fields",
         "kind": "static_from",
-        "line": 733,
+        "line": 731,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44694,7 +44630,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44703,7 +44639,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_apply_regional_field_inputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44717,7 +44653,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44726,7 +44662,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_build_regional_outputs",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44740,7 +44676,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44749,7 +44685,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_clone_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44763,7 +44699,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44772,7 +44708,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_conditioning_set_values",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44786,7 +44722,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44795,7 +44731,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_mask_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44809,7 +44745,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44818,7 +44754,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_config",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44832,7 +44768,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44841,7 +44777,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_normalize_regional_fields",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44855,7 +44791,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44864,7 +44800,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_parse_json_object",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44878,7 +44814,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44887,7 +44823,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_config_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44901,7 +44837,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44910,7 +44846,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_fields_json",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44924,7 +44860,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44933,7 +44869,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_mask_bounds_area",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44947,7 +44883,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44956,7 +44892,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_payload_canvas",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44970,7 +44906,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -44979,7 +44915,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.regional:_regional_union_mask_for_ids",
         "kind": "static_from",
-        "line": 768,
+        "line": 766,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -44993,7 +44929,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45002,7 +44938,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_DEFAULT_PROFILE",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45016,7 +44952,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45025,7 +44961,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODES",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45039,7 +44975,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45048,7 +44984,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45062,7 +44998,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45071,7 +45007,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:ANIMA_MOD_GUIDANCE_PROFILE_OFF",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45085,7 +45021,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45094,7 +45030,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_apply_spectrum_anima_mod_guidance",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45108,7 +45044,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45117,7 +45053,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_find_spectrum_anima_mod_guidance_class",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45131,7 +45067,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45140,7 +45076,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_normalize_anima_mod_guidance_profile",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45154,7 +45090,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45163,7 +45099,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.conditioning:_resolve_anima_mod_guidance_enabled",
         "kind": "static_from",
-        "line": 795,
+        "line": 793,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45177,7 +45113,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45186,7 +45122,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_CLUSTER_COUNT",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45200,7 +45136,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45209,7 +45145,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_ISOLATION",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45223,7 +45159,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45232,7 +45168,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_DOMINANT_THRESHOLD",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45246,7 +45182,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45255,7 +45191,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_EXACT_TOP_K",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45269,7 +45205,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45278,7 +45214,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_RMS_SCALE_CAP",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45292,7 +45228,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45301,7 +45237,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_START_PERCENT",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45315,7 +45251,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45324,7 +45260,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STRENGTH_SCALE",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45338,7 +45274,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45347,7 +45283,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45361,7 +45297,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45370,7 +45306,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_INPUT_MODES",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45384,7 +45320,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45393,7 +45329,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:ARTIST_MIX_MODE_FROM_PROMPT_DATA",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45407,7 +45343,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45416,7 +45352,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_inline_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45430,7 +45366,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45439,7 +45375,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_mix_mode_tooltip",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45453,7 +45389,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45462,7 +45398,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_prompt_with_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45476,7 +45412,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45485,7 +45421,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_artist_tags_from_prompt",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45499,7 +45435,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45508,7 +45444,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_blend_conditionings",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45522,7 +45458,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45531,7 +45467,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_float",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45545,7 +45481,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45554,7 +45490,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_bounded_artist_mix_int",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45568,7 +45504,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45577,7 +45513,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_clustered",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45591,7 +45527,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45600,7 +45536,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_artist_delta_rms",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45614,7 +45550,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45623,7 +45559,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_encode_prompt_data_positive_conditioning",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45637,7 +45573,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45646,7 +45582,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_join_artist_mix_source_prompts",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45660,7 +45596,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45669,7 +45605,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_mix_mode",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45683,7 +45619,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45692,7 +45628,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_normalize_artist_tag_position",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45706,7 +45642,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45715,7 +45651,7 @@
         "conditional": true,
         "imported": "easyuse_anima.prompt.artist_mix:_parse_artist_mix_items",
         "kind": "static_from",
-        "line": 810,
+        "line": 808,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45729,7 +45665,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45738,7 +45674,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaArtistMixConditioning",
         "kind": "static_from",
-        "line": 889,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45752,7 +45688,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45761,7 +45697,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataConditioning",
         "kind": "static_from",
-        "line": 889,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45775,7 +45711,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45784,7 +45720,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_data_nodes:EasyUseAnimaPromptDataUnpack",
         "kind": "static_from",
-        "line": 889,
+        "line": 887,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45798,30 +45734,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime",
-        "kind": "static_from",
-        "line": 889,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_data_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45830,7 +45743,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_ANY_TYPE",
         "kind": "static_from",
-        "line": 895,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45844,7 +45757,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45853,7 +45766,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_AnyType",
         "kind": "static_from",
-        "line": 895,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45867,7 +45780,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45876,7 +45789,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.input_types:_FlexibleOptionalInputType",
         "kind": "static_from",
-        "line": 895,
+        "line": 892,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45890,7 +45803,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45899,7 +45812,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvanced",
         "kind": "static_from",
-        "line": 900,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45913,7 +45826,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45922,7 +45835,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:EasyUseAnimaPromptStudioAdvancedV2",
         "kind": "static_from",
-        "line": 900,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45936,7 +45849,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45945,7 +45858,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_advanced_nodes:_bind_prompt_advanced_node_runtime",
         "kind": "static_from",
-        "line": 900,
+        "line": 897,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45959,7 +45872,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45968,7 +45881,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaAIOGenerator",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -45982,7 +45895,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -45991,7 +45904,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:EasyUseAnimaInput",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46005,7 +45918,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46014,7 +45927,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_generation_settings_json",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46028,7 +45941,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46037,7 +45950,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_aio_input_settings_json",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46051,7 +45964,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46060,7 +45973,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_bind_aio_node_runtime",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46074,7 +45987,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46083,7 +45996,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_easy_use_anima_input_signature",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46097,7 +46010,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46106,7 +46019,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.aio_nodes:_require_easy_use_anima_input",
         "kind": "static_from",
-        "line": 906,
+        "line": 903,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46120,7 +46033,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46129,7 +46042,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_down",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46143,7 +46056,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46152,7 +46065,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_align_nearest",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46166,7 +46079,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46175,7 +46088,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.geometry:_image_tensor_size",
         "kind": "static_from",
-        "line": 915,
+        "line": 912,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46189,7 +46102,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46198,7 +46111,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_context_value",
         "kind": "static_from",
-        "line": 926,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46212,7 +46125,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46221,7 +46134,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_sam3_context",
         "kind": "static_from",
-        "line": 926,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46235,7 +46148,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46244,7 +46157,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.sam3:_segs_has_items",
         "kind": "static_from",
-        "line": 926,
+        "line": 923,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46258,7 +46171,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46267,7 +46180,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_SCALE_MULTIPLES",
         "kind": "static_from",
-        "line": 938,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46281,7 +46194,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46290,7 +46203,7 @@
         "conditional": true,
         "imported": "easyuse_anima.image.scaling:IMAGE_UPSCALE_METHODS",
         "kind": "static_from",
-        "line": 938,
+        "line": 935,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46304,7 +46217,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46313,7 +46226,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_sampler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46327,7 +46240,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46336,7 +46249,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_comfy_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46350,7 +46263,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46359,7 +46272,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.capabilities:_impact_scheduler_names",
         "kind": "static_from",
-        "line": 946,
+        "line": 943,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46373,7 +46286,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46382,7 +46295,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_call_with_supported_kwargs",
         "kind": "static_from",
-        "line": 952,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46396,7 +46309,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46405,7 +46318,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_common_upscale_image",
         "kind": "static_from",
-        "line": 952,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46419,7 +46332,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46428,7 +46341,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.invocation:_node_output_tuple",
         "kind": "static_from",
-        "line": 952,
+        "line": 949,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46442,7 +46355,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46451,7 +46364,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.wiring:resolve_comfy_host_helper",
         "kind": "static_from",
-        "line": 957,
+        "line": 954,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46465,7 +46378,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46474,7 +46387,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_clip_loader_types",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46488,7 +46401,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46497,7 +46410,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_diffusion_model_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46511,7 +46424,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46520,7 +46433,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_text_encoder_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46534,7 +46447,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46543,7 +46456,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_comfy_vae_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46557,7 +46470,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46566,7 +46479,7 @@
         "conditional": true,
         "imported": "easyuse_anima.infrastructure.comfy.resources:_folder_path_names",
         "kind": "static_from",
-        "line": 960,
+        "line": 957,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46580,7 +46493,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46589,7 +46502,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaDetailerAlignHook",
         "kind": "static_from",
-        "line": 968,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46603,7 +46516,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46612,7 +46525,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.image_nodes:EasyUseAnimaImageScaleByMultiple",
         "kind": "static_from",
-        "line": 968,
+        "line": 965,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46626,7 +46539,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46635,7 +46548,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Context",
         "kind": "static_from",
-        "line": 972,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46649,7 +46562,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46658,7 +46571,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.sam3_nodes:EasyUseAnimaSAM3Detailer",
         "kind": "static_from",
-        "line": 972,
+        "line": 969,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46672,7 +46585,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46681,7 +46594,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptBuilder",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46695,7 +46608,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46704,7 +46617,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrector",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46718,7 +46631,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46727,7 +46640,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptCorrectorSimple",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46741,7 +46654,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46750,7 +46663,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.prompt_nodes:EasyUseAnimaPromptStudio",
         "kind": "static_from",
-        "line": 976,
+        "line": 973,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46764,30 +46677,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
-            "kind": "try",
-            "line": 9
-          }
-        ],
-        "classification": "compatibility_fallback",
-        "conditional": true,
-        "imported": "easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime",
-        "kind": "static_from",
-        "line": 976,
-        "optional": false,
-        "role": "compatibility_fallback",
-        "source": "nodes.py",
-        "target": "easyuse_anima/nodes/prompt_nodes.py"
-      },
-      {
-        "branch_context": [
-          {
-            "branch": "except",
-            "catches_import_error": true,
-            "exceptions": [
-              "ImportError"
-            ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46796,7 +46686,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaPromptStudioRegional",
         "kind": "static_from",
-        "line": 983,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46810,7 +46700,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46819,7 +46709,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:EasyUseAnimaRegionalConditioning",
         "kind": "static_from",
-        "line": 983,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46833,7 +46723,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46842,7 +46732,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.regional_nodes:_bind_regional_node_runtime",
         "kind": "static_from",
-        "line": 983,
+        "line": 979,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46856,7 +46746,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46865,7 +46755,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:LATENT_ALIGN",
         "kind": "static_from",
-        "line": 988,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46879,7 +46769,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46888,7 +46778,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_parse_random_response",
         "kind": "static_from",
-        "line": 988,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46902,7 +46792,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46911,7 +46801,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.client:_post_random",
         "kind": "static_from",
-        "line": 988,
+        "line": 984,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46925,7 +46815,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46934,7 +46824,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_advanced_resolution_from_selection",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46948,7 +46838,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46957,7 +46847,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_normalize_resolution_bucket",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46971,7 +46861,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -46980,7 +46870,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_ratio_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -46994,7 +46884,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47003,7 +46893,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolution_label",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47017,7 +46907,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47026,7 +46916,7 @@
         "conditional": true,
         "imported": "easyuse_anima.naia.resolution:_resolve_naia_resolution",
         "kind": "static_from",
-        "line": 1006,
+        "line": 1002,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47040,7 +46930,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47049,7 +46939,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:EasyUseAnimaNAIARandomPrompt",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47063,7 +46953,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47072,7 +46962,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.naia_nodes:_bind_naia_node_runtime",
         "kind": "static_from",
-        "line": 1029,
+        "line": 1025,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47086,7 +46976,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47095,7 +46985,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:EasyUseAnimaWildcard",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47109,7 +46999,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47118,7 +47008,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.wildcard_nodes:_bind_wildcard_node_runtime",
         "kind": "static_from",
-        "line": 1033,
+        "line": 1029,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47132,7 +47022,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47141,7 +47031,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_apply_lora_syntax_format",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47155,7 +47045,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47164,7 +47054,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_dedupe_text_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47178,7 +47068,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47187,7 +47077,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_fallback_lora_path",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47201,7 +47091,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47210,7 +47100,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_info",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47224,7 +47114,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47233,7 +47123,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_get_lora_manager_trigger_words",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47247,7 +47137,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47256,7 +47146,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_load_lora_manager_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47270,7 +47160,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47279,7 +47169,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_combo_values",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47293,7 +47183,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47302,7 +47192,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_manager_trigger_words_from_metadata",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47316,7 +47206,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47325,7 +47215,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_model_exists",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47339,7 +47229,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47348,7 +47238,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_lora_stack_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47362,7 +47252,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47371,7 +47261,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_metadata_json_paths_for_lora",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47385,7 +47275,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47394,7 +47284,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_missing_lora_display_name",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47408,7 +47298,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47417,7 +47307,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_raise_missing_loras",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47431,7 +47321,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47440,7 +47330,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.metadata:_trigger_words_from_value",
         "kind": "static_from",
-        "line": 1038,
+        "line": 1034,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47454,7 +47344,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47463,7 +47353,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_correct_style_prompt",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47477,7 +47367,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47486,7 +47376,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_format_strength",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47500,7 +47390,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47509,7 +47399,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_get_loras_list",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47523,7 +47413,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47532,7 +47422,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_load_profile_data",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47546,7 +47436,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47555,7 +47445,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_profile_key",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47569,7 +47459,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47578,7 +47468,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_select_profile_values",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47592,7 +47482,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47601,7 +47491,7 @@
         "conditional": true,
         "imported": "easyuse_anima.lora.preset:_wrap_profile_index",
         "kind": "static_from",
-        "line": 1054,
+        "line": 1050,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47615,7 +47505,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47624,7 +47514,7 @@
         "conditional": true,
         "imported": "easyuse_anima.nodes.lora_nodes:EasyUseAnimaLoraPreset",
         "kind": "static_from",
-        "line": 1063,
+        "line": 1059,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47638,7 +47528,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47647,7 +47537,7 @@
         "conditional": true,
         "imported": "anima_prompt:correct_prompt",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47661,7 +47551,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47670,7 +47560,7 @@
         "conditional": true,
         "imported": "anima_prompt:load_knowledge_base",
         "kind": "static_from",
-        "line": 1066,
+        "line": 1062,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47684,7 +47574,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47693,7 +47583,7 @@
         "conditional": true,
         "imported": "anima_prompt.parser:parse_prompt",
         "kind": "static_from",
-        "line": 1067,
+        "line": 1063,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47707,7 +47597,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47716,7 +47606,7 @@
         "conditional": true,
         "imported": "settings:resolve_metadata_filter_words",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47730,7 +47620,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47739,7 +47629,7 @@
         "conditional": true,
         "imported": "settings:resolve_naia_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47753,7 +47643,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47762,7 +47652,7 @@
         "conditional": true,
         "imported": "settings:resolve_prompt_translation_settings",
         "kind": "static_from",
-        "line": 1068,
+        "line": 1064,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47776,7 +47666,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47785,7 +47675,7 @@
         "conditional": true,
         "imported": "prompt_translation:has_prompt_translation_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47799,7 +47689,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47808,7 +47698,7 @@
         "conditional": true,
         "imported": "prompt_translation:translate_prompt_markers",
         "kind": "static_from",
-        "line": 1073,
+        "line": 1069,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47822,7 +47712,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47831,7 +47721,7 @@
         "conditional": true,
         "imported": "wildcard_engine:MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47845,7 +47735,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47854,7 +47744,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PROMPT_STUDIO_WILDCARD_MODE_LABELS",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47868,7 +47758,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47877,7 +47767,7 @@
         "conditional": true,
         "imported": "wildcard_engine:PUBLIC_MAX_SEED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47891,7 +47781,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47900,7 +47790,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_DECREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47914,7 +47804,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47923,7 +47813,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47937,7 +47827,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47946,7 +47836,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_INCREMENT",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47960,7 +47850,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47969,7 +47859,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_MODES",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -47983,7 +47873,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -47992,7 +47882,7 @@
         "conditional": true,
         "imported": "wildcard_engine:SEED_CONTROL_RANDOMIZE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48006,7 +47896,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48015,7 +47905,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_FIXED",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48029,7 +47919,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48038,7 +47928,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_POPULATE",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48052,7 +47942,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48061,7 +47951,7 @@
         "conditional": true,
         "imported": "wildcard_engine:WILDCARD_MODE_SEQUENTIAL",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48075,7 +47965,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48084,7 +47974,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcard_texts",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48098,7 +47988,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48107,7 +47997,7 @@
         "conditional": true,
         "imported": "wildcard_engine:expand_wildcards",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48121,7 +48011,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48130,7 +48020,7 @@
         "conditional": true,
         "imported": "wildcard_engine:has_wildcard_syntax",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48144,7 +48034,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48153,7 +48043,7 @@
         "conditional": true,
         "imported": "wildcard_engine:next_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48167,7 +48057,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48176,7 +48066,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_prompt_studio_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48190,7 +48080,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48199,7 +48089,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_seed",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48213,7 +48103,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48222,7 +48112,7 @@
         "conditional": true,
         "imported": "wildcard_engine:normalize_wildcard_mode",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -48236,7 +48126,7 @@
             "exceptions": [
               "ImportError"
             ],
-            "handler_line": 552,
+            "handler_line": 550,
             "kind": "try",
             "line": 9
           }
@@ -48245,7 +48135,7 @@
         "conditional": true,
         "imported": "wildcard_engine:wildcard_sources_signature",
         "kind": "static_from",
-        "line": 1074,
+        "line": 1070,
         "optional": false,
         "role": "compatibility_fallback",
         "source": "nodes.py",
@@ -54825,7 +54715,7 @@
         "column": 9,
         "context": "assign:logger",
         "kind": "import_time_call",
-        "line": 1096,
+        "line": 1092,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54834,7 +54724,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1671,
+        "line": 1667,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54843,7 +54733,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1674,
+        "line": 1670,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54852,7 +54742,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1680,
+        "line": 1676,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54861,7 +54751,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1686,
+        "line": 1682,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54870,7 +54760,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1689,
+        "line": 1685,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54879,7 +54769,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1692,
+        "line": 1688,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54888,7 +54778,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1698,
+        "line": 1694,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54897,7 +54787,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1704,
+        "line": 1700,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54906,7 +54796,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1710,
+        "line": 1706,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54915,7 +54805,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1716,
+        "line": 1712,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54924,7 +54814,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1722,
+        "line": 1718,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54933,7 +54823,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1728,
+        "line": 1724,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54942,7 +54832,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1735,
+        "line": 1731,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54951,25 +54841,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1739,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_prompt_data_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1742,
-        "module": "nodes.py",
-        "scope": "<module>"
-      },
-      {
-        "callee": "_bind_prompt_node_runtime",
-        "column": 0,
-        "context": "expression",
-        "kind": "import_time_call",
-        "line": 1748,
+        "line": 1735,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54978,7 +54850,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1751,
+        "line": 1738,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -54987,7 +54859,7 @@
         "column": 0,
         "context": "expression",
         "kind": "import_time_call",
-        "line": 1758,
+        "line": 1745,
         "module": "nodes.py",
         "scope": "<module>"
       },
@@ -55399,12 +55271,6 @@
       },
       {
         "kind": "dict",
-        "line": 52,
-        "module": "easyuse_anima/nodes/prompt_data_nodes.py",
-        "name": "_RUNTIME_HELPER_DEFAULTS"
-      },
-      {
-        "kind": "dict",
         "line": 46,
         "module": "easyuse_anima/nodes/wildcard_nodes.py",
         "name": "WILDCARD_MODE_DISPLAY_LABELS"
@@ -55501,13 +55367,13 @@
       },
       {
         "kind": "dict",
-        "line": 1158,
+        "line": 1154,
         "module": "nodes.py",
         "name": "AIO_GENERATION_DEFAULT_SETTINGS"
       },
       {
         "kind": "dict",
-        "line": 1147,
+        "line": 1143,
         "module": "nodes.py",
         "name": "AIO_INPUT_DEFAULT_SETTINGS"
       },

--- a/tests/fixtures/python_compatibility_surface.v1.json
+++ b/tests/fixtures/python_compatibility_surface.v1.json
@@ -70,7 +70,8 @@
       "B-11c30b",
       "B-11c30c",
       "B-11c30c1",
-      "B-11c30c2"
+      "B-11c30c2",
+      "B-11c30c2a"
     ]
   },
   "enums": {
@@ -105,14 +106,14 @@
   "expected_counts": {
     "root_entrypoints": 3,
     "excluded_preamble_implementation_bindings": 5,
-    "nodes_canonical_bindings": 283,
+    "nodes_canonical_bindings": 281,
     "nodes_legacy_bindings": 27,
     "mapped_public_classes": 18,
     "unmapped_classes": 2,
     "root_residual_functions": 1,
     "root_residual_classes": 0,
     "root_residual_globals": 26,
-    "runtime_binders": 18,
+    "runtime_binders": 16,
     "direct_nodes_import_test_files": 21
   },
   "mapped_public_classes": [
@@ -161,8 +162,6 @@
     "_bind_regional_node_runtime",
     "_bind_prompt_advanced_node_runtime",
     "_bind_aio_node_runtime",
-    "_bind_prompt_data_node_runtime",
-    "_bind_prompt_node_runtime",
     "_bind_wildcard_node_runtime",
     "_bind_naia_node_runtime"
   ],
@@ -385,8 +384,7 @@
       "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_advanced_outputs_from_prompt_data": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_advanced_resolution_from_selection": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -499,25 +497,14 @@
     "_apply_aio_spectrum_model_patches_for_comfy_sampler": [
       "easyuse_anima.aio.legacy_generation"
     ],
-    "_apply_prompt_data_overrides": [
-      "easyuse_anima.nodes.prompt_data_nodes"
-    ],
     "_apply_regional_field_inputs": [
       "easyuse_anima.nodes.regional_nodes"
     ],
     "_apply_spectrum_anima_mod_guidance": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.nodes.prompt_data_nodes"
-    ],
-    "_artist_mix_inline_prompt": [
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_artist_mix_mode_tooltip": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes"
-    ],
-    "_artist_prompt_with_position": [
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_as_bool": [
       "easyuse_anima.aio.conditioning",
@@ -529,8 +516,6 @@
       "easyuse_anima.aio.sampling",
       "easyuse_anima.aio.usdu",
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.nodes.prompt_nodes",
       "easyuse_anima.nodes.regional_nodes"
     ],
     "_as_float": [
@@ -555,13 +540,11 @@
     ],
     "_bounded_artist_mix_float": [
       "easyuse_anima.aio.generation_normalization",
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_bounded_artist_mix_int": [
       "easyuse_anima.aio.generation_normalization",
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_build_advanced_prompt_data": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
@@ -629,9 +612,6 @@
     "_correct_advanced_field_sequence": [
       "easyuse_anima.aio.conditioning"
     ],
-    "_correct_builder_prompt": [
-      "easyuse_anima.nodes.prompt_nodes"
-    ],
     "_decode_latent_with_comfy": [
       "easyuse_anima.aio.legacy_generation"
     ],
@@ -642,15 +622,11 @@
       "easyuse_anima.aio.legacy_generation"
     ],
     "_encode_prompt_data_positive_conditioning": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_expand_advanced_wildcard_fields": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.regional_nodes"
-    ],
-    "_filter_metadata_prompt": [
-      "easyuse_anima.nodes.prompt_nodes"
     ],
     "_folder_path_names": [
       "easyuse_anima.aio.resources"
@@ -659,8 +635,7 @@
       "easyuse_anima.aio.output"
     ],
     "_generate_empty_latent_with_comfy": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_get_aio_first_pass_cache": [
       "easyuse_anima.aio.legacy_generation"
@@ -680,13 +655,6 @@
     ],
     "_is_aio_detailer_target_name": [
       "easyuse_anima.aio.generation_normalization"
-    ],
-    "_join_artist_mix_source_prompts": [
-      "easyuse_anima.nodes.prompt_data_nodes"
-    ],
-    "_join_prompt_tokens": [
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.nodes.prompt_nodes"
     ],
     "_json_clone": [
       "easyuse_anima.aio.generation_normalization",
@@ -768,15 +736,10 @@
     "_normalize_anima_mod_guidance_profile": [
       "easyuse_anima.aio.generation_normalization",
       "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.aio.sampling",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.aio.sampling"
     ],
     "_normalize_artist_mix_mode": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes"
-    ],
-    "_normalize_artist_tag_position": [
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "_normalize_mask_ids": [
       "easyuse_anima.nodes.regional_nodes"
@@ -784,8 +747,7 @@
     "_normalize_prompt_data": [
       "easyuse_anima.aio.conditioning",
       "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.nodes.aio_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.nodes.aio_nodes"
     ],
     "_normalize_prompt_studio_wildcard_seed_control": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
@@ -827,7 +789,6 @@
     ],
     "_prompt_translation_change_key": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_nodes",
       "easyuse_anima.nodes.regional_nodes"
     ],
     "_put_aio_first_pass_cache": [
@@ -865,8 +826,7 @@
       "easyuse_anima.nodes.aio_nodes"
     ],
     "_resolve_anima_mod_guidance_enabled": [
-      "easyuse_anima.aio.legacy_generation",
-      "easyuse_anima.nodes.prompt_data_nodes"
+      "easyuse_anima.aio.legacy_generation"
     ],
     "_resolve_naia_resolution": [
       "easyuse_anima.nodes.prompt_advanced_nodes"
@@ -938,15 +898,10 @@
       "easyuse_anima.nodes.prompt_advanced_nodes",
       "easyuse_anima.nodes.regional_nodes"
     ],
-    "_split_tag_text": [
-      "easyuse_anima.nodes.prompt_nodes"
-    ],
     "_stable_change_key": [
       "easyuse_anima.aio.first_pass_cache",
       "easyuse_anima.nodes.aio_nodes",
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_data_nodes",
-      "easyuse_anima.nodes.prompt_nodes",
       "easyuse_anima.nodes.regional_nodes"
     ],
     "_tag_aio_preview_images": [
@@ -958,14 +913,7 @@
       "easyuse_anima.nodes.regional_nodes"
     ],
     "_translate_prompt_text": [
-      "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_nodes"
-    ],
-    "correct_prompt": [
-      "easyuse_anima.nodes.prompt_nodes"
-    ],
-    "load_knowledge_base": [
-      "easyuse_anima.nodes.prompt_nodes"
+      "easyuse_anima.nodes.prompt_advanced_nodes"
     ],
     "logger": [
       "easyuse_anima.aio.legacy_generation",
@@ -988,7 +936,6 @@
     ],
     "resolve_metadata_filter_words": [
       "easyuse_anima.nodes.prompt_advanced_nodes",
-      "easyuse_anima.nodes.prompt_nodes",
       "easyuse_anima.nodes.regional_nodes"
     ],
     "resolve_naia_settings": [
@@ -1001,21 +948,21 @@
   },
   "runtime_binder_audit": {
     "summary": {
-      "binder_count": 18,
+      "binder_count": 16,
       "family_count": 3,
       "mode_counts": {
-        "comfy_provider_then_root": 10,
-        "root_globals": 6,
+        "comfy_provider_then_root": 9,
+        "root_globals": 5,
         "explicit_callbacks": 2
       },
-      "unique_resolver_names": 248,
-      "unique_root_resolver_names": 243,
+      "unique_resolver_names": 237,
+      "unique_root_resolver_names": 232,
       "unique_provider_resolver_names": 5,
       "unique_direct_root_dependencies": 10,
-      "direct_root_dependency_slots": 21,
-      "provider_consumer_slots": 15,
-      "provider_consumer_modules": 10,
-      "repository_replacement_names": 148,
+      "direct_root_dependency_slots": 20,
+      "provider_consumer_slots": 14,
+      "provider_consumer_modules": 9,
+      "repository_replacement_names": 142,
       "repository_replacement_files": 18
     },
     "families": {
@@ -1035,9 +982,7 @@
       ],
       "prompt_node_adapters": [
         "_bind_regional_node_runtime",
-        "_bind_prompt_advanced_node_runtime",
-        "_bind_prompt_data_node_runtime",
-        "_bind_prompt_node_runtime"
+        "_bind_prompt_advanced_node_runtime"
       ],
       "wildcard_naia": [
         "_bind_wildcard_node_runtime",
@@ -1149,12 +1094,9 @@
       "_apply_aio_spectrum_correction_patch_for_comfy_sampler",
       "_apply_aio_spectrum_forecast_patch_for_comfy_sampler",
       "_apply_aio_spectrum_model_patches_for_comfy_sampler",
-      "_apply_prompt_data_overrides",
       "_apply_regional_field_inputs",
       "_apply_spectrum_anima_mod_guidance",
-      "_artist_mix_inline_prompt",
       "_artist_mix_mode_tooltip",
-      "_artist_prompt_with_position",
       "_as_bool",
       "_as_float",
       "_as_int",
@@ -1181,13 +1123,11 @@
       "_context_value",
       "_copy_prompt_data_for_update",
       "_correct_advanced_field_sequence",
-      "_correct_builder_prompt",
       "_decode_latent_with_comfy",
       "_easy_use_anima_input_signature",
       "_encode_image_with_comfy_vae",
       "_encode_prompt_data_positive_conditioning",
       "_expand_advanced_wildcard_fields",
-      "_filter_metadata_prompt",
       "_folder_path_names",
       "_format_strength",
       "_generate_empty_latent_with_comfy",
@@ -1196,8 +1136,6 @@
       "_image_tensor_size",
       "_impact_scheduler_names",
       "_is_aio_detailer_target_name",
-      "_join_artist_mix_source_prompts",
-      "_join_prompt_tokens",
       "_json_clone",
       "_json_object",
       "_load_aio_resources_from_input_context",
@@ -1222,7 +1160,6 @@
       "_normalize_aio_spectrum_settings",
       "_normalize_anima_mod_guidance_profile",
       "_normalize_artist_mix_mode",
-      "_normalize_artist_tag_position",
       "_normalize_mask_ids",
       "_normalize_prompt_data",
       "_normalize_prompt_studio_wildcard_seed_control",
@@ -1270,15 +1207,12 @@
       "_send_aio_preview_event",
       "_set_naia_field_text",
       "_single_value",
-      "_split_tag_text",
       "_stable_change_key",
       "_tag_aio_preview_images",
       "_translate_prompt_fields",
       "_translate_prompt_text",
       "ceil",
-      "correct_prompt",
       "json",
-      "load_knowledge_base",
       "logger",
       "next_seed",
       "normalize_prompt_studio_wildcard_mode",
@@ -1549,9 +1483,6 @@
       "_copy_prompt_data_for_update": [
         "tests/test_aio_nodes.py"
       ],
-      "_correct_builder_prompt": [
-        "tests/test_node_contracts.py"
-      ],
       "_decode_latent_with_comfy": [
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
@@ -1567,9 +1498,6 @@
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_nodes.py"
       ],
-      "_filter_metadata_prompt": [
-        "tests/test_node_contracts.py"
-      ],
       "_folder_path_names": [
         "tests/test_comfy_adapters.py",
         "tests/test_node_contracts.py"
@@ -1579,8 +1507,7 @@
       ],
       "_generate_empty_latent_with_comfy": [
         "tests/test_aio_legacy_generation.py",
-        "tests/test_aio_nodes.py",
-        "tests/test_prompt_corrector.py"
+        "tests/test_aio_nodes.py"
       ],
       "_get_aio_first_pass_cache": [
         "tests/test_aio_legacy_generation.py"
@@ -1600,9 +1527,6 @@
         "tests/test_node_contracts.py"
       ],
       "_is_aio_detailer_target_name": [
-        "tests/test_node_contracts.py"
-      ],
-      "_join_prompt_tokens": [
         "tests/test_node_contracts.py"
       ],
       "_json_clone": [
@@ -1773,22 +1697,13 @@
         "tests/test_aio_legacy_generation.py",
         "tests/test_aio_preview.py"
       ],
-      "_translate_prompt_text": [
-        "tests/test_node_contracts.py"
-      ],
       "ceil": [
-        "tests/test_node_contracts.py"
-      ],
-      "correct_prompt": [
         "tests/test_node_contracts.py"
       ],
       "expand_wildcards": [
         "tests/test_wildcards.py"
       ],
       "json": [
-        "tests/test_node_contracts.py"
-      ],
-      "load_knowledge_base": [
         "tests/test_node_contracts.py"
       ],
       "logger": [
@@ -1802,8 +1717,7 @@
         "tests/test_node_contracts.py"
       ],
       "resolve_metadata_filter_words": [
-        "tests/test_node_contracts.py",
-        "tests/test_prompt_corrector.py"
+        "tests/test_node_contracts.py"
       ],
       "resolve_naia_settings": [
         "tests/test_naia_settings.py",
@@ -3003,7 +2917,6 @@
           "_prompt_translation_change_key",
           "_single_value",
           "_stable_change_key",
-          "_translate_prompt_text",
           "next_seed",
           "resolve_metadata_filter_words",
           "resolve_naia_settings",
@@ -3119,143 +3032,6 @@
           "_run_aio_legacy_generation",
           "_stable_change_key",
           "json"
-        ]
-      },
-      {
-        "binder": "_bind_prompt_data_node_runtime",
-        "module": "easyuse_anima.nodes.prompt_data_nodes",
-        "family": "prompt_node_adapters",
-        "mode": "comfy_provider_then_root",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_RUNTIME_RESOLVER"
-        ],
-        "direct_root_dependencies": [
-          "_resolve_comfy_host_helper"
-        ],
-        "resolver_names": [
-          "_advanced_outputs_from_prompt_data",
-          "_apply_prompt_data_overrides",
-          "_apply_spectrum_anima_mod_guidance",
-          "_artist_mix_inline_prompt",
-          "_artist_mix_mode_tooltip",
-          "_artist_prompt_with_position",
-          "_as_bool",
-          "_bounded_artist_mix_float",
-          "_bounded_artist_mix_int",
-          "_encode_prompt_data_positive_conditioning",
-          "_encode_with_comfy_clip",
-          "_generate_empty_latent_with_comfy",
-          "_join_artist_mix_source_prompts",
-          "_join_prompt_tokens",
-          "_normalize_anima_mod_guidance_profile",
-          "_normalize_artist_mix_mode",
-          "_normalize_artist_tag_position",
-          "_normalize_prompt_data",
-          "_resolve_anima_mod_guidance_enabled",
-          "_stable_change_key"
-        ],
-        "root_resolver_names": [
-          "_advanced_outputs_from_prompt_data",
-          "_apply_prompt_data_overrides",
-          "_apply_spectrum_anima_mod_guidance",
-          "_artist_mix_inline_prompt",
-          "_artist_mix_mode_tooltip",
-          "_artist_prompt_with_position",
-          "_as_bool",
-          "_bounded_artist_mix_float",
-          "_bounded_artist_mix_int",
-          "_encode_prompt_data_positive_conditioning",
-          "_generate_empty_latent_with_comfy",
-          "_join_artist_mix_source_prompts",
-          "_join_prompt_tokens",
-          "_normalize_anima_mod_guidance_profile",
-          "_normalize_artist_mix_mode",
-          "_normalize_artist_tag_position",
-          "_normalize_prompt_data",
-          "_resolve_anima_mod_guidance_enabled",
-          "_stable_change_key"
-        ],
-        "provider_resolver_names": [
-          "_encode_with_comfy_clip"
-        ],
-        "repository_replacement_names": [
-          "_advanced_outputs_from_prompt_data",
-          "_apply_spectrum_anima_mod_guidance",
-          "_as_bool",
-          "_encode_prompt_data_positive_conditioning",
-          "_generate_empty_latent_with_comfy",
-          "_join_prompt_tokens",
-          "_normalize_anima_mod_guidance_profile",
-          "_normalize_prompt_data",
-          "_resolve_anima_mod_guidance_enabled",
-          "_stable_change_key"
-        ]
-      },
-      {
-        "binder": "_bind_prompt_node_runtime",
-        "module": "easyuse_anima.nodes.prompt_nodes",
-        "family": "prompt_node_adapters",
-        "mode": "root_globals",
-        "root_observation": "call_time_resolver",
-        "root_keywords": [
-          "resolve_helper"
-        ],
-        "bound_globals": [
-          "_as_bool",
-          "_correct_builder_prompt",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_prompt_translation_change_key",
-          "_split_tag_text",
-          "_stable_change_key",
-          "_translate_prompt_text",
-          "correct_prompt",
-          "load_knowledge_base",
-          "resolve_metadata_filter_words"
-        ],
-        "direct_root_dependencies": [],
-        "resolver_names": [
-          "_as_bool",
-          "_correct_builder_prompt",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_prompt_translation_change_key",
-          "_split_tag_text",
-          "_stable_change_key",
-          "_translate_prompt_text",
-          "correct_prompt",
-          "load_knowledge_base",
-          "resolve_metadata_filter_words"
-        ],
-        "root_resolver_names": [
-          "_as_bool",
-          "_correct_builder_prompt",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_prompt_translation_change_key",
-          "_split_tag_text",
-          "_stable_change_key",
-          "_translate_prompt_text",
-          "correct_prompt",
-          "load_knowledge_base",
-          "resolve_metadata_filter_words"
-        ],
-        "provider_resolver_names": [],
-        "repository_replacement_names": [
-          "_as_bool",
-          "_correct_builder_prompt",
-          "_filter_metadata_prompt",
-          "_join_prompt_tokens",
-          "_prompt_translation_change_key",
-          "_stable_change_key",
-          "_translate_prompt_text",
-          "correct_prompt",
-          "load_knowledge_base",
-          "resolve_metadata_filter_words"
         ]
       },
       {
@@ -4574,16 +4350,14 @@
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.output",
         "canonical runtime resolver: easyuse_anima.aio.sampling",
-        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
+        "canonical runtime resolver: easyuse_anima.nodes.aio_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.output string runtime lookup",
         "AST:easyuse_anima.aio.sampling string runtime lookup",
-        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup"
+        "AST:easyuse_anima.nodes.aio_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -4649,8 +4423,6 @@
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
@@ -4659,8 +4431,6 @@
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -4702,8 +4472,6 @@
         "canonical runtime resolver: easyuse_anima.aio.sampling",
         "canonical runtime resolver: easyuse_anima.aio.usdu",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
@@ -4719,8 +4487,6 @@
         "AST:easyuse_anima.aio.sampling string runtime lookup",
         "AST:easyuse_anima.aio.usdu string runtime lookup",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -5518,34 +5284,6 @@
       "lifecycle_state": "supported"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_data_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_prompt_data_node_runtime": "_bind_prompt_data_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.prompt_data_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.prompt_data_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
-    },
-    {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_nodes:supported_public_reexport",
       "surface": "nodes_canonical_bindings",
       "symbols": {
@@ -5577,34 +5315,6 @@
         "mapping, workflow, and direct identity parity"
       ],
       "lifecycle_state": "supported"
-    },
-    {
-      "id": "nodes_canonical_bindings:easyuse_anima.nodes.prompt_nodes:transitional_private_seam",
-      "surface": "nodes_canonical_bindings",
-      "symbols": {
-        "_bind_prompt_node_runtime": "_bind_prompt_node_runtime"
-      },
-      "classification": "transitional_private_seam",
-      "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.nodes.prompt_nodes",
-      "target_state": "canonical",
-      "identity_requirement": "required",
-      "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.nodes.prompt_nodes",
-      "owner": "#184/#188",
-      "first_release": null,
-      "known_consumers": [
-        "nodes.py residual runtime"
-      ],
-      "evidence": [
-        "AST:nodes.py direct runtime load"
-      ],
-      "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
-      ],
-      "lifecycle_state": "transitional"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.nodes.regional_nodes:supported_public_reexport",
@@ -5848,15 +5558,11 @@
         "ARTIST_MIX_DEFAULT_STYLE_GAIN": "ARTIST_MIX_DEFAULT_STYLE_GAIN",
         "ARTIST_MIX_INPUT_MODES": "ARTIST_MIX_INPUT_MODES",
         "ARTIST_MIX_MODE_FROM_PROMPT_DATA": "ARTIST_MIX_MODE_FROM_PROMPT_DATA",
-        "_artist_mix_inline_prompt": "_artist_mix_inline_prompt",
         "_artist_mix_mode_tooltip": "_artist_mix_mode_tooltip",
-        "_artist_prompt_with_position": "_artist_prompt_with_position",
         "_bounded_artist_mix_float": "_bounded_artist_mix_float",
         "_bounded_artist_mix_int": "_bounded_artist_mix_int",
         "_encode_prompt_data_positive_conditioning": "_encode_prompt_data_positive_conditioning",
-        "_join_artist_mix_source_prompts": "_join_artist_mix_source_prompts",
-        "_normalize_artist_mix_mode": "_normalize_artist_mix_mode",
-        "_normalize_artist_tag_position": "_normalize_artist_tag_position"
+        "_normalize_artist_mix_mode": "_normalize_artist_mix_mode"
       },
       "classification": "transitional_private_seam",
       "current_target": "nodes.py",
@@ -5871,15 +5577,13 @@
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
+        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup"
+        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5892,10 +5596,14 @@
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.artist_mix:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
+        "_artist_mix_inline_prompt": "_artist_mix_inline_prompt",
+        "_artist_prompt_with_position": "_artist_prompt_with_position",
         "_artist_tags_from_prompt": "_artist_tags_from_prompt",
         "_blend_conditionings": "_blend_conditionings",
         "_encode_artist_clustered": "_encode_artist_clustered",
         "_encode_artist_delta_rms": "_encode_artist_delta_rms",
+        "_join_artist_mix_source_prompts": "_join_artist_mix_source_prompts",
+        "_normalize_artist_tag_position": "_normalize_artist_tag_position",
         "_parse_artist_mix_items": "_parse_artist_mix_items"
       },
       "classification": "unsupported_test_only",
@@ -5946,15 +5654,13 @@
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.aio.generation_normalization",
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
-        "canonical runtime resolver: easyuse_anima.aio.sampling",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
+        "canonical runtime resolver: easyuse_anima.aio.sampling"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.aio.generation_normalization string runtime lookup",
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
-        "AST:easyuse_anima.aio.sampling string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup"
+        "AST:easyuse_anima.aio.sampling string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -5997,7 +5703,6 @@
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "_prompt_translation_change_key": "_prompt_translation_change_key",
-        "_split_tag_text": "_split_tag_text",
         "_translate_prompt_text": "_translate_prompt_text"
       },
       "classification": "transitional_private_seam",
@@ -6011,12 +5716,10 @@
       "first_release": null,
       "known_consumers": [
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [
@@ -6027,12 +5730,40 @@
       "lifecycle_state": "transitional"
     },
     {
+      "id": "nodes_canonical_bindings:easyuse_anima.prompt.correction:unsupported_test_only",
+      "surface": "nodes_canonical_bindings",
+      "symbols": {
+        "_split_tag_text": "_split_tag_text"
+      },
+      "classification": "unsupported_test_only",
+      "current_target": "nodes.py",
+      "canonical_target": "easyuse_anima.prompt.correction",
+      "target_state": "canonical",
+      "identity_requirement": "not_applicable",
+      "binding_shape": "direct_import",
+      "import_target": "easyuse_anima.prompt.correction",
+      "owner": "#184/#188",
+      "first_release": null,
+      "known_consumers": [
+        "repository tests may import this root name"
+      ],
+      "evidence": [
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
+      ],
+      "removal_gates": [
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
+      ],
+      "lifecycle_state": "unsupported"
+    },
+    {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.data:transitional_private_seam",
       "surface": "nodes_canonical_bindings",
       "symbols": {
         "PROMPT_DATA_TYPE": "PROMPT_DATA_TYPE",
         "_advanced_outputs_from_prompt_data": "_advanced_outputs_from_prompt_data",
-        "_apply_prompt_data_overrides": "_apply_prompt_data_overrides",
         "_copy_prompt_data_for_update": "_copy_prompt_data_for_update",
         "_normalize_prompt_data": "_normalize_prompt_data",
         "_prompt_data_json_safe": "_prompt_data_json_safe",
@@ -6054,8 +5785,7 @@
         "canonical runtime resolver: easyuse_anima.aio.legacy_generation",
         "canonical runtime resolver: easyuse_anima.aio.preview",
         "canonical runtime resolver: easyuse_anima.nodes.aio_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes"
+        "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes"
       ],
       "evidence": [
         "AST:easyuse_anima.aio.conditioning string runtime lookup",
@@ -6064,8 +5794,7 @@
         "AST:easyuse_anima.aio.legacy_generation string runtime lookup",
         "AST:easyuse_anima.aio.preview string runtime lookup",
         "AST:easyuse_anima.nodes.aio_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup"
+        "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup"
       ],
       "removal_gates": [
         "canonical production consumer migration",
@@ -6075,36 +5804,33 @@
       "lifecycle_state": "transitional"
     },
     {
-      "id": "nodes_canonical_bindings:easyuse_anima.prompt.fields:transitional_private_seam",
+      "id": "nodes_canonical_bindings:easyuse_anima.prompt.data:unsupported_test_only",
       "surface": "nodes_canonical_bindings",
       "symbols": {
-        "_correct_builder_prompt": "_correct_builder_prompt",
-        "_filter_metadata_prompt": "_filter_metadata_prompt",
-        "_join_prompt_tokens": "_join_prompt_tokens"
+        "_apply_prompt_data_overrides": "_apply_prompt_data_overrides"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
-      "canonical_target": "easyuse_anima.prompt.fields",
+      "canonical_target": "easyuse_anima.prompt.data",
       "target_state": "canonical",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
-      "import_target": "easyuse_anima.prompt.fields",
+      "import_target": "easyuse_anima.prompt.data",
       "owner": "#184/#188",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_data_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:easyuse_anima.nodes.prompt_data_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_canonical_bindings:easyuse_anima.prompt.fields:unsupported_test_only",
@@ -6113,6 +5839,9 @@
         "_HASH_COMMENT_RE": "_HASH_COMMENT_RE",
         "_INLINE_SPACE_RE": "_INLINE_SPACE_RE",
         "_WEIGHTED_TOKEN_RE": "_WEIGHTED_TOKEN_RE",
+        "_correct_builder_prompt": "_correct_builder_prompt",
+        "_filter_metadata_prompt": "_filter_metadata_prompt",
+        "_join_prompt_tokens": "_join_prompt_tokens",
         "_metadata_filter_key": "_metadata_filter_key",
         "_metadata_filter_keys": "_metadata_filter_keys",
         "_prompt_tokens": "_prompt_tokens"
@@ -6242,33 +5971,34 @@
       "lifecycle_state": "unsupported"
     },
     {
-      "id": "nodes_legacy_bindings:anima_prompt:transitional_private_seam",
+      "id": "nodes_legacy_bindings:anima_prompt:unsupported_test_only",
       "surface": "nodes_legacy_bindings",
       "symbols": {
         "correct_prompt": "correct_prompt",
         "load_knowledge_base": "load_knowledge_base"
       },
-      "classification": "transitional_private_seam",
+      "classification": "unsupported_test_only",
       "current_target": "nodes.py",
       "canonical_target": null,
       "target_state": "legacy_owner",
-      "identity_requirement": "required",
+      "identity_requirement": "not_applicable",
       "binding_shape": "direct_import",
       "import_target": "anima_prompt",
       "owner": "#184/#186",
       "first_release": null,
       "known_consumers": [
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes"
+        "repository tests may import this root name"
       ],
       "evidence": [
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup"
+        "AST:no nodes.py runtime load",
+        "test-only consumption is not public support evidence"
       ],
       "removal_gates": [
-        "canonical production consumer migration",
-        "focused monkeypatch and identity contract review",
-        "separate B-10b or B-11 rollback unit"
+        "test imports migrate to canonical targets",
+        "no production consumer evidence",
+        "separate B-10b removal review"
       ],
-      "lifecycle_state": "transitional"
+      "lifecycle_state": "unsupported"
     },
     {
       "id": "nodes_legacy_bindings:prompt_translation:unsupported_test_only",
@@ -6319,13 +6049,11 @@
       "known_consumers": [
         "nodes.py residual runtime",
         "canonical runtime resolver: easyuse_anima.nodes.prompt_advanced_nodes",
-        "canonical runtime resolver: easyuse_anima.nodes.prompt_nodes",
         "canonical runtime resolver: easyuse_anima.nodes.regional_nodes"
       ],
       "evidence": [
         "AST:nodes.py direct runtime load",
         "AST:easyuse_anima.nodes.prompt_advanced_nodes string runtime lookup",
-        "AST:easyuse_anima.nodes.prompt_nodes string runtime lookup",
         "AST:easyuse_anima.nodes.regional_nodes string runtime lookup"
       ],
       "removal_gates": [

--- a/tests/test_node_contracts.py
+++ b/tests/test_node_contracts.py
@@ -214,6 +214,15 @@ def _deterministic_comfy_inputs():
     }
     with (
         patch.multiple(nodes, **replacements),
+        patch.multiple(
+            prompt_nodes,
+            resolve_metadata_filter_words=replacements[
+                "resolve_metadata_filter_words"
+            ],
+            _prompt_translation_change_key=replacements[
+                "_prompt_translation_change_key"
+            ],
+        ),
         patch_comfy_helper(
             nodes,
             "_comfy_max_resolution",
@@ -2808,6 +2817,7 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
 
     def test_root_prompt_corrector_objects_are_direct_canonical_aliases(self):
         self.assertFalse(hasattr(prompt_correction, "_bind_prompt_correction_runtime"))
+        self.assertFalse(hasattr(prompt_nodes, "_bind_prompt_node_runtime"))
         for name in self.CORRECTION_HELPERS:
             with self.subTest(name=name):
                 self.assertIs(getattr(nodes, name), getattr(prompt_correction, name))
@@ -2832,7 +2842,7 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
                 with self.subTest(name=name):
                     self.assertIs(getattr(package_nodes, name), getattr(package_prompt_nodes, name))
 
-    def test_canonical_service_and_root_adapter_monkeypatches_drive_prompt_corrector_nodes(self):
+    def test_canonical_service_and_adapter_monkeypatches_drive_prompt_corrector_nodes(self):
         settings = types.SimpleNamespace(provider="off", source="auto", target="en")
         correction_result = types.SimpleNamespace(
             text="canonical result",
@@ -2850,13 +2860,25 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
                 return_value=settings,
             ) as resolve_settings,
             patch.object(
-                nodes,
+                prompt_nodes,
                 "_prompt_translation_change_key",
                 return_value={"bound": "translation"},
             ) as translation_key,
-            patch.object(nodes, "_stable_change_key", side_effect=lambda payload: payload) as stable_key,
-            patch.object(nodes, "load_knowledge_base", return_value="bound kb") as load_kb,
-            patch.object(nodes, "correct_prompt", return_value=correction_result) as correct,
+            patch.object(
+                prompt_nodes,
+                "_stable_change_key",
+                side_effect=lambda payload: payload,
+            ) as stable_key,
+            patch.object(
+                prompt_nodes,
+                "load_knowledge_base",
+                return_value="bound kb",
+            ) as load_kb,
+            patch.object(
+                prompt_nodes,
+                "correct_prompt",
+                return_value=correction_result,
+            ) as correct,
         ):
             change_key = prompt_nodes.EasyUseAnimaPromptCorrector.IS_CHANGED(
                 prompt="%{bound prompt}",
@@ -2931,11 +2953,19 @@ class PromptCorrectorMoveContractTests(unittest.TestCase):
         translate_markers.assert_called_once_with("%{abc}", settings)
 
     def test_translation_stays_outside_the_correction_error_mapping(self):
-        with patch.object(nodes, "_translate_prompt_text", side_effect=ValueError("translate")):
+        with patch.object(
+            prompt_nodes,
+            "_translate_prompt_text",
+            side_effect=ValueError("translate"),
+        ):
             with self.assertRaisesRegex(ValueError, "^translate$"):
                 prompt_nodes.EasyUseAnimaPromptCorrector().correct("prompt", "", "")
 
-        with patch.object(nodes, "load_knowledge_base", side_effect=ValueError("correct")):
+        with patch.object(
+            prompt_nodes,
+            "load_knowledge_base",
+            side_effect=ValueError("correct"),
+        ):
             with self.assertRaisesRegex(
                 RuntimeError,
                 r"^\[EasyUse Anima\] prompt correction failed: correct$",
@@ -3107,6 +3137,7 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
     def test_root_prompt_data_conditioning_objects_are_direct_canonical_aliases(self):
         self.assertFalse(hasattr(prompt_artist_mix, "_bind_artist_mix_runtime"))
         self.assertFalse(hasattr(prompt_conditioning, "_bind_conditioning_runtime"))
+        self.assertFalse(hasattr(prompt_data_nodes, "_bind_prompt_data_node_runtime"))
         for name in (
             *self.RETIRED_PROMPT_DATA_ALIASES,
             *self.RETIRED_CONDITIONING_ALIASES,
@@ -3171,8 +3202,12 @@ class PromptDataConditioningMoveContractTests(unittest.TestCase):
             (nodes.PROMPT_DATA_TYPE, *nodes.EasyUseAnimaPromptStudioAdvanced.RETURN_NAMES),
         )
 
-    def test_root_change_key_monkeypatch_drives_canonical_adapter(self):
-        with patch.object(nodes, "_stable_change_key", side_effect=lambda value: value) as stable:
+    def test_canonical_change_key_monkeypatch_drives_canonical_adapter(self):
+        with patch.object(
+            prompt_data_nodes,
+            "_stable_change_key",
+            side_effect=lambda value: value,
+        ) as stable:
             change_key = prompt_data_nodes.EasyUseAnimaPromptDataUnpack.IS_CHANGED(
                 {nodes.PROMPT_DATA_TYPE: True}
             )
@@ -3244,6 +3279,7 @@ class PromptBuilderStudioMoveContractTests(unittest.TestCase):
 
     def test_root_prompt_builder_studio_objects_are_direct_canonical_aliases(self):
         self.assertFalse(hasattr(prompt_fields, "_bind_prompt_fields_runtime"))
+        self.assertFalse(hasattr(prompt_nodes, "_bind_prompt_node_runtime"))
         for name in self.RETIRED_FIELD_DEFAULTS:
             with self.subTest(retired=name):
                 self.assertFalse(hasattr(nodes, name))
@@ -3327,16 +3363,20 @@ class PromptBuilderStudioMoveContractTests(unittest.TestCase):
             artist_overrides=["bound_artist"],
         )
 
-    def test_root_monkeypatches_drive_canonical_builder_order_and_change_key(self):
+    def test_canonical_adapter_monkeypatches_drive_builder_order_and_change_key(self):
         with (
-            patch.object(nodes, "_stable_change_key", side_effect=lambda value: value) as stable,
             patch.object(
-                nodes,
+                prompt_nodes,
+                "_stable_change_key",
+                side_effect=lambda value: value,
+            ) as stable,
+            patch.object(
+                prompt_nodes,
                 "_prompt_translation_change_key",
                 return_value={"bound": "translation"},
             ) as translation_key,
             patch.object(
-                nodes,
+                prompt_nodes,
                 "resolve_metadata_filter_words",
                 return_value="bound filters",
             ) as resolve_filter,
@@ -3352,20 +3392,32 @@ class PromptBuilderStudioMoveContractTests(unittest.TestCase):
         resolve_filter.assert_called_once_with()
 
         with (
-            patch.object(nodes, "_as_bool", side_effect=(True, False)),
-            patch.object(nodes, "_translate_prompt_text", side_effect=lambda value: f"t:{value}"),
-            patch.object(nodes, "_join_prompt_tokens", side_effect=lambda *parts: "|".join(parts)),
+            patch.object(prompt_nodes, "_as_bool", side_effect=(True, False)),
             patch.object(
-                nodes,
+                prompt_nodes,
+                "_translate_prompt_text",
+                side_effect=lambda value: f"t:{value}",
+            ),
+            patch.object(
+                prompt_nodes,
+                "_join_prompt_tokens",
+                side_effect=lambda *parts: "|".join(parts),
+            ),
+            patch.object(
+                prompt_nodes,
                 "_correct_builder_prompt",
                 side_effect=lambda value, artist_overrides="": f"c:{value}:{artist_overrides}",
             ),
             patch.object(
-                nodes,
+                prompt_nodes,
                 "_filter_metadata_prompt",
                 side_effect=lambda prompt, words: f"f:{prompt}:{words}",
             ),
-            patch.object(nodes, "resolve_metadata_filter_words", return_value="filters"),
+            patch.object(
+                prompt_nodes,
+                "resolve_metadata_filter_words",
+                return_value="filters",
+            ),
         ):
             result = prompt_nodes.EasyUseAnimaPromptBuilder().build(
                 True,

--- a/tests/test_nodes_module_analyzer.py
+++ b/tests/test_nodes_module_analyzer.py
@@ -73,12 +73,12 @@ def load_dynamic():
     def test_current_nodes_module_shape_matches_recorded_baseline(self):
         report = analyzer.analyze_path(ROOT / "nodes.py")
 
-        self.assertEqual(report["git_blob_sha1"], "1815fadba3e329f88f95cc8aa29002e86b0b7a24")
-        # B-11c30c1 retires only the six Prompt/Regional service runtime binder
-        # imports and calls without changing the public class surface.
+        self.assertEqual(report["git_blob_sha1"], "50d59e888edad18fa357a5ed0d9e46ac0b3b521f")
+        # B-11c30c2a retires only the Prompt Data and Classic Prompt adapter
+        # runtime binder imports and calls without changing the public class surface.
         self.assertEqual(report["top_level"]["function_count"], 1)
         self.assertEqual(report["top_level"]["class_count"], 0)
-        self.assertEqual(report["line_count"], 1_763)
+        self.assertEqual(report["line_count"], 1_750)
         class_names = {item["name"] for item in report["top_level"]["classes"]}
         self.assertNotIn("EasyUseAnimaAIOGenerator", class_names)
         self.assertNotIn("EasyUseAnimaInput", class_names)

--- a/tests/test_prompt_corrector.py
+++ b/tests/test_prompt_corrector.py
@@ -16,6 +16,7 @@ import nodes
 import settings as easyuse_settings
 from easyuse_anima.naia.client import _clean_prompt
 from easyuse_anima.naia.resolution import ADVANCED_RESOLUTION_BUCKETS
+from easyuse_anima.nodes import prompt_data_nodes, prompt_nodes
 from easyuse_anima.nodes.prompt_advanced_nodes import EasyUseAnimaPromptStudioExtend
 from easyuse_anima.prompt import artist_mix as prompt_artist_mix
 from easyuse_anima.prompt import conditioning as prompt_conditioning
@@ -453,7 +454,11 @@ class PromptBuilderTests(unittest.TestCase):
         self.assertEqual(metadata, prompt)
 
     def test_metadata_filter_only_changes_metadata_prompt(self):
-        with patch("nodes.resolve_metadata_filter_words", return_value="best quality\nhigh detail"):
+        with patch.object(
+            prompt_nodes,
+            "resolve_metadata_filter_words",
+            return_value="best quality\nhigh detail",
+        ):
             prompt, quality, use_amg, metadata = EasyUseAnimaPromptBuilder().build(
                 False,
                 False,
@@ -744,7 +749,11 @@ class PromptBuilderTests(unittest.TestCase):
             "_encode_with_comfy_clip",
             lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
         ):
-            with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+            with patch.object(
+                prompt_data_nodes,
+                "_generate_empty_latent_with_comfy",
+                lambda width, height: {"samples": (width, height, 1)},
+            ):
                 patched_model, positive, negative, latent_image = EasyUseAnimaPromptDataConditioning().apply(
                     model,
                     clip=object(),
@@ -798,7 +807,11 @@ class PromptBuilderTests(unittest.TestCase):
             "_encode_with_comfy_clip",
             lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
         ):
-            with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+            with patch.object(
+                prompt_data_nodes,
+                "_generate_empty_latent_with_comfy",
+                lambda width, height: {"samples": (width, height, 1)},
+            ):
                 with patch.object(
                     prompt_conditioning,
                     "_find_spectrum_anima_mod_guidance_class",
@@ -863,7 +876,11 @@ class PromptBuilderTests(unittest.TestCase):
             "_encode_with_comfy_clip",
             lambda clip, text: [[f"cond:{text}", {"encoded_text": text}]],
         ):
-            with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+            with patch.object(
+                prompt_data_nodes,
+                "_generate_empty_latent_with_comfy",
+                lambda width, height: {"samples": (width, height, 1)},
+            ):
                 with patch.object(
                     prompt_conditioning,
                     "_find_spectrum_anima_mod_guidance_class",
@@ -945,7 +962,11 @@ class PromptBuilderTests(unittest.TestCase):
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch.object(prompt_artist_mix, "_blend_conditionings", fake_blend):
-                with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+                with patch.object(
+                    prompt_data_nodes,
+                    "_generate_empty_latent_with_comfy",
+                    lambda width, height: {"samples": (width, height, 1)},
+                ):
                     _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                         object(),
                         clip=object(),
@@ -982,7 +1003,11 @@ class PromptBuilderTests(unittest.TestCase):
             return [[f"cond:{text}", {"encoded_text": text}]]
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
-            with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+            with patch.object(
+                prompt_data_nodes,
+                "_generate_empty_latent_with_comfy",
+                lambda width, height: {"samples": (width, height, 1)},
+            ):
                 _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                     object(),
                     clip=object(),
@@ -1018,7 +1043,11 @@ class PromptBuilderTests(unittest.TestCase):
             return [[f"cond:{text}", {"encoded_text": text}]]
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
-            with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+            with patch.object(
+                prompt_data_nodes,
+                "_generate_empty_latent_with_comfy",
+                lambda width, height: {"samples": (width, height, 1)},
+            ):
                 _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                     object(),
                     clip=object(),
@@ -1053,7 +1082,11 @@ class PromptBuilderTests(unittest.TestCase):
 
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch.object(prompt_artist_mix, "_encode_artist_delta_rms", fake_delta):
-                with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+                with patch.object(
+                    prompt_data_nodes,
+                    "_generate_empty_latent_with_comfy",
+                    lambda width, height: {"samples": (width, height, 1)},
+                ):
                     _model, positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                         object(),
                         clip=object(),
@@ -1100,7 +1133,11 @@ class PromptBuilderTests(unittest.TestCase):
         with patch_comfy_helper(nodes, "_encode_with_comfy_clip", fake_encode):
             with patch.object(prompt_artist_mix, "_encode_artist_delta_rms", fake_delta):
                 with patch.object(prompt_artist_mix, "_encode_artist_clustered", fake_clustered):
-                    with patch("nodes._generate_empty_latent_with_comfy", lambda width, height: {"samples": (width, height, 1)}):
+                    with patch.object(
+                        prompt_data_nodes,
+                        "_generate_empty_latent_with_comfy",
+                        lambda width, height: {"samples": (width, height, 1)},
+                    ):
                         _model, delta_positive, _negative, _latent = EasyUseAnimaPromptDataConditioning().apply(
                             object(),
                             clip=object(),

--- a/tests/test_python_compatibility_surface.py
+++ b/tests/test_python_compatibility_surface.py
@@ -91,7 +91,7 @@ PROMPT_SERVICE_RUNTIME_BINDERS = (
     "_bind_prompt_fields_runtime",
     "_bind_prompt_correction_runtime",
 )
-PROMPT_NODE_ADAPTER_UNBLOCKED_RUNTIME_BINDERS = (
+PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS = (
     "_bind_prompt_data_node_runtime",
     "_bind_prompt_node_runtime",
 )
@@ -101,7 +101,6 @@ PROMPT_NODE_ADAPTER_SEED_BLOCKED_RUNTIME_BINDERS = (
 )
 PROMPT_NODE_ADAPTER_RUNTIME_BINDERS = (
     *PROMPT_NODE_ADAPTER_SEED_BLOCKED_RUNTIME_BINDERS,
-    *PROMPT_NODE_ADAPTER_UNBLOCKED_RUNTIME_BINDERS,
 )
 RUNTIME_BINDER_FAMILIES = {
     "aio": (
@@ -2138,6 +2137,7 @@ def _build_document() -> dict[str, Any]:
                 "B-11c30c",
                 "B-11c30c1",
                 "B-11c30c2",
+                "B-11c30c2a",
             ],
         },
         "enums": {
@@ -2150,14 +2150,14 @@ def _build_document() -> dict[str, Any]:
         "expected_counts": {
             "root_entrypoints": 3,
             "excluded_preamble_implementation_bindings": 5,
-            "nodes_canonical_bindings": 283,
+            "nodes_canonical_bindings": 281,
             "nodes_legacy_bindings": 27,
             "mapped_public_classes": 18,
             "unmapped_classes": 2,
             "root_residual_functions": 1,
             "root_residual_classes": 0,
             "root_residual_globals": 26,
-            "runtime_binders": 18,
+            "runtime_binders": 16,
             "direct_nodes_import_test_files": 21,
         },
         "mapped_public_classes": sorted(mapped_classes),
@@ -2389,7 +2389,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             len(self.document["direct_nodes_import_test_files"]),
             counts["direct_nodes_import_test_files"],
         )
-        self.assertEqual(len(set(self.document["runtime_binders"])), 18)
+        self.assertEqual(len(set(self.document["runtime_binders"])), 16)
         self.assertEqual(len(set(self.document["direct_nodes_import_test_files"])), 21)
 
     def test_runtime_binder_audit_covers_provider_and_root_names(self):
@@ -2397,21 +2397,21 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
         self.assertEqual(
             audit["summary"],
             {
-                "binder_count": 18,
+                "binder_count": 16,
                 "family_count": 3,
                 "mode_counts": {
-                    "comfy_provider_then_root": 10,
-                    "root_globals": 6,
+                    "comfy_provider_then_root": 9,
+                    "root_globals": 5,
                     "explicit_callbacks": 2,
                 },
-                "unique_resolver_names": 248,
-                "unique_root_resolver_names": 243,
+                "unique_resolver_names": 237,
+                "unique_root_resolver_names": 232,
                 "unique_provider_resolver_names": 5,
                 "unique_direct_root_dependencies": 10,
-                "direct_root_dependency_slots": 21,
-                "provider_consumer_slots": 15,
-                "provider_consumer_modules": 10,
-                "repository_replacement_names": 148,
+                "direct_root_dependency_slots": 20,
+                "provider_consumer_slots": 14,
+                "provider_consumer_modules": 9,
+                "repository_replacement_names": 142,
                 "repository_replacement_files": 18,
             },
         )
@@ -2479,7 +2479,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                     "call_time_resolver",
                 )
 
-    def test_prompt_service_binders_are_retired_and_node_adapter_group_is_exact(self):
+    def test_prompt_service_and_unblocked_node_adapter_binders_are_retired(self):
         audit = self.document["runtime_binder_audit"]
         self.assertNotIn("prompt_regional", audit["families"])
         self.assertNotIn("prompt_services", audit["families"])
@@ -2488,7 +2488,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             list(PROMPT_NODE_ADAPTER_RUNTIME_BINDERS),
         )
         self.assertEqual(
-            list(PROMPT_NODE_ADAPTER_UNBLOCKED_RUNTIME_BINDERS),
+            list(PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS),
             [
                 "_bind_prompt_data_node_runtime",
                 "_bind_prompt_node_runtime",
@@ -2502,19 +2502,22 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             ],
         )
         self.assertTrue(
-            set(PROMPT_SERVICE_RUNTIME_BINDERS).isdisjoint(
-                self.document["runtime_binders"]
-            )
+            (
+                set(PROMPT_SERVICE_RUNTIME_BINDERS)
+                | set(PROMPT_NODE_ADAPTER_RETIRED_RUNTIME_BINDERS)
+            ).isdisjoint(self.document["runtime_binders"])
         )
-        service_modules = {
+        retired_modules = {
             "_bind_regional_runtime": "easyuse_anima.prompt.regional",
             "_bind_advanced_runtime": "easyuse_anima.prompt.advanced",
             "_bind_conditioning_runtime": "easyuse_anima.prompt.conditioning",
             "_bind_artist_mix_runtime": "easyuse_anima.prompt.artist_mix",
             "_bind_prompt_fields_runtime": "easyuse_anima.prompt.fields",
             "_bind_prompt_correction_runtime": "easyuse_anima.prompt.correction",
+            "_bind_prompt_data_node_runtime": "easyuse_anima.nodes.prompt_data_nodes",
+            "_bind_prompt_node_runtime": "easyuse_anima.nodes.prompt_nodes",
         }
-        for binder, module in service_modules.items():
+        for binder, module in retired_modules.items():
             functions = {
                 node.name
                 for node in _read_tree(_module_path(module)).body
@@ -2538,14 +2541,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
                     "easyuse_anima.nodes.prompt_advanced_nodes",
                     "root_globals",
                 ),
-                "_bind_prompt_data_node_runtime": (
-                    "easyuse_anima.nodes.prompt_data_nodes",
-                    "comfy_provider_then_root",
-                ),
-                "_bind_prompt_node_runtime": (
-                    "easyuse_anima.nodes.prompt_nodes",
-                    "root_globals",
-                ),
             },
         )
         entry_by_binder = {
@@ -2553,12 +2548,6 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             for entry in audit["entries"]
             if entry["binder"] in PROMPT_NODE_ADAPTER_RUNTIME_BINDERS
         }
-        for binder in PROMPT_NODE_ADAPTER_UNBLOCKED_RUNTIME_BINDERS:
-            with self.subTest(unblocked=binder):
-                self.assertNotIn(
-                    "_consume_reserved_wildcard_next_seed",
-                    entry_by_binder[binder]["root_resolver_names"],
-                )
         for binder in PROMPT_NODE_ADAPTER_SEED_BLOCKED_RUNTIME_BINDERS:
             with self.subTest(seed_blocked=binder):
                 self.assertIn(
@@ -2573,7 +2562,7 @@ class PythonCompatibilitySurfaceTests(unittest.TestCase):
             "_AIO_FIRST_PASS_CACHE_ORDER",
             "_load_aio_resources_from_input_context",
             "_sample_latent_with_aio_backend",
-            "_encode_prompt_data_positive_conditioning",
+            "_advanced_fields_json",
         }
         consumers = self.document["runtime_resolver_consumers"]
         classifications = {


### PR DESCRIPTION
## 변경 요약

- B-11c30c2a에서 Prompt Data와 Classic Prompt 노드 어댑터의 두 runtime binder를 제거했습니다.
- Prompt Data는 canonical prompt/AiO helper를 직접 사용하고 CLIP 인코딩은 기존 E-07 provider를 call time에 해석합니다.
- Classic Prompt는 canonical common/prompt helper와 기존 `anima_prompt`/`settings` fallback import를 직접 사용합니다.
- Advanced/Regional 어댑터와 `_consume_reserved_wildcard_next_seed`는 #167/D-12 경계로 유지했습니다.

## 작업 전 inventory

- 기준: `dev@6a21e2667ea5eb8723346d44d8d913444f230b05`
- 유형: Move
- 대상:
  - `easyuse_anima.nodes.prompt_data_nodes:_bind_prompt_data_node_runtime`
  - `easyuse_anima.nodes.prompt_nodes:_bind_prompt_node_runtime`
- 호출자:
  - root `nodes.py` relative-package/flat-fallback import 각 2개
  - root import-time binder 호출 각 1개
- bind/global state: 12 slots / 12 unique
- resolver: 30 root slots / 27 unique
- E-07 provider: Prompt Data `_encode_with_comfy_clip` 1 slot
- direct root dependency: `_resolve_comfy_host_helper` 1 slot
- repository replacement evidence: 20 slots / 17 unique
- 두 binder 모두 `_consume_reserved_wildcard_next_seed`를 사용하지 않음
- binder는 private migration seam이며 mapped node class는 direct canonical re-export임

## 구현 결과

- root binder import/call과 canonical binder 정의 및 bind-time mutation state를 제거했습니다.
- Comfy host ledger는 22 consumer slots / 15 modules로 유지됩니다.
- 남은 runtime binder는 16개입니다.
  - provider-then-root 9
  - root-only 5
  - explicit callbacks 2
- `nodes.py`는 1,763줄에서 1,750줄로 줄었습니다.
- root-only 테스트 seam은 canonical adapter/provider seam으로 이전했습니다.
- schema, mapped-class identity, prompt/conditioning 출력, provider lookup order, optional-dependency timing, saved workflow, seed/wildcard 동작은 변경하지 않았습니다.

## 주요 변경 파일

Production:

- `nodes.py`
- `easyuse_anima/nodes/prompt_data_nodes.py`
- `easyuse_anima/nodes/prompt_nodes.py`

Gate/docs/tests:

- backend roadmap/provider/compatibility 문서
- compatibility/Comfy host/backend analyzer fixtures
- Prompt Data·Classic Prompt contract/behavior tests

## 검증

Focused:

- Python compatibility surface: 21 passed
- Prompt Data / Prompt Builder / Prompt Corrector move contracts: 5 + 6 + 7 passed
- Prompt Builder / Prompt Corrector behavior: 63 + 15 passed
- Comfy host wiring: 10 passed
- Python backend analyzer: 18 passed
- 최종 deterministic gate 재확인: public contract 1, nodes analyzer 4, compatibility 21 passed

Official full:

- Python unittest: 966 passed
- Frontend: 114 JavaScript files passed
- Python compile: passed
- Pyright baseline ratchet: passed
- Python import boundary gate: passed
- git diff check: passed
- 최종 실행 시간: 48.7초
- Ruff: 68 findings, G-01 report-only

## 테스트 표면

- ComfyUI Codex test instance: repository full/module contract
- Live ComfyUI smoke: not run

## 남은 위험 / 제외

- B-11c30c2b의 Advanced/Regional binder는 #167/D-12 seed-reservation owner가 생길 때까지 차단 상태입니다.
- Live browser/runtime 실행은 이번 mechanical Move 범위에서 수행하지 않았습니다.
