### PR TITLE
S167-01: backend seed reservation 계약 고정

### DIFF
--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -32,7 +32,7 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
 | --- | --- | --- |
 | A - baseline | Complete; #191 is closed | Keep fixtures and analyzers current during later moves |
 | B - `nodes.py` extraction | Integrated through B-11c30c / PR #339 / `d0188b5` | Retire the Prompt/Regional service and node-adapter binder lanes separately, complete the remaining binder families, then perform the final root shim as a separate Move |
-| C - feature contracts/behavior | Partially complete | Finish #168; then #167 and #169 in separate Contract/Behavior PRs |
+| C - feature contracts/behavior | Partially complete through S167-01 / PR #343 | Continue #167 and #169 in separate Contract/Move/Behavior PRs |
 | D - root consolidation | Not started | Execute #186 feature by feature after the corresponding behavior contracts are stable |
 | E - runtime ownership | Partial: E-02a and E-07a/E-07b integrated | Continue #187 only where canonical feature owners and explicit contracts exist |
 | F - typed boundaries | Partial patterns exist | Extend typed request/result/config and pure migration patterns feature by feature |
@@ -110,9 +110,10 @@ merged PR, the owning issue's evidence record, and every stated exit gate.
   `4cc5cab`, leaving 18 binders across AiO, Prompt node adapters, and
   Wildcard/NAIA. B-11c30c2 completes the production-free split gate in PR
   #341 / `6a21e26`: c2a owns the Prompt Data and Classic Prompt adapters, while
-  c2b owns Advanced and Regional only after #167/D-12 resolves their root
-  seed-reservation dependency. B-11c30c2a completes the unblocked adapter Move
-  in PR #342; c2b remains blocked.
+  c2b owns Advanced and Regional only after their root seed-reservation
+  dependency has a canonical behavior-preserving owner. B-11c30c2a completes
+  the unblocked adapter Move in PR #342. S167-01 / PR #343 freezes the contract
+  and exact owner-Move boundary; c2b remains blocked only by that separate Move.
 
 ### Current quality baseline
 
@@ -354,8 +355,8 @@ surfaces. AiO mechanical extraction must not start until #168 exits.
 | 11 | B-09b2 AiO generator adapter move | COMPLETE on `dev` | Move | #184 | PR #270 / `57d40b4` |
 | 12 | B-10a machine-readable compatibility audit | COMPLETE on `dev` | Contract/gate | #184/#188 | PR #271 / `3c7b857` |
 | 13 | B-10b private alias reduction | COMPLETE on `dev` through PR #291 / `c6b4680` | Contract/cleanup, split PRs | #184/#188 | Audited alias surface integrated |
-| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2a PR #342; the remaining c2b adapters wait on #167/D-12 | Move/Contract, split PRs | #184 | c2b waits for #167/D-12 seed reservation ownership |
-| 15 | S167 backend seed reservation series | BLOCKED by B exit/interface | Contract then Behavior | #167 | Canonical AiO/node seams |
+| 14 | B-11 registration/bootstrap/root shim | IN PROGRESS through B-11c30c2a PR #342; the remaining c2b adapters wait on the S167-01 canonical consumer Move | Move/Contract, split PRs | #184 | S167-01 contract |
+| 15 | S167 backend seed reservation series | S167-01 Contract COMPLETE in PR #343; consumer Move, Behavior, and Adapter remain | Contract then Move then Behavior | #167 | Canonical AiO/node seams |
 | 16 | A169 stage pipeline series | BLOCKED by #168 and B exit | Contract then Behavior | #169 | Typed config and mechanical AiO move |
 | 17 | A169 first-pass cache policy | BLOCKED by stage/cache ownership seam | Behavior | #169 | Mechanical cache move and benchmark harness |
 | 18 | D-series canonical root consolidation | BLOCKED by relevant C contracts | Move | #186 | Phase B exit; per-feature behavior stable |
@@ -1025,9 +1026,11 @@ unchanged. The separate legacy Wildcard unsupported alias remains for D-12.
     and Classic Prompt adapters have complete canonical/provider owners and form
     B-11c30c2a. Advanced and Regional both call the root-only
     `_consume_reserved_wildcard_next_seed` from their real build paths; they
-    form B-11c30c2b and remain blocked until #167 S167-01 or D-12 supplies the
-    behavior-preserving owner. Do not add a callback binder, import root
-    `nodes.py`, or duplicate seed reservation merely to retire these binders.
+    form B-11c30c2b. S167-01 / PR #343 freezes the request/service contract but
+    intentionally does not move this consumer. A separate behavior-preserving
+    consumer Move must supply the owner before c2b. Do not add a callback
+    binder, import root `nodes.py`, or duplicate seed reservation merely to
+    retire these binders.
   - B-11c30c2a retires only `_bind_prompt_data_node_runtime` and
     `_bind_prompt_node_runtime` in PR #342. Prompt Data uses canonical
     prompt/AiO owners plus the existing E-07 CLIP provider at call time;
@@ -1081,7 +1084,8 @@ S167-01 uses
 symbol/caller/alias/global-state inventory and allowed-file gate. The contract
 does not itself move the root Prompt Studio compatibility consumer. That
 behavior-preserving owner Move and B-11c30c2b remain separate rollback units
-before S167-02.
+before S167-02. PR #343 completes this contract without changing any existing
+runtime, payload bytes, or reservation behavior.
 
 Do not mix this sequence into B-09 or #169 stages.
 

--- a/docs/architecture/python-backend-execution-roadmap.md
+++ b/docs/architecture/python-backend-execution-roadmap.md
@@ -1076,6 +1076,13 @@ Split into at least these rollback units:
 3. **S167-03 Adapter:** browser queue interceptor becomes a compatibility/display
    adapter; headless and browser behavior parity is proven.
 
+S167-01 uses
+[`seed-reservation-contract.md`](seed-reservation-contract.md) as its exact
+symbol/caller/alias/global-state inventory and allowed-file gate. The contract
+does not itself move the root Prompt Studio compatibility consumer. That
+behavior-preserving owner Move and B-11c30c2b remain separate rollback units
+before S167-02.
+
 Do not mix this sequence into B-09 or #169 stages.
 
 ### A169 — Stage pipeline (#169)

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -122,11 +122,20 @@ migration. The parser does not select a concrete seed or consult mutable state.
 
 S167-01 may change only:
 
+- `easyuse_anima/__init__.py`;
 - `easyuse_anima/seed/__init__.py`;
 - `easyuse_anima/seed/reservation.py`;
 - `tests/test_seed_reservation_contract.py`;
+- `tests/test_python_backend_analyzer.py`;
+- `tests/fixtures/python_backend_baseline.json`;
 - `docs/architecture/seed-reservation-contract.md`;
 - `docs/architecture/python-backend-execution-roadmap.md`.
+
+The root and seed package initializers may expose only the side-effect-free seed
+contract modules needed to keep shipped modules inside the runtime import
+closure. The analyzer test and baseline fixture may change only by that
+deterministic module-inventory delta. These are contract/gate maintenance, not
+a Move or Behavior change.
 
 S167-01 must not change:
 

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -131,11 +131,12 @@ S167-01 may change only:
 - `docs/architecture/seed-reservation-contract.md`;
 - `docs/architecture/python-backend-execution-roadmap.md`.
 
-The root and seed package initializers may expose only the side-effect-free seed
-contract modules needed to keep shipped modules inside the runtime import
-closure. The analyzer test and baseline fixture may change only by that
-deterministic module-inventory delta. These are contract/gate maintenance, not
-a Move or Behavior change.
+The root and seed package initializers may privately import only the
+side-effect-free seed contract modules needed to keep shipped modules inside
+the runtime import closure. Their existing empty public `__all__` surfaces must
+remain unchanged. The analyzer test and baseline fixture may change only by
+that deterministic module-inventory delta. These are contract/gate
+maintenance, not a Move or Behavior change.
 
 S167-01 must not change:
 

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -1,0 +1,156 @@
+# Backend seed reservation contract
+
+- Owner issue: [#167](https://github.com/n0va39/ComfyUI-EasyUseAnima/issues/167)
+- Roadmap unit: S167-01
+- PR type: Contract
+- Inventory baseline: `dev` commit
+  `ddcc2517f0286fd4e249ff18b09e80a8a64e3dc7`
+
+This document freezes the request and service boundary needed before backend
+seed reservation behavior is implemented. S167-01 does not reserve, advance,
+commit, release, retry, or cancel a seed.
+
+## Current inventory
+
+### Symbols and owners
+
+| Surface | Current owner | Contract evidence |
+| --- | --- | --- |
+| AiO legacy sentinels | `easyuse_anima.aio.generation_normalization` | `AIO_SPECIAL_SEED_RANDOM = -1`, `AIO_SPECIAL_SEED_INCREMENT = -2`, `AIO_SPECIAL_SEED_DECREMENT = -3` |
+| AiO input normalization | `easyuse_anima.aio.generation_normalization._normalize_aio_seed` | Values are normalized into the legacy `-3..MAX_SEED` range |
+| AiO execution seed | `easyuse_anima.aio.sampling._resolve_aio_runtime_seed` | All three legacy sentinels currently become a fresh random seed in backend execution |
+| AiO browser reservation | `web/js/aio/generator_queue_runtime.js` | A per-runtime `WeakMap` reserves concrete seeds and settles accepted/rejected calls in FIFO order |
+| Prompt Studio browser reservation | `web/js/prompt_studio/advanced_queue_seed_runtime.js` | A separate runtime injects a version-1 hidden next-seed payload |
+| Prompt Studio backend payload consumer | root `nodes.py._consume_reserved_wildcard_next_seed` | Consumes and removes the hidden payload from request-local inputs and the workflow prompt |
+| Prompt Studio seed arithmetic | root `wildcard_engine.py` and `web/js/prompt_studio/wildcard_seed_contract.js` | Fixed/randomize/increment/decrement use the JavaScript-safe public range for advanced controls |
+| Runtime composition | `easyuse_anima.runtime.RuntimeServices` | Only the Comfy host provider is composed; no backend seed-reservation service exists |
+
+### Callers and aliases
+
+- `_resolve_aio_runtime_seed` is called by AiO sampling, legacy generation, and
+  output paths. Root `nodes.py` retains direct compatibility aliases for the
+  AiO special-seed constants and normalization/sampling helpers.
+- `_consume_reserved_wildcard_next_seed` has exactly two production callers:
+  `easyuse_anima.nodes.prompt_advanced_nodes` and
+  `easyuse_anima.nodes.regional_nodes`.
+- Those two node adapters receive the root consumer through
+  `_bind_prompt_advanced_node_runtime` and `_bind_regional_node_runtime`.
+  B-11c30c2b cannot retire those binders until a separate Move supplies a
+  canonical behavior-preserving consumer.
+- No Python service or request object currently represents a reservation.
+
+### Existing payloads
+
+The Prompt Studio hidden payload is version 1:
+
+```json
+{
+  "version": 1,
+  "current_seed": 42,
+  "next_seed": 43,
+  "mode": "populate",
+  "control": "increment"
+}
+```
+
+It is a browser-computed compatibility payload, not an authoritative backend
+reservation. AiO has no equivalent reservation payload: its serialized sampler
+settings contain `seed` and `seed_after_generate`, and the browser replaces a
+legacy sentinel with a concrete seed before queue submission when the extension
+is loaded.
+
+### Mutable and request-local state
+
+- AiO browser reservation state is a `WeakMap` local to one queue runtime.
+- Prompt Studio browser reservation state is local to its queue runtime and
+  settles the hidden payload after the queue result.
+- Backend execution owns no reservation map, lock, token, or lifecycle state.
+- The root Prompt Studio consumer mutates only the passed request dictionaries
+  by removing its hidden compatibility input.
+- `RuntimeServices` owns no seed state.
+
+## S167-01 contract
+
+The canonical package boundary is `easyuse_anima.seed.reservation`.
+
+### Request
+
+`SeedReservationRequest` carries:
+
+- `version`: contract version 1;
+- `stream_id`: stable logical seed stream identity;
+- `request_id`: idempotency identity for one queue request;
+- `selection`: `concrete`, `randomize`, `increment`, or `decrement`;
+- `seed`: a non-negative concrete seed only when `selection` is `concrete`;
+- `after_generate`: `fixed`, `randomize`, `increment`, or `decrement`.
+
+The request contains intent only. It does not contain a browser-authoritative
+`next_seed`.
+
+### Reservation and settlement
+
+`SeedReservation` carries the service-selected concrete execution seed and
+opaque reservation identity. `SeedReservationSettlement` is one of
+`accepted`, `rejected`, or `cancelled`.
+
+`SeedReservationService` exposes only:
+
+1. `reserve(request) -> SeedReservation`;
+2. `settle(reservation_id, settlement) -> None`.
+
+Atomic ordering, seed arithmetic, random generation, idempotent settlement,
+late acceptance, retry, cancellation, storage lifetime, and cleanup are
+S167-02 Behavior. The browser compatibility/display cutover is S167-03.
+
+### Legacy compatibility parsing
+
+The compatibility parser accepts an already normalized legacy seed value:
+
+| Legacy value | Selection |
+| --- | --- |
+| `-1` | `randomize` |
+| `-2` | `increment` |
+| `-3` | `decrement` |
+| `0` or greater | `concrete` with the same seed |
+
+Other negative values are invalid at this boundary. Existing AiO normalization
+continues to own coercion and clamping until a later separately classified
+migration. The parser does not select a concrete seed or consult mutable state.
+
+## Allowed-file boundary
+
+S167-01 may change only:
+
+- `easyuse_anima/seed/__init__.py`;
+- `easyuse_anima/seed/reservation.py`;
+- `tests/test_seed_reservation_contract.py`;
+- `docs/architecture/seed-reservation-contract.md`;
+- `docs/architecture/python-backend-execution-roadmap.md`.
+
+S167-01 must not change:
+
+- root `nodes.py` or `wildcard_engine.py`;
+- AiO generation, sampling, or output modules;
+- Prompt Studio or AiO frontend files;
+- `RuntimeServices`, bootstrap, registration, routes, or workflow schemas;
+- existing hidden payload bytes;
+- seed arithmetic, random generation, queue ordering, failure, retry, or
+  cancellation behavior;
+- B-11c30c2b binders.
+
+## Follow-up rollback units
+
+1. **S167-01 Contract:** add the pure request/result/service types and legacy
+   parser described here.
+2. **Seed consumer Move:** move the existing root hidden-payload consumer to a
+   canonical owner without changing bytes, mutations, validation, or return
+   values.
+3. **B-11c30c2b Move:** retire the Advanced and Regional node-adapter binders
+   against that canonical owner.
+4. **S167-02 Behavior:** implement the authoritative atomic backend service and
+   lifecycle.
+5. **S167-03 Adapter:** reduce browser interceptors to compatibility/display
+   adapters and prove browser/headless parity.
+
+No step may copy the current root consumer, import root `nodes.py` from the
+canonical package, or mix reservation behavior into a Move.

--- a/docs/architecture/seed-reservation-contract.md
+++ b/docs/architecture/seed-reservation-contract.md
@@ -77,6 +77,7 @@ The canonical package boundary is `easyuse_anima.seed.reservation`.
 
 `SeedReservationRequest` carries:
 
+- `schema`: `easyuse_anima_seed_reservation_request`;
 - `version`: contract version 1;
 - `stream_id`: stable logical seed stream identity;
 - `request_id`: idempotency identity for one queue request;
@@ -89,9 +90,9 @@ The request contains intent only. It does not contain a browser-authoritative
 
 ### Reservation and settlement
 
-`SeedReservation` carries the service-selected concrete execution seed and
-opaque reservation identity. `SeedReservationSettlement` is one of
-`accepted`, `rejected`, or `cancelled`.
+`SeedReservation` carries the service-selected concrete execution seed,
+candidate accepted `next_seed`, and opaque reservation identity.
+`SeedReservationSettlement` is one of `accepted`, `rejected`, or `cancelled`.
 
 `SeedReservationService` exposes only:
 

--- a/easyuse_anima/__init__.py
+++ b/easyuse_anima/__init__.py
@@ -1,5 +1,5 @@
 """Internal package boundary for EasyUse Anima backend modules."""
 
-from . import seed as seed
+from . import seed as _seed
 
-__all__ = ("seed",)
+__all__ = ()

--- a/easyuse_anima/__init__.py
+++ b/easyuse_anima/__init__.py
@@ -1,3 +1,5 @@
 """Internal package boundary for EasyUse Anima backend modules."""
 
-__all__ = ()
+from . import seed as seed
+
+__all__ = ("seed",)

--- a/easyuse_anima/seed/__init__.py
+++ b/easyuse_anima/seed/__init__.py
@@ -1,0 +1,3 @@
+"""Side-effect-free backend seed reservation contracts."""
+
+__all__ = ()

--- a/easyuse_anima/seed/__init__.py
+++ b/easyuse_anima/seed/__init__.py
@@ -1,3 +1,5 @@
 """Side-effect-free backend seed reservation contracts."""
 
-__all__ = ()
+from . import reservation as reservation
+
+__all__ = ("reservation",)

--- a/easyuse_anima/seed/__init__.py
+++ b/easyuse_anima/seed/__init__.py
@@ -1,5 +1,5 @@
 """Side-effect-free backend seed reservation contracts."""
 
-from . import reservation as reservation
+from . import reservation as _reservation
 
-__all__ = ("reservation",)
+__all__ = ()

--- a/easyuse_anima/seed/reservation.py
+++ b/easyuse_anima/seed/reservation.py
@@ -1,0 +1,300 @@
+# pyright: strict
+"""Pure request and service contracts for backend seed reservation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypeAlias, cast
+
+
+SEED_RESERVATION_REQUEST_SCHEMA = "easyuse_anima_seed_reservation_request"
+SEED_RESERVATION_CONTRACT_VERSION = 1
+
+SEED_SELECTION_CONCRETE = "concrete"
+SEED_SELECTION_RANDOMIZE = "randomize"
+SEED_SELECTION_INCREMENT = "increment"
+SEED_SELECTION_DECREMENT = "decrement"
+SEED_SELECTIONS = frozenset(
+    {
+        SEED_SELECTION_CONCRETE,
+        SEED_SELECTION_RANDOMIZE,
+        SEED_SELECTION_INCREMENT,
+        SEED_SELECTION_DECREMENT,
+    }
+)
+
+SEED_CONTROL_FIXED = "fixed"
+SEED_CONTROLS = frozenset(
+    {
+        SEED_CONTROL_FIXED,
+        SEED_SELECTION_RANDOMIZE,
+        SEED_SELECTION_INCREMENT,
+        SEED_SELECTION_DECREMENT,
+    }
+)
+
+SEED_SETTLEMENT_ACCEPTED = "accepted"
+SEED_SETTLEMENT_REJECTED = "rejected"
+SEED_SETTLEMENT_CANCELLED = "cancelled"
+SEED_SETTLEMENTS = frozenset(
+    {
+        SEED_SETTLEMENT_ACCEPTED,
+        SEED_SETTLEMENT_REJECTED,
+        SEED_SETTLEMENT_CANCELLED,
+    }
+)
+
+SeedSelection: TypeAlias = Literal[
+    "concrete",
+    "randomize",
+    "increment",
+    "decrement",
+]
+SeedControl: TypeAlias = Literal[
+    "fixed",
+    "randomize",
+    "increment",
+    "decrement",
+]
+SeedReservationSettlement: TypeAlias = Literal[
+    "accepted",
+    "rejected",
+    "cancelled",
+]
+
+_LEGACY_SELECTION_BY_SEED: Mapping[int, SeedSelection] = {
+    -1: SEED_SELECTION_RANDOMIZE,
+    -2: SEED_SELECTION_INCREMENT,
+    -3: SEED_SELECTION_DECREMENT,
+}
+
+
+class SeedReservationContractError(ValueError):
+    """A seed reservation request or result violates the versioned contract."""
+
+
+def _require_version(value: object) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value != SEED_RESERVATION_CONTRACT_VERSION
+    ):
+        raise SeedReservationContractError(
+            "Seed reservation version is missing or unsupported"
+        )
+    return value
+
+
+def _require_identity(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SeedReservationContractError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _require_choice(
+    value: object,
+    choices: frozenset[str],
+    label: str,
+) -> str:
+    if not isinstance(value, str) or value not in choices:
+        raise SeedReservationContractError(f"{label} is invalid")
+    return value
+
+
+def _require_concrete_seed(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SeedReservationContractError(
+            f"{label} must be a non-negative integer"
+        )
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class SeedReservationRequest:
+    """Versioned intent for one logical seed stream and queue request."""
+
+    schema: str
+    version: int
+    stream_id: str
+    request_id: str
+    selection: SeedSelection
+    seed: int | None
+    after_generate: SeedControl
+
+    def __post_init__(self) -> None:
+        if self.schema != SEED_RESERVATION_REQUEST_SCHEMA:
+            raise SeedReservationContractError(
+                "Seed reservation schema is missing or unsupported"
+            )
+        _require_version(self.version)
+        object.__setattr__(
+            self,
+            "stream_id",
+            _require_identity(self.stream_id, "Seed stream_id"),
+        )
+        object.__setattr__(
+            self,
+            "request_id",
+            _require_identity(self.request_id, "Seed request_id"),
+        )
+        selection = cast(
+            SeedSelection,
+            _require_choice(self.selection, SEED_SELECTIONS, "Seed selection"),
+        )
+        object.__setattr__(self, "selection", selection)
+        object.__setattr__(
+            self,
+            "after_generate",
+            cast(
+                SeedControl,
+                _require_choice(
+                    self.after_generate,
+                    SEED_CONTROLS,
+                    "Seed after_generate",
+                ),
+            ),
+        )
+        if selection == SEED_SELECTION_CONCRETE:
+            object.__setattr__(
+                self,
+                "seed",
+                _require_concrete_seed(self.seed, "Concrete seed"),
+            )
+        elif self.seed is not None:
+            raise SeedReservationContractError(
+                "Non-concrete seed selection must not carry a seed"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SeedReservation:
+    """Opaque reservation plus service-selected concrete seed state."""
+
+    version: int
+    reservation_id: str
+    stream_id: str
+    request_id: str
+    execution_seed: int
+    next_seed: int
+
+    def __post_init__(self) -> None:
+        _require_version(self.version)
+        object.__setattr__(
+            self,
+            "reservation_id",
+            _require_identity(self.reservation_id, "Seed reservation_id"),
+        )
+        object.__setattr__(
+            self,
+            "stream_id",
+            _require_identity(self.stream_id, "Seed stream_id"),
+        )
+        object.__setattr__(
+            self,
+            "request_id",
+            _require_identity(self.request_id, "Seed request_id"),
+        )
+        object.__setattr__(
+            self,
+            "execution_seed",
+            _require_concrete_seed(self.execution_seed, "Execution seed"),
+        )
+        object.__setattr__(
+            self,
+            "next_seed",
+            _require_concrete_seed(self.next_seed, "Next seed"),
+        )
+
+
+class SeedReservationService(Protocol):
+    """Port implemented by the authoritative S167-02 reservation owner."""
+
+    def reserve(self, request: SeedReservationRequest) -> SeedReservation: ...
+
+    def settle(
+        self,
+        reservation_id: str,
+        settlement: SeedReservationSettlement,
+    ) -> None: ...
+
+
+def parse_seed_reservation_request(
+    payload: Mapping[str, object],
+) -> SeedReservationRequest:
+    """Parse a version-1 concrete request without reserving or selecting a seed."""
+
+    if not isinstance(cast(object, payload), Mapping):
+        raise SeedReservationContractError(
+            "Seed reservation request must be a JSON object"
+        )
+    return SeedReservationRequest(
+        schema=cast(str, payload.get("schema")),
+        version=cast(int, payload.get("version")),
+        stream_id=cast(str, payload.get("stream_id")),
+        request_id=cast(str, payload.get("request_id")),
+        selection=cast(SeedSelection, payload.get("selection")),
+        seed=cast(int | None, payload.get("seed")),
+        after_generate=cast(SeedControl, payload.get("after_generate")),
+    )
+
+
+def parse_legacy_seed_reservation_request(
+    *,
+    stream_id: str,
+    request_id: str,
+    normalized_seed: int,
+    after_generate: SeedControl,
+) -> SeedReservationRequest:
+    """Translate an already-normalized legacy AiO seed without choosing a seed."""
+
+    if isinstance(normalized_seed, bool) or not isinstance(normalized_seed, int):
+        raise SeedReservationContractError(
+            "Legacy normalized seed must be an integer"
+        )
+    if normalized_seed < -3:
+        raise SeedReservationContractError(
+            "Legacy normalized seed is outside the supported range"
+        )
+    selection = _LEGACY_SELECTION_BY_SEED.get(
+        normalized_seed,
+        SEED_SELECTION_CONCRETE,
+    )
+    concrete_seed = (
+        normalized_seed if selection == SEED_SELECTION_CONCRETE else None
+    )
+    return SeedReservationRequest(
+        schema=SEED_RESERVATION_REQUEST_SCHEMA,
+        version=SEED_RESERVATION_CONTRACT_VERSION,
+        stream_id=stream_id,
+        request_id=request_id,
+        selection=selection,
+        seed=concrete_seed,
+        after_generate=after_generate,
+    )
+
+
+__all__ = (
+    "SEED_CONTROL_FIXED",
+    "SEED_CONTROLS",
+    "SEED_RESERVATION_CONTRACT_VERSION",
+    "SEED_RESERVATION_REQUEST_SCHEMA",
+    "SEED_SELECTION_CONCRETE",
+    "SEED_SELECTION_DECREMENT",
+    "SEED_SELECTION_INCREMENT",
+    "SEED_SELECTION_RANDOMIZE",
+    "SEED_SELECTIONS",
+    "SEED_SETTLEMENT_ACCEPTED",
+    "SEED_SETTLEMENT_CANCELLED",
+    "SEED_SETTLEMENT_REJECTED",
+    "SEED_SETTLEMENTS",
+    "SeedControl",
+    "SeedReservation",
+    "SeedReservationContractError",
+    "SeedReservationRequest",
+    "SeedReservationService",
+    "SeedReservationSettlement",
+    "SeedSelection",
+    "parse_legacy_seed_reservation_request",
+    "parse_seed_reservation_request",
+)

--- a/easyuse_anima/seed/reservation.py
+++ b/easyuse_anima/seed/reservation.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal, Protocol, TypeAlias, cast
 
-
 SEED_RESERVATION_REQUEST_SCHEMA = "easyuse_anima_seed_reservation_request"
 SEED_RESERVATION_CONTRACT_VERSION = 1
 
@@ -248,20 +247,21 @@ def parse_legacy_seed_reservation_request(
 ) -> SeedReservationRequest:
     """Translate an already-normalized legacy AiO seed without choosing a seed."""
 
-    if isinstance(normalized_seed, bool) or not isinstance(normalized_seed, int):
+    raw_seed = cast(object, normalized_seed)
+    if isinstance(raw_seed, bool) or not isinstance(raw_seed, int):
         raise SeedReservationContractError(
             "Legacy normalized seed must be an integer"
         )
-    if normalized_seed < -3:
+    if raw_seed < -3:
         raise SeedReservationContractError(
             "Legacy normalized seed is outside the supported range"
         )
     selection = _LEGACY_SELECTION_BY_SEED.get(
-        normalized_seed,
+        raw_seed,
         SEED_SELECTION_CONCRETE,
     )
     concrete_seed = (
-        normalized_seed if selection == SEED_SELECTION_CONCRETE else None
+        raw_seed if selection == SEED_SELECTION_CONCRETE else None
     )
     return SeedReservationRequest(
         schema=SEED_RESERVATION_REQUEST_SCHEMA,

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4408,6 +4408,24 @@
         "source": "autocomplete_index.py"
       },
       {
+        "alias": "seed",
+        "bound_name": "seed",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".:seed",
+        "kind": "static_from",
+        "line": 3,
+        "name": "seed",
+        "optional": false,
+        "requested": ".",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/__init__.py",
+        "target": "easyuse_anima/seed/__init__.py"
+      },
+      {
         "alias": null,
         "bound_name": "annotations",
         "branch_context": [],
@@ -15652,6 +15670,143 @@
         "scope": "<module>",
         "source": "easyuse_anima/runtime.py",
         "target": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "alias": "reservation",
+        "bound_name": "reservation",
+        "branch_context": [],
+        "classification": "internal",
+        "column": 0,
+        "conditional": false,
+        "imported": ".:reservation",
+        "kind": "static_from",
+        "line": 3,
+        "name": "reservation",
+        "optional": false,
+        "requested": ".",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/__init__.py",
+        "target": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "annotations",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
+        "line": 4,
+        "name": "annotations",
+        "optional": false,
+        "requested": "__future__",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Mapping",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "name": "Mapping",
+        "optional": false,
+        "requested": "collections.abc",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "dataclass",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 7,
+        "name": "dataclass",
+        "optional": false,
+        "requested": "dataclasses",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Literal",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Literal",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Literal",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "Protocol",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 8,
+        "name": "Protocol",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "TypeAlias",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 8,
+        "name": "TypeAlias",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "alias": null,
+        "bound_name": "cast",
+        "branch_context": [],
+        "classification": "external",
+        "column": 0,
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 8,
+        "name": "cast",
+        "optional": false,
+        "requested": "typing",
+        "role": "ordinary",
+        "scope": "<module>",
+        "source": "easyuse_anima/seed/reservation.py"
       },
       {
         "alias": null,
@@ -37416,6 +37571,10 @@
         "to": "storage.py"
       },
       {
+        "from": "easyuse_anima/__init__.py",
+        "to": "easyuse_anima/seed/__init__.py"
+      },
+      {
         "from": "easyuse_anima/aio/generation_detailer.py",
         "to": "easyuse_anima/aio/generation_sampling.py"
       },
@@ -37882,6 +38041,10 @@
       {
         "from": "easyuse_anima/runtime.py",
         "to": "easyuse_anima/infrastructure/comfy/provider.py"
+      },
+      {
+        "from": "easyuse_anima/seed/__init__.py",
+        "to": "easyuse_anima/seed/reservation.py"
       },
       {
         "from": "easyuse_anima/workflow.py",
@@ -38595,6 +38758,18 @@
       {
         "cyclic": false,
         "modules": [
+          "easyuse_anima/seed/__init__.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
+          "easyuse_anima/seed/reservation.py"
+        ]
+      },
+      {
+        "cyclic": false,
+        "modules": [
           "easyuse_anima/workflow.py"
         ]
       },
@@ -38631,7 +38806,7 @@
     ]
   },
   "inventory": {
-    "module_count": 86,
+    "module_count": 88,
     "modules": [
       {
         "is_package": true,
@@ -38779,9 +38954,9 @@
       },
       {
         "is_package": true,
-        "loc": 3,
+        "loc": 5,
         "module": "easyuse_anima",
-        "normalized_git_blob_sha1": "9929d9f7b1b98cbd8ae63bae889e60307115c260",
+        "normalized_git_blob_sha1": "83f88fc53534e344f4e575ae287a022046046e6e",
         "path": "easyuse_anima/__init__.py",
         "top_level": {
           "class_count": 0,
@@ -39591,6 +39766,30 @@
           "class_count": 1,
           "function_count": 2,
           "global_count": 2
+        }
+      },
+      {
+        "is_package": true,
+        "loc": 5,
+        "module": "easyuse_anima.seed",
+        "normalized_git_blob_sha1": "857dfcdf6896a2bc880c2f723e07518181c39e5c",
+        "path": "easyuse_anima/seed/__init__.py",
+        "top_level": {
+          "class_count": 0,
+          "function_count": 0,
+          "global_count": 1
+        }
+      },
+      {
+        "is_package": false,
+        "loc": 300,
+        "module": "easyuse_anima.seed.reservation",
+        "normalized_git_blob_sha1": "cba158be576da33aec0029813dedf9b06db53660",
+        "path": "easyuse_anima/seed/reservation.py",
+        "top_level": {
+          "class_count": 4,
+          "function_count": 6,
+          "global_count": 18
         }
       },
       {
@@ -51980,6 +52179,83 @@
         "conditional": false,
         "imported": "__future__:annotations",
         "kind": "static_from",
+        "line": 4,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "collections.abc:Mapping",
+        "kind": "static_from",
+        "line": 6,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "dataclasses:dataclass",
+        "kind": "static_from",
+        "line": 7,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Literal",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:Protocol",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:TypeAlias",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "typing:cast",
+        "kind": "static_from",
+        "line": 8,
+        "optional": false,
+        "role": "ordinary",
+        "source": "easyuse_anima/seed/reservation.py"
+      },
+      {
+        "branch_context": [],
+        "classification": "external",
+        "conditional": false,
+        "imported": "__future__:annotations",
+        "kind": "static_from",
         "line": 3,
         "optional": false,
         "role": "ordinary",
@@ -53611,6 +53887,8 @@
       "easyuse_anima/prompt/regional.py",
       "easyuse_anima/registration.py",
       "easyuse_anima/runtime.py",
+      "easyuse_anima/seed/__init__.py",
+      "easyuse_anima/seed/reservation.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -53699,6 +53977,8 @@
       "easyuse_anima/prompt/regional.py",
       "easyuse_anima/registration.py",
       "easyuse_anima/runtime.py",
+      "easyuse_anima/seed/__init__.py",
+      "easyuse_anima/seed/reservation.py",
       "easyuse_anima/workflow.py",
       "nodes.py",
       "prompt_translation.py",
@@ -54711,6 +54991,51 @@
         "scope": "<module>"
       },
       {
+        "callee": "frozenset",
+        "column": 18,
+        "context": "assign:SEED_SELECTIONS",
+        "kind": "import_time_call",
+        "line": 17,
+        "module": "easyuse_anima/seed/reservation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 16,
+        "context": "assign:SEED_CONTROLS",
+        "kind": "import_time_call",
+        "line": 27,
+        "module": "easyuse_anima/seed/reservation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "frozenset",
+        "column": 19,
+        "context": "assign:SEED_SETTLEMENTS",
+        "kind": "import_time_call",
+        "line": 39,
+        "module": "easyuse_anima/seed/reservation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:SeedReservationRequest",
+        "kind": "import_time_call",
+        "line": 112,
+        "module": "easyuse_anima/seed/reservation.py",
+        "scope": "<module>"
+      },
+      {
+        "callee": "dataclass",
+        "column": 1,
+        "context": "decorator:SeedReservation",
+        "kind": "import_time_call",
+        "line": 169,
+        "module": "easyuse_anima/seed/reservation.py",
+        "scope": "<module>"
+      },
+      {
         "callee": "logging.getLogger",
         "column": 9,
         "context": "assign:logger",
@@ -55364,6 +55689,12 @@
         "line": 73,
         "module": "easyuse_anima/registration.py",
         "name": "__all__"
+      },
+      {
+        "kind": "dict",
+        "line": 65,
+        "module": "easyuse_anima/seed/reservation.py",
+        "name": "_LEGACY_SELECTION_BY_SEED"
       },
       {
         "kind": "dict",

--- a/tests/fixtures/python_backend_baseline.json
+++ b/tests/fixtures/python_backend_baseline.json
@@ -4408,8 +4408,8 @@
         "source": "autocomplete_index.py"
       },
       {
-        "alias": "seed",
-        "bound_name": "seed",
+        "alias": "_seed",
+        "bound_name": "_seed",
         "branch_context": [],
         "classification": "internal",
         "column": 0,
@@ -15672,8 +15672,8 @@
         "target": "easyuse_anima/infrastructure/comfy/provider.py"
       },
       {
-        "alias": "reservation",
-        "bound_name": "reservation",
+        "alias": "_reservation",
+        "bound_name": "_reservation",
         "branch_context": [],
         "classification": "internal",
         "column": 0,
@@ -38956,7 +38956,7 @@
         "is_package": true,
         "loc": 5,
         "module": "easyuse_anima",
-        "normalized_git_blob_sha1": "83f88fc53534e344f4e575ae287a022046046e6e",
+        "normalized_git_blob_sha1": "1a48bda62d3d234f97860f719e1af46410cd5371",
         "path": "easyuse_anima/__init__.py",
         "top_level": {
           "class_count": 0,
@@ -39772,7 +39772,7 @@
         "is_package": true,
         "loc": 5,
         "module": "easyuse_anima.seed",
-        "normalized_git_blob_sha1": "857dfcdf6896a2bc880c2f723e07518181c39e5c",
+        "normalized_git_blob_sha1": "653d1c05aec0ab255562bf631fc9707071b5cc4e",
         "path": "easyuse_anima/seed/__init__.py",
         "top_level": {
           "class_count": 0,

--- a/tests/test_python_backend_analyzer.py
+++ b/tests/test_python_backend_analyzer.py
@@ -683,9 +683,9 @@ ignored/
 
         self.assertEqual(analyzer.render_json(report), expected_text)
         self.assertEqual(report["schema_version"], 2)
-        self.assertEqual(report["inventory"]["module_count"], 86)
-        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 86)
-        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 86)
+        self.assertEqual(report["inventory"]["module_count"], 88)
+        self.assertEqual(len(report["registry"]["shipped_python_modules"]), 88)
+        self.assertEqual(len(report["registry"]["runtime_import_closure"]), 88)
         self.assertEqual(report["registry"]["missing_internal_imports"], [])
         self.assertEqual(report["registry"]["unreachable_shipped_python_modules"], [])
         self.assertTrue(
@@ -748,6 +748,8 @@ ignored/
                 "easyuse_anima/profiles/mutation.py",
                 "easyuse_anima/registration.py",
                 "easyuse_anima/runtime.py",
+                "easyuse_anima/seed/__init__.py",
+                "easyuse_anima/seed/reservation.py",
                 "easyuse_anima/prompt/__init__.py",
                 "easyuse_anima/prompt/advanced.py",
                 "easyuse_anima/prompt/correction.py",

--- a/tests/test_seed_reservation_contract.py
+++ b/tests/test_seed_reservation_contract.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+from easyuse_anima.aio import generation_normalization
+from easyuse_anima.seed import reservation
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _request_payload(**updates: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema": reservation.SEED_RESERVATION_REQUEST_SCHEMA,
+        "version": reservation.SEED_RESERVATION_CONTRACT_VERSION,
+        "stream_id": "node:42",
+        "request_id": "queue:abc",
+        "selection": reservation.SEED_SELECTION_CONCRETE,
+        "seed": 123,
+        "after_generate": reservation.SEED_CONTROL_FIXED,
+    }
+    payload.update(updates)
+    return payload
+
+
+class SeedReservationContractTests(unittest.TestCase):
+    def test_concrete_request_parses_to_an_immutable_normalized_value(self):
+        parsed = reservation.parse_seed_reservation_request(
+            _request_payload(stream_id=" node:42 ", request_id=" queue:abc ")
+        )
+
+        self.assertEqual(
+            parsed,
+            reservation.SeedReservationRequest(
+                schema=reservation.SEED_RESERVATION_REQUEST_SCHEMA,
+                version=1,
+                stream_id="node:42",
+                request_id="queue:abc",
+                selection="concrete",
+                seed=123,
+                after_generate="fixed",
+            ),
+        )
+        with self.assertRaises(FrozenInstanceError):
+            parsed.seed = 456
+
+    def test_non_concrete_request_has_no_browser_authoritative_seed(self):
+        for selection in ("randomize", "increment", "decrement"):
+            with self.subTest(selection=selection):
+                parsed = reservation.parse_seed_reservation_request(
+                    _request_payload(selection=selection, seed=None)
+                )
+                self.assertEqual(parsed.selection, selection)
+                self.assertIsNone(parsed.seed)
+
+    def test_legacy_sentinels_map_to_distinct_selection_intents(self):
+        expected = {
+            generation_normalization.AIO_SPECIAL_SEED_RANDOM: "randomize",
+            generation_normalization.AIO_SPECIAL_SEED_INCREMENT: "increment",
+            generation_normalization.AIO_SPECIAL_SEED_DECREMENT: "decrement",
+        }
+
+        self.assertEqual(set(expected), {-1, -2, -3})
+        for legacy_seed, selection in expected.items():
+            with self.subTest(legacy_seed=legacy_seed):
+                parsed = reservation.parse_legacy_seed_reservation_request(
+                    stream_id="aio:7",
+                    request_id=f"queue:{legacy_seed}",
+                    normalized_seed=legacy_seed,
+                    after_generate="fixed",
+                )
+                self.assertEqual(parsed.selection, selection)
+                self.assertIsNone(parsed.seed)
+
+    def test_legacy_concrete_seed_preserves_the_exact_python_integer(self):
+        legacy_uint64_max = (1 << 64) - 1
+
+        parsed = reservation.parse_legacy_seed_reservation_request(
+            stream_id="aio:7",
+            request_id="queue:concrete",
+            normalized_seed=legacy_uint64_max,
+            after_generate="increment",
+        )
+
+        self.assertEqual(parsed.selection, "concrete")
+        self.assertEqual(parsed.seed, legacy_uint64_max)
+        self.assertEqual(parsed.after_generate, "increment")
+
+    def test_request_taxonomy_rejects_ambiguous_or_invalid_values(self):
+        invalid_payloads = (
+            [],
+            _request_payload(schema="other"),
+            _request_payload(version=True),
+            _request_payload(version=2),
+            _request_payload(stream_id=" "),
+            _request_payload(request_id=None),
+            _request_payload(selection="random"),
+            _request_payload(selection="randomize", seed=1),
+            _request_payload(seed=None),
+            _request_payload(seed=True),
+            _request_payload(seed=-1),
+            _request_payload(after_generate="accept"),
+        )
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload), self.assertRaises(
+                reservation.SeedReservationContractError
+            ):
+                reservation.parse_seed_reservation_request(payload)
+
+    def test_legacy_parser_requires_an_already_normalized_supported_integer(self):
+        for seed in (-4, True, 1.5, "-1"):
+            with self.subTest(seed=seed), self.assertRaises(
+                reservation.SeedReservationContractError
+            ):
+                reservation.parse_legacy_seed_reservation_request(
+                    stream_id="aio:7",
+                    request_id="queue:invalid",
+                    normalized_seed=seed,
+                    after_generate="fixed",
+                )
+
+        with self.assertRaises(reservation.SeedReservationContractError):
+            reservation.parse_legacy_seed_reservation_request(
+                stream_id="aio:7",
+                request_id="queue:invalid-control",
+                normalized_seed=1,
+                after_generate="unknown",
+            )
+
+    def test_reservation_result_is_concrete_immutable_and_versioned(self):
+        result = reservation.SeedReservation(
+            version=1,
+            reservation_id=" reservation:1 ",
+            stream_id=" node:42 ",
+            request_id=" queue:abc ",
+            execution_seed=123,
+            next_seed=124,
+        )
+
+        self.assertEqual(result.reservation_id, "reservation:1")
+        self.assertEqual(result.stream_id, "node:42")
+        self.assertEqual(result.request_id, "queue:abc")
+        with self.assertRaises(FrozenInstanceError):
+            result.next_seed = 125
+
+        for updates in (
+            {"version": 2},
+            {"reservation_id": ""},
+            {"execution_seed": -1},
+            {"execution_seed": True},
+            {"next_seed": -1},
+        ):
+            values = {
+                "version": 1,
+                "reservation_id": "reservation:1",
+                "stream_id": "node:42",
+                "request_id": "queue:abc",
+                "execution_seed": 123,
+                "next_seed": 124,
+                **updates,
+            }
+            with self.subTest(values=values), self.assertRaises(
+                reservation.SeedReservationContractError
+            ):
+                reservation.SeedReservation(**values)
+
+    def test_service_port_has_no_implicit_runtime_or_state_owner(self):
+        class FakeService:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, object]] = []
+
+            def reserve(
+                self,
+                request: reservation.SeedReservationRequest,
+            ) -> reservation.SeedReservation:
+                self.calls.append(("reserve", request))
+                return reservation.SeedReservation(
+                    version=1,
+                    reservation_id="reservation:1",
+                    stream_id=request.stream_id,
+                    request_id=request.request_id,
+                    execution_seed=10,
+                    next_seed=11,
+                )
+
+            def settle(
+                self,
+                reservation_id: str,
+                settlement: reservation.SeedReservationSettlement,
+            ) -> None:
+                self.calls.append((reservation_id, settlement))
+
+        service: reservation.SeedReservationService = FakeService()
+        request = reservation.parse_seed_reservation_request(_request_payload())
+        reserved = service.reserve(request)
+        service.settle(reserved.reservation_id, "accepted")
+
+        self.assertEqual(reserved.execution_seed, 10)
+        self.assertEqual(
+            service.calls,
+            [("reserve", request), ("reservation:1", "accepted")],
+        )
+
+    def test_contract_import_is_side_effect_free_in_a_fresh_process(self):
+        script = (
+            f"import sys; sys.path.insert(0, {str(ROOT)!r}); "
+            "import easyuse_anima.seed.reservation; "
+            "blocked = {'nodes', 'wildcard_engine'} & set(sys.modules); "
+            "print(','.join(sorted(blocked)))"
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-I", "-B", "-c", script],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목적

#167의 첫 rollback unit인 **S167-01 Contract**를 구현합니다. concrete seed request/result/service interface와 legacy `-1/-2/-3` 호환 파싱을 고정하며, 실제 예약·산술·queue lifecycle 동작은 바꾸지 않습니다.

기준선: `dev@ddcc2517f0286fd4e249ff18b09e80a8a64e3dc7`  
최종 head: `d6c8eca995beba11f3ef44713f4751cacac2d127`

## 작업 전 inventory

### symbol / owner

- AiO legacy sentinel과 정규화: `easyuse_anima.aio.generation_normalization`
- AiO backend 실행 seed: `easyuse_anima.aio.sampling._resolve_aio_runtime_seed`
- AiO browser reservation: `web/js/aio/generator_queue_runtime.js`
- Prompt Studio browser reservation: `web/js/prompt_studio/advanced_queue_seed_runtime.js`
- Prompt Studio backend consumer: root `nodes.py._consume_reserved_wildcard_next_seed`
- runtime composition: `easyuse_anima.runtime.RuntimeServices`에는 seed state/service가 없음

### caller / alias

- root consumer의 production caller는 Advanced와 Regional node adapter 두 곳입니다.
- 두 adapter는 각각 `_bind_prompt_advanced_node_runtime`, `_bind_regional_node_runtime`을 통해 root consumer를 받습니다.
- root `nodes.py`에는 AiO sentinel/normalizer/sampling helper의 compatibility alias가 남아 있습니다.
- Python backend에는 기존 reservation request/service object가 없습니다.

### global state

- AiO와 Prompt Studio의 예약 상태는 서로 다른 frontend runtime이 소유합니다.
- Backend에는 reservation map, lock, token, lifecycle state가 없습니다.
- root Prompt Studio consumer는 전달받은 request-local dict만 변경합니다.

## 변경 요약

- `easyuse_anima.seed.reservation`에 versioned request/result/service Protocol과 strict parser 추가
- legacy normalized seed `-1/-2/-3`을 randomize/increment/decrement intent로 구별하며 concrete seed는 선택하지 않음
- immutable dataclass와 contract validation 추가
- 새 canonical module을 side-effect 없이 runtime import closure에 등록하되 기존 package `__all__`은 빈 상태로 유지
- deterministic Python backend analyzer fixture와 module-count gate 갱신
- S167-01 이후 작업을 **consumer Move → B-11c30c2b Move → S167-02 Behavior → S167-03 Adapter**로 분리

## allowed-file boundary

변경 파일은 아래 8개뿐입니다.

- `easyuse_anima/__init__.py`
- `easyuse_anima/seed/__init__.py`
- `easyuse_anima/seed/reservation.py`
- `tests/test_seed_reservation_contract.py`
- `tests/test_python_backend_analyzer.py`
- `tests/fixtures/python_backend_baseline.json`
- `docs/architecture/seed-reservation-contract.md`
- `docs/architecture/python-backend-execution-roadmap.md`

root `nodes.py`, `wildcard_engine.py`, AiO 실행 모듈, frontend, RuntimeServices/bootstrap/registration, payload bytes, seed 산술/RNG/queue ordering/failure/retry/cancel 동작, B-11c30c2b binder는 변경하지 않았습니다.

## 검증

- seed reservation contract focused unittest: **9/9 통과**
- analyzer current-repository fixture focused unittest: **1/1 통과**
- package skeleton side-effect/public-surface focused unittest: **1/1 통과**
- `tools/check_project.ps1 -Profile full`: **통과**
  - Python unittest: **975/975 통과**
  - frontend: **114 JavaScript files**, TypeScript 6.0.3 통과
  - Pyright baseline ratchet: 71 files, 기존 19 errors, **새 진단 0**
  - import boundary: 6 groups, **0 violations**
  - Ruff: 70 findings, G-01 report-only; 실행/configuration failure 없음
  - `git diff --check`: 통과
- GitHub checks: 등록된 check 없음
- ComfyUI live/API/browser smoke: 실행하지 않음 — pure Contract/gate 변경이며 기존 실행 경로를 연결하지 않음

## rollback / 남은 위험

이 PR은 8개 파일의 Contract/gate 단위로 독립 rollback 가능합니다. atomic reservation, concrete seed selection, settlement lifecycle, cancellation/retry/late accept와 frontend cutover는 의도적으로 구현하지 않았습니다.

다음 작업은 root hidden-payload consumer를 bytes/mutation/return 값 변경 없이 canonical owner로 옮기는 별도 **Move**입니다. 그 뒤에만 B-11c30c2b Advanced/Regional binder retirement를 진행합니다.